### PR TITLE
🐛 Fix sitemap API key mismatch after defining language code

### DIFF
--- a/server/api/__sitemap__/store.get.ts
+++ b/server/api/__sitemap__/store.get.ts
@@ -2,21 +2,20 @@ export default defineSitemapEventHandler(async (event) => {
   const config = useRuntimeConfig()
   const baseURL = config.public.baseURL
   const defaultLocale = config.public.i18n.defaultLocale
-  const locales = (config.public.i18n.locales as Array<{ code: string }>)
-    .map(locale => locale.code)
+  const locales = config.public.i18n.locales as Array<{ code: string, language: string }>
   try {
     const result = await fetchAirtableCMSProductsByTagId('latest')
     setHeader(event, 'Cache-Control', 'public, max-age=3600, stale-while-revalidate=86400')
     return result.records.map(record => locales.map((locale) => {
-      const localePath = locale === defaultLocale ? '' : `/${locale}`
+      const localePath = locale.code === defaultLocale ? '' : `/${locale.code}`
       return {
-        _sitemap: locale,
+        _sitemap: locale.language,
         loc: `${baseURL}${localePath}/store/${record.classId}`,
-        alternatives: locales.filter(l => l !== locale).map((l) => {
-          const lPath = l === defaultLocale ? '' : `/${l}`
+        alternatives: locales.filter(l => l.code !== locale.code).map((l) => {
+          const lPath = l.code === defaultLocale ? '' : `/${l.code}`
           return {
             href: `${baseURL}${lPath}/store/${record.classId}`,
-            hreflang: l,
+            hreflang: l.language,
           }
         }),
       }


### PR DESCRIPTION
when language is not defined, code is used as key, but language is used as key now after we defined it