### PR TITLE
[TAS-3955] 💩 Fix Crisp blocking tab bar button

### DIFF
--- a/components/AppTabBar.vue
+++ b/components/AppTabBar.vue
@@ -1,5 +1,5 @@
 <template>
-  <nav class="lg:hidden bg-white border-t border-[#EBEBEB] fixed bottom-0 left-0 right-0 pb-safe">
+  <nav class="lg:hidden bg-white border-t border-[#EBEBEB] fixed bottom-0 left-0 right-0 pb-safe pr-[68px]">
     <ul class="flex justify-around items-center min-h-14">
       <li
         v-for="item in menuItems"


### PR DESCRIPTION
I dont have a great solution...
<img width="423" alt="Screenshot 2025-06-16 at 11 19 52" src="https://github.com/user-attachments/assets/429f56d8-5406-4a28-8e0c-a6b5ba74ddf5" />
<img width="427" alt="Screenshot 2025-06-16 at 11 19 25" src="https://github.com/user-attachments/assets/92f86a77-aea3-48c1-9611-2ffb3ec1f1ad" />

@ckxpress want to hide this Crisp button on loaded, but I couldn't find the option in Nuxt Scripts. Does @williamchong know how?