### PR TITLE
[TAS-3997] 🚑 Guard callOnce undefined key

### DIFF
--- a/components/AffiliateAlert.vue
+++ b/components/AffiliateAlert.vue
@@ -37,7 +37,9 @@ async function fetchInfo() {
   }
 }
 
-await callOnce(affiliateId.value, fetchInfo)
+if (affiliateId.value) {
+  await callOnce(affiliateId.value, fetchInfo)
+}
 
 watch(affiliateId, async (newId, oldId) => {
   if (newId !== oldId) {


### PR DESCRIPTION
`callOnce()` key cannot be undefined