### PR TITLE
[TAS-4026] 🐛 Load connector logos via static URL import

### DIFF
--- a/components/LoginConnectorIcon.vue
+++ b/components/LoginConnectorIcon.vue
@@ -7,10 +7,10 @@
 </template>
 
 <script setup lang="ts">
-import cosmostation from '~/assets/images/login-connectors/cosmostation.svg'
-import keplr from '~/assets/images/login-connectors/keplr.svg'
-import metamask from '~/assets/images/login-connectors/metamask.svg'
-import rabby from '~/assets/images/login-connectors/rabby.svg'
+import cosmostation from '~/assets/images/login-connectors/cosmostation.svg?url'
+import keplr from '~/assets/images/login-connectors/keplr.svg?url'
+import metamask from '~/assets/images/login-connectors/metamask.svg?url'
+import rabby from '~/assets/images/login-connectors/rabby.svg?url'
 
 const props = defineProps<{
   connectorId: string


### PR DESCRIPTION
Use component SVGs(`nuxt-svgo`) for reactive icons, and image URLs(`?url`) for static logo display.
![截圖 2025-06-25 14 23 19](https://github.com/user-attachments/assets/faa5679e-0704-4983-a0bb-99f60443a33a)
