### PR TITLE
💄 Add logo to error page

### DIFF
--- a/error.vue
+++ b/error.vue
@@ -1,8 +1,13 @@
 <template>
-  <main class="flex flex-col items-center justify-center h-svh">
+  <main class="flex flex-col items-center justify-center h-svh px-4">
+    <AppLogo
+      class="mb-16"
+      :height="36"
+    />
+
     <p
       v-if="props.error?.statusCode"
-      class="mb-4 text-8xl font-semibold text-center"
+      class="mb-4 text-8xl font-semibold font-mono text-center"
       v-text="props.error.statusCode"
     />
 


### PR DESCRIPTION
Before
<img width="609" alt="Screenshot 2025-06-30 at 15 04 49" src="https://github.com/user-attachments/assets/0a641ea2-03ef-4ca2-96b4-211140ca4e35" />

After
<img width="587" alt="Screenshot 2025-06-30 at 15 03 59" src="https://github.com/user-attachments/assets/48f96073-d890-4493-b1b8-c61fa6d1bcc8" />
