### PR TITLE
[TAS-4068] 🚑 Fix broken paywall modal due to @nuxt/ui 3.2.0 upgrade

### DIFF
--- a/components/PaywallModal.props.ts
+++ b/components/PaywallModal.props.ts
@@ -1,0 +1,15 @@
+export interface PaywallModalProps {
+  'modelValue'?: SubscriptionPlan
+  'isFullscreen'?: boolean
+  'isBackdropDismissible'?: boolean
+  'isCloseButtonHidden'?: boolean
+  'originalYearlyPrice'?: string | number
+  'originalMonthlyPrice'?: string | number
+  'discountedYearlyPrice'?: string | number
+  'discountedMonthlyPrice'?: string | number
+  'isProcessingSubscription'?: boolean
+  'onUpdate:modelValue'?: (value: SubscriptionPlan) => void
+  'onSubscribe'?: () => void
+  'onOpen'?: () => void
+  'onClose'?: () => void
+}

--- a/composables/use-text-to-speech.ts
+++ b/composables/use-text-to-speech.ts
@@ -140,7 +140,7 @@ export function useTextToSpeech(options: TTSOptions = {}) {
 
   async function startTextToSpeech() {
     if (!user.value?.isLikerPlus) {
-      subscription.paywallModal.open()
+      subscription.openPaywallModal()
       return
     }
 

--- a/pages/pricing.vue
+++ b/pages/pricing.vue
@@ -106,13 +106,11 @@ onMounted(async () => {
 
   if (!hasOpened.value) {
     hasOpened.value = true
-    subscription.paywallModal.open({
+    await subscription.openPaywallModal({
       isFullscreen: true,
       isBackdropDismissible: false,
-      onClose: () => {
-        router.back()
-      },
     })
+    router.back()
   }
 })
 </script>

--- a/types/subscription.d.ts
+++ b/types/subscription.d.ts
@@ -1,0 +1,1 @@
+declare type SubscriptionPlan = 'monthly' | 'yearly'

--- a/utils/api.ts
+++ b/utils/api.ts
@@ -307,7 +307,7 @@ export function fetchLikerPlusCheckoutLink({
   gadSource,
   fbClickId,
 }: {
-  period: 'monthly' | 'yearly'
+  period: SubscriptionPlan
   from?: string
   referrer?: string
   utmCampaign?: string


### PR DESCRIPTION
After upgrading to Nuxt UI 3.2, somehow the props injected by `open()` overwrite(not merging) the props in `create()` in `useOverlay()`.