### PR TITLE
💄 Fix tag select options width

### DIFF
--- a/pages/store/index.vue
+++ b/pages/store/index.vue
@@ -114,7 +114,7 @@
                 ? 'bg-(--app-bg) hover:bg-theme-white/80'
                 : 'bg-theme-black hover:bg-theme-black/80 text-white',
             ],
-            content: 'rounded-lg',
+            content: 'min-w-fit rounded-lg',
             placeholder: isDefaultTagId ? '!text-black text-sm laptop:text-base' : undefined,
           }"
         />


### PR DESCRIPTION
Before
<img width="161" height="325" alt="Screenshot 2025-11-03 at 16 35 51" src="https://github.com/user-attachments/assets/e7e6e79f-9323-4c49-b5d5-668f4ba106fd" />
After
<img width="195" height="317" alt="Screenshot 2025-11-03 at 16 35 38" src="https://github.com/user-attachments/assets/ab1f2e19-5595-4ff3-ae08-333cfb4fb0a0" />