### PR TITLE
🐛 Reorder ref and watch in claim to prevent hoisting issue

### DIFF
--- a/pages/store/claim.vue
+++ b/pages/store/claim.vue
@@ -189,6 +189,7 @@ const receivedNFTId = computed(() => bookInfo.firstUserOwnedNFTId.value)
 const canStartReading = computed(() => !!receivedNFTId.value)
 const isCheckingItemsDelivery = ref(false)
 const hasBypassedIndexer = ref(false)
+const hasOpenCollectorMessageModal = ref(false)
 let stopCollectorMessageModalTimer: (() => void) | null = null
 
 onMounted(async () => {
@@ -261,9 +262,10 @@ async function checkItemsDeliveryThroughIndexer() {
 }
 
 function openCollectorModal() {
-  if (isOpenCollectorMessageModal.value) return
+  if (isOpenCollectorMessageModal.value || hasOpenCollectorMessageModal.value) return
   stopCollectorMessageModalTimer?.()
   isOpenCollectorMessageModal.value = true
+  hasOpenCollectorMessageModal.value = true
 }
 
 async function waitForItemsDelivery({ timeout = 30000, interval = 3000 } = {}) {


### PR DESCRIPTION
> ⏺ Yes, looking at the minified code more carefully, isClaiming (j in minified form) also has this issue -
>   and it's likely the actual cause of the error you're seeing!
> 
>   Here's why:
> 
>   In the minified code, the order is:
>   1. Various computeds and refs are defined
>   2. onMounted hook is defined
>   3. More computeds are defined
>   4. Watches with immediate: true are created ← These run immediately
>   5. Functions like Se() (startClaimingItems) are defined
>   6. j (isClaiming) ref is declared ← Declared AFTER watchers run
> 
>   The problematic watch is:
> 
>   G(_, a => {
>       a && O()  // Calls startClaimFlow()
>   }, { immediate: !0 })
> 
>   This watch has immediate: true and calls O() → startClaimFlow() → startClaimingItems(), which immediately
>    accesses isClaiming.value:
> 
>   async function startClaimingItems() {
>     if (isClaiming.value) return  // ← Tries to access isClaiming before it's declared!
> 
>   The fix is to move the isClaiming declaration earlier, before the watches that use it: