### PR TITLE
🐛 Fix shelf is not fetched if user land on reader first

### DIFF
--- a/stores/bookshelf.ts
+++ b/stores/bookshelf.ts
@@ -58,7 +58,7 @@ export const useBookshelfStore = defineStore('bookshelf', () => {
     isRefresh?: boolean
     limit?: number
   }) {
-    const isRefresh = shouldRefresh || (!items.value.length && !hasFetched.value)
+    const isRefresh = shouldRefresh || !hasFetched.value
     if (!walletAddress || isFetching.value || (!isRefresh && !nextKey.value)) {
       return
     }


### PR DESCRIPTION
The bug is reader checks ownership, which adds 1 book to shelf item as side effect