### PR TITLE
♻️ Replace custom SSE parsing with eventsource-parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "@wagmi/core": "3.0.0",
         "@wagmi/vue": "^0.4.2",
         "@walletconnect/ethereum-provider": "~2.21.1",
+        "eventsource-parser": "^3.0.6",
         "firebase-admin": "^13.4.0",
         "jwt-decode": "^4.0.0",
         "markdown-it": "^14.1.0",
@@ -16578,6 +16579,15 @@
       "license": "Apache-2.0",
       "dependencies": {
         "bare-events": "^2.7.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/execa": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@wagmi/core": "3.0.0",
     "@wagmi/vue": "^0.4.2",
     "@walletconnect/ethereum-provider": "~2.21.1",
+    "eventsource-parser": "^3.0.6",
     "firebase-admin": "^13.4.0",
     "jwt-decode": "^4.0.0",
     "markdown-it": "^14.1.0",


### PR DESCRIPTION
Use EventSourceParserStream to handle SSE framing in the Minimax TTS provider instead of manual buffer splitting and regex extraction.