### PR TITLE
🔒 Switch locale sync to /preferences API with scoped permissions

### DIFF
--- a/stores/account.ts
+++ b/stores/account.ts
@@ -16,6 +16,8 @@ const JWT_PERMISSIONS = [
   'write:nftbook',
   'read:plus',
   'write:plus',
+  'read:preferences',
+  'write:preferences',
 ]
 
 function verifyTokenPermissions(token: string): boolean {


### PR DESCRIPTION
The /users/update endpoint requires 'write' scope which our token doesn't have. Switch to /users/preferences which only needs 'write:preferences', and add read/write:preferences scopes to login JWT permissions.