### PR TITLE
⚡️ Encode mic recordings as MP3 instead of WAV using lamejs

### DIFF
--- a/components/CustomVoiceUploadModal.vue
+++ b/components/CustomVoiceUploadModal.vue
@@ -379,6 +379,7 @@ function formatSeconds(sec: number): string {
 
 onMounted(() => {
   hasMicrophone.value = !!navigator.mediaDevices?.getUserMedia
+  if (hasMicrophone.value) import('@breezystack/lamejs')
 })
 
 async function startRecording() {
@@ -401,12 +402,12 @@ async function startRecording() {
       }
       const rawBlob = new Blob(recordingChunks.value, { type: recorder.mimeType })
       try {
-        const wavBlob = await convertBlobToWav(rawBlob)
-        const file = new File([wavBlob], 'recording.wav', { type: 'audio/wav' })
+        const mp3Blob = await convertBlobToMp3(rawBlob)
+        const file = new File([mp3Blob], 'recording.mp3', { type: 'audio/mpeg' })
         setAudioFile(file)
       }
       catch (error) {
-        console.error('[CustomVoice] WAV conversion failed:', error)
+        console.error('[CustomVoice] MP3 conversion failed:', error)
         errorMessage.value = $t('tts_custom_voice_error_recording_failed')
       }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@breezystack/lamejs": "^1.2.7",
         "@coinbase/wallet-sdk": "~4.3.6",
         "@farcaster/miniapp-sdk": "^0.2.1",
         "@likecoin/epub-ts": "^0.4.6",
@@ -1703,6 +1704,12 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@breezystack/lamejs": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@breezystack/lamejs/-/lamejs-1.2.7.tgz",
+      "integrity": "sha512-6wc7ck65ctA75Hq7FYHTtTvGnYs6msgdxiSUICQ+A01nVOWg6rqouZB8IdyteRlfpYYiFovkf67dIeOgWIUzTA==",
+      "license": "LGPL-3.0"
     },
     "node_modules/@canvas/image-data": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "typecheck": "nuxt typecheck"
   },
   "dependencies": {
+    "@breezystack/lamejs": "^1.2.7",
     "@coinbase/wallet-sdk": "~4.3.6",
     "@farcaster/miniapp-sdk": "^0.2.1",
     "@likecoin/epub-ts": "^0.4.6",

--- a/utils/audio.ts
+++ b/utils/audio.ts
@@ -1,58 +1,48 @@
-export function encodeWav(audioBuffer: AudioBuffer): Blob {
-  const numChannels = audioBuffer.numberOfChannels
-  const sampleRate = audioBuffer.sampleRate
-  const format = 1 // PCM
-  const bitsPerSample = 16
-  const bytesPerSample = bitsPerSample / 8
-  const blockAlign = numChannels * bytesPerSample
-  const dataLength = audioBuffer.length * blockAlign
-  const headerLength = 44
-  const buffer = new ArrayBuffer(headerLength + dataLength)
-  const view = new DataView(buffer)
-
-  function writeString(offset: number, str: string) {
-    for (let i = 0; i < str.length; i++) {
-      view.setUint8(offset + i, str.charCodeAt(i))
-    }
+function convertFloat32ToInt16(float32: Float32Array): Int16Array {
+  const int16 = new Int16Array(float32.length)
+  for (let i = 0; i < float32.length; i++) {
+    const s = Math.max(-1, Math.min(1, float32[i]!))
+    int16[i] = s < 0 ? s * 0x8000 : s * 0x7FFF
   }
-
-  writeString(0, 'RIFF')
-  view.setUint32(4, 36 + dataLength, true)
-  writeString(8, 'WAVE')
-  writeString(12, 'fmt ')
-  view.setUint32(16, 16, true)
-  view.setUint16(20, format, true)
-  view.setUint16(22, numChannels, true)
-  view.setUint32(24, sampleRate, true)
-  view.setUint32(28, sampleRate * blockAlign, true)
-  view.setUint16(32, blockAlign, true)
-  view.setUint16(34, bitsPerSample, true)
-  writeString(36, 'data')
-  view.setUint32(40, dataLength, true)
-
-  const channels = []
-  for (let ch = 0; ch < numChannels; ch++) {
-    channels.push(audioBuffer.getChannelData(ch))
-  }
-
-  let offset = headerLength
-  for (let i = 0; i < audioBuffer.length; i++) {
-    for (let ch = 0; ch < numChannels; ch++) {
-      const sample = Math.max(-1, Math.min(1, channels[ch]![i]!))
-      view.setInt16(offset, sample < 0 ? sample * 0x8000 : sample * 0x7FFF, true)
-      offset += bytesPerSample
-    }
-  }
-
-  return new Blob([buffer], { type: 'audio/wav' })
+  return int16
 }
 
-export async function convertBlobToWav(blob: Blob): Promise<Blob> {
+async function encodeMp3(audioBuffer: AudioBuffer): Promise<Blob> {
+  const { Mp3Encoder } = await import('@breezystack/lamejs')
+  const channels = audioBuffer.numberOfChannels
+  const sampleRate = audioBuffer.sampleRate
+  const kbps = 128
+  const encoder = new Mp3Encoder(channels, sampleRate, kbps)
+
+  const left = convertFloat32ToInt16(audioBuffer.getChannelData(0))
+  const right = channels > 1
+    ? convertFloat32ToInt16(audioBuffer.getChannelData(1))
+    : left
+
+  const blockSize = 1152
+  const mp3Chunks: Uint8Array[] = []
+
+  for (let i = 0; i < left.length; i += blockSize) {
+    const leftBlock = left.subarray(i, i + blockSize)
+    const rightBlock = right.subarray(i, i + blockSize)
+    const buf = channels > 1
+      ? encoder.encodeBuffer(leftBlock, rightBlock)
+      : encoder.encodeBuffer(leftBlock)
+    if (buf.length > 0) mp3Chunks.push(buf)
+  }
+
+  const end = encoder.flush()
+  if (end.length > 0) mp3Chunks.push(end)
+
+  return new Blob(mp3Chunks, { type: 'audio/mpeg' })
+}
+
+export async function convertBlobToMp3(blob: Blob): Promise<Blob> {
   const audioCtx = new AudioContext()
   try {
     const arrayBuffer = await blob.arrayBuffer()
     const audioBuffer = await audioCtx.decodeAudioData(arrayBuffer)
-    return encodeWav(audioBuffer)
+    return encodeMp3(audioBuffer)
   }
   finally {
     await audioCtx.close()


### PR DESCRIPTION
Replace client-side WAV encoding with MP3 (128kbps) via @breezystack/lamejs, reducing upload size ~10x. The library is lazy-loaded on first recording.