### PR TITLE
♻️ Refactor to use VueUse composables over manual implementations

### DIFF
--- a/components/AffiliateAlert.vue
+++ b/components/AffiliateAlert.vue
@@ -59,9 +59,9 @@ const affiliateName = computed(() => {
 
 const cacheTs = ref('')
 
-watch([isCacheDisabled, affiliateInfo], () => {
+watchImmediate([isCacheDisabled, affiliateInfo], () => {
   cacheTs.value = `${Math.round(Date.now() / 1000)}`
-}, { immediate: true })
+})
 
 const affiliateAvatarSrc = computed(() => {
   const src = affiliateInfo.value?.avatarSrc

--- a/components/ExpandableContent.vue
+++ b/components/ExpandableContent.vue
@@ -42,14 +42,15 @@ const shouldShowExpandToggle = ref(false)
 const content = ref(null)
 const contentHeight = ref(0)
 
-let resizeObserver = null
-
 const updateHeight = () => {
   if (content.value) {
     contentHeight.value = content.value.scrollHeight
     shouldShowExpandToggle.value = contentHeight.value > props.height
   }
 }
+
+onMounted(updateHeight)
+useResizeObserver(content, updateHeight)
 
 const containerStyle = computed(() => {
   if (isExpanded.value || !shouldShowExpandToggle.value) {
@@ -70,21 +71,4 @@ const toggleButtonLabel = computed(() => {
 const toggleButtonIcon = computed(() => {
   return isExpanded.value ? 'i-material-symbols-keyboard-arrow-up-rounded' : 'i-material-symbols-keyboard-arrow-down-rounded'
 })
-
-onMounted(() => {
-  updateHeight()
-  resizeObserver = new ResizeObserver(updateHeight)
-  if (content.value) {
-    resizeObserver.observe(content.value)
-  }
-})
-
-onBeforeUnmount(() => {
-  if (resizeObserver && content.value) {
-    resizeObserver.unobserve(content.value)
-    resizeObserver.disconnect()
-  }
-})
-
-watch(content, updateHeight)
 </script>

--- a/components/PDFReader.vue
+++ b/components/PDFReader.vue
@@ -611,13 +611,7 @@ function handleKeydown(event: KeyboardEvent) {
   }
 }
 
-onMounted(() => {
-  window.addEventListener('keydown', handleKeydown)
-})
-
-onBeforeUnmount(() => {
-  window.removeEventListener('keydown', handleKeydown)
-})
+useEventListener('keydown', handleKeydown)
 
 function handleMobileTTSClick() {
   if (props.isAudioHidden) {

--- a/components/PaywallModal.vue
+++ b/components/PaywallModal.vue
@@ -260,11 +260,10 @@ const modalContentClass = computed(() => {
 })
 
 // NOTE: This could be simplified by computed, but props not updated after `open()` in `useOverlay()`
-const selectedPlan = ref(props.modelValue || 'yearly')
-watch(
-  selectedPlan,
-  value => emit('update:modelValue', value),
-)
+const selectedPlan = useVModel(props, 'modelValue', emit, {
+  passive: true,
+  defaultValue: 'yearly',
+})
 
 const isPaidTrial = computed(() => props.trialPeriodDays && props.trialPeriodDays >= PAID_TRIAL_PERIOD_DAYS_THRESHOLD)
 
@@ -301,7 +300,7 @@ const handleCloseButtonClick = () => {
 
 function handleSubscribeButtonClick() {
   emit('subscribe', {
-    selectedPlan: selectedPlan.value,
+    selectedPlan: selectedPlan.value ?? 'yearly',
     mustCollectPaymentMethod: props.mustCollectPaymentMethod,
     trialPeriodDays: props.trialPeriodDays,
     utmCampaign: utmCampaign.value,

--- a/composables/use-subscription.ts
+++ b/composables/use-subscription.ts
@@ -199,7 +199,7 @@ export function useSubscription() {
           coupon,
         })
         if (redirectRoute && redirectRoute?.name) {
-          accountStore.plusRedirectRoute = redirectRoute
+          accountStore.savePlusRedirectRoute(redirectRoute)
         }
         await navigateTo(url, { external: true })
       }

--- a/composables/use-subscription.ts
+++ b/composables/use-subscription.ts
@@ -199,7 +199,7 @@ export function useSubscription() {
           coupon,
         })
         if (redirectRoute && redirectRoute?.name) {
-          accountStore.savePlusRedirectRoute(redirectRoute)
+          accountStore.plusRedirectRoute = redirectRoute
         }
         await navigateTo(url, { external: true })
       }

--- a/pages/account/index.vue
+++ b/pages/account/index.vue
@@ -445,9 +445,9 @@ const { customVoice, hasCustomVoice, fetchCustomVoice } = useCustomVoice()
 const overlay = useOverlay()
 const customVoiceModal = overlay.create(CustomVoiceUploadModal)
 
-watch(hasLoggedIn, (loggedIn) => {
+watchImmediate(hasLoggedIn, (loggedIn) => {
   if (loggedIn) fetchCustomVoice()
-}, { immediate: true })
+})
 
 const walletAddress = computed(() => user.value?.evmWallet)
 const {

--- a/pages/plus/success.vue
+++ b/pages/plus/success.vue
@@ -138,7 +138,7 @@ onMounted(async () => {
     }
 
     if (giftNFTClassId && giftCartId && giftPaymentId && giftClaimToken) {
-      accountStore.clearPlusRedirectRoute()
+      accountStore.plusRedirectRoute = null
       await navigateTo(localeRoute({
         name: 'claim-page',
         query: {
@@ -150,10 +150,10 @@ onMounted(async () => {
       }), { replace: true })
     }
     else {
-      const redirectRoute = accountStore.getPlusRedirectRoute()
+      const redirectRoute = accountStore.plusRedirectRoute
 
       if (redirectRoute && redirectRoute.name) {
-        accountStore.clearPlusRedirectRoute()
+        accountStore.plusRedirectRoute = null
         await navigateTo(localeRoute(redirectRoute), { replace: true })
       }
       else {

--- a/pages/plus/success.vue
+++ b/pages/plus/success.vue
@@ -138,7 +138,7 @@ onMounted(async () => {
     }
 
     if (giftNFTClassId && giftCartId && giftPaymentId && giftClaimToken) {
-      accountStore.plusRedirectRoute = null
+      accountStore.savePlusRedirectRoute(null)
       await navigateTo(localeRoute({
         name: 'claim-page',
         query: {
@@ -153,7 +153,7 @@ onMounted(async () => {
       const redirectRoute = accountStore.plusRedirectRoute
 
       if (redirectRoute && redirectRoute.name) {
-        accountStore.plusRedirectRoute = null
+        accountStore.savePlusRedirectRoute(null)
         await navigateTo(localeRoute(redirectRoute), { replace: true })
       }
       else {

--- a/stores/account.ts
+++ b/stores/account.ts
@@ -551,7 +551,7 @@ export const useAccountStore = defineStore('account', () => {
       await $fetch('/api/logout', { method: 'POST' })
       await refreshSession()
       clearCaches()
-      plusRedirectRoute.value = null
+      savePlusRedirectRoute(null)
       blockingModal.patch({ title: $t('account_logged_out') })
       // Wait for a moment to show the logged out message
       await sleep(500)
@@ -599,6 +599,10 @@ export const useAccountStore = defineStore('account', () => {
 
   const plusRedirectRoute = useLocalStorage<RouteLocationAsRelativeGeneric | null>('plus_redirect_route', null)
 
+  function savePlusRedirectRoute(route: RouteLocationAsRelativeGeneric | null) {
+    plusRedirectRoute.value = route
+  }
+
   return {
     likeWallet,
     isLoggingIn,
@@ -613,5 +617,6 @@ export const useAccountStore = defineStore('account', () => {
     exportPrivateKey,
     clearCaches,
     plusRedirectRoute,
+    savePlusRedirectRoute,
   }
 })

--- a/stores/account.ts
+++ b/stores/account.ts
@@ -551,7 +551,7 @@ export const useAccountStore = defineStore('account', () => {
       await $fetch('/api/logout', { method: 'POST' })
       await refreshSession()
       clearCaches()
-      clearPlusRedirectRoute()
+      plusRedirectRoute.value = null
       blockingModal.patch({ title: $t('account_logged_out') })
       // Wait for a moment to show the logged out message
       await sleep(500)
@@ -597,38 +597,7 @@ export const useAccountStore = defineStore('account', () => {
     }
   }
 
-  function savePlusRedirectRoute(route: RouteLocationAsRelativeGeneric) {
-    if (!window.localStorage) return
-    try {
-      localStorage.setItem('plus_redirect_route', JSON.stringify(route))
-    }
-    catch (error) {
-      console.warn('Failed to store redirect route:', error)
-    }
-  }
-
-  function getPlusRedirectRoute() {
-    if (!window.localStorage) return null
-    try {
-      const strRoute = localStorage.getItem('plus_redirect_route')
-      return strRoute ? JSON.parse(strRoute) : null
-    }
-    catch (error) {
-      console.error('Failed to parse stored redirect route:', error)
-      clearPlusRedirectRoute()
-      return null
-    }
-  }
-
-  function clearPlusRedirectRoute() {
-    if (!window.localStorage) return
-    try {
-      localStorage.removeItem('plus_redirect_route')
-    }
-    catch (error) {
-      console.warn('Failed to clear stored redirect route:', error)
-    }
-  }
+  const plusRedirectRoute = useLocalStorage<RouteLocationAsRelativeGeneric | null>('plus_redirect_route', null)
 
   return {
     likeWallet,
@@ -643,8 +612,6 @@ export const useAccountStore = defineStore('account', () => {
     restoreConnection,
     exportPrivateKey,
     clearCaches,
-    clearPlusRedirectRoute,
-    getPlusRedirectRoute,
-    savePlusRedirectRoute,
+    plusRedirectRoute,
   }
 })


### PR DESCRIPTION
Replace manual patterns with VueUse equivalents for better maintainability:
- useLocalStorage for localStorage in account store (plusRedirectRoute)
- useResizeObserver in ExpandableContent (removes manual lifecycle)
- useEventListener in PDFReader (removes addEventListener/removeEventListener)
- useVModel in PaywallModal (simplifies v-model wiring)
- useIntervalFn in CustomVoiceUploadModal (replaces setInterval/clearInterval)
- watchImmediate in AffiliateAlert and account page (cleaner API)