### PR TITLE
🐛 Show actual error details in TTS unknown error modal

### DIFF
--- a/components/TTSPlayerModal.vue
+++ b/components/TTSPlayerModal.vue
@@ -339,6 +339,20 @@ const {
       })
       return
     }
+    if (error instanceof MediaError) {
+      const codeNames: Record<number, string> = {
+        1: 'MEDIA_ERR_ABORTED',
+        2: 'MEDIA_ERR_NETWORK',
+        3: 'MEDIA_ERR_DECODE',
+        4: 'MEDIA_ERR_SRC_NOT_SUPPORTED',
+      }
+      handleError(new Error(`MediaError ${codeNames[error.code] || error.code}: ${error.message}`))
+      return
+    }
+    if (error instanceof Event) {
+      handleError(new Error(`Audio error event: ${error.type}`))
+      return
+    }
     handleError(error)
   },
   onAllSegmentsPlayed: () => {


### PR DESCRIPTION
Convert MediaError and Event objects to proper Error instances with descriptive messages so the error modal displays debug info instead of just "未知錯誤".