### PR TITLE
🐛 Fix dual page rendering and cover page handling in PDFReader

### DIFF
--- a/components/PDFReader.vue
+++ b/components/PDFReader.vue
@@ -154,7 +154,7 @@
             />
           </div>
           <div
-            v-if="!isCoverPage"
+            v-show="!isCoverPage"
             :class="[
               ...pagePaddingClasses,
               'pl-2 laptop:pl-2',
@@ -492,7 +492,8 @@ async function renderDualPages() {
   if (!pdfDocument.value || !leftCanvas.value || !rightCanvas.value) return
 
   const leftPageNum = dualLeftPage.value
-  const rightPageNum = dualRightPage.value ?? leftPageNum + 1
+  const rightPageNum = dualRightPage.value
+  const hasRightPage = Boolean(rightPageNum)
 
   const leftContext = leftCanvas.value.getContext('2d')
   const rightContext = rightCanvas.value.getContext('2d')
@@ -502,10 +503,14 @@ async function renderDualPages() {
 
   const actualLeftPageNum = isCoverPage.value
     ? leftPageNum
-    : (isRightToLeft.value ? rightPageNum : leftPageNum)
+    : (isRightToLeft.value
+        ? (hasRightPage ? rightPageNum! : leftPageNum)
+        : leftPageNum)
   const actualRightPageNum = isCoverPage.value
     ? undefined
-    : (isRightToLeft.value ? leftPageNum : rightPageNum)
+    : (isRightToLeft.value
+        ? (hasRightPage ? leftPageNum : undefined)
+        : rightPageNum)
 
   const leftPageTask = pdfDocument.value.getPage(actualLeftPageNum).then(async (leftPage) => {
     const leftViewport = leftPage.getViewport({ scale: scale.value })
@@ -548,6 +553,8 @@ async function renderDualPages() {
     rightContext.clearRect(0, 0, rightCanvas.value.width, rightCanvas.value.height)
     rightCanvas.value.width = 0
     rightCanvas.value.height = 0
+    rightCanvas.value.style.width = '0px'
+    rightCanvas.value.style.height = '0px'
   }
 
   await Promise.all(renderTasks)

--- a/components/PDFReader.vue
+++ b/components/PDFReader.vue
@@ -154,6 +154,7 @@
             />
           </div>
           <div
+            v-if="!isCoverPage"
             :class="[
               ...pagePaddingClasses,
               'pl-2 laptop:pl-2',
@@ -301,24 +302,39 @@ const { pixelRatio } = useDevicePixelRatio()
 
 const isMobile = useMediaQuery('(max-width: 768px)')
 
+const dualLeftPage = computed(() => {
+  if (!isDualPageMode.value || totalPages.value <= 1) return currentPage.value
+  if (currentPage.value <= 1) return 1
+  return currentPage.value % 2 === 0 ? currentPage.value : currentPage.value - 1
+})
+const dualRightPage = computed(() => {
+  if (!isDualPageMode.value || totalPages.value <= 1) return undefined
+  const rightPage = dualLeftPage.value + 1
+  return rightPage <= totalPages.value ? rightPage : undefined
+})
+const isCoverPage = computed(() => {
+  return isDualPageMode.value && totalPages.value > 1 && dualLeftPage.value === 1
+})
+
 const pageDisplayText = computed(() => {
   if (isDualPageMode.value && totalPages.value > 1) {
-    const leftPage = currentPage.value
-    const rightPage = currentPage.value + 1
-    if (rightPage <= totalPages.value) {
+    const leftPage = dualLeftPage.value
+    const rightPage = dualRightPage.value
+    if (rightPage && !isCoverPage.value) {
       return `${leftPage}-${rightPage} / ${totalPages.value}`
     }
+    return `${leftPage} / ${totalPages.value}`
   }
   return `${currentPage.value} / ${totalPages.value}`
 })
 
 const isAtFirstPage = computed(() => currentPage.value <= 1)
 const isAtLastPage = computed(() => {
-  let current = currentPage.value
-  if (isDualPageMode.value && totalPages.value > 1) {
-    current += 1
+  if (!isDualPageMode.value || totalPages.value <= 1) {
+    return currentPage.value >= totalPages.value
   }
-  return current >= totalPages.value
+  const lastVisiblePage = dualRightPage.value ?? dualLeftPage.value
+  return lastVisiblePage >= totalPages.value
 })
 
 async function loadPDFLib() {
@@ -348,6 +364,12 @@ onMounted(async () => {
 watch(isMobile, async (value) => {
   if (value && isDualPageMode.value) {
     isDualPageMode.value = false
+  }
+})
+
+watch(isDualPageMode, (value) => {
+  if (value && currentPage.value > 1 && currentPage.value % 2 === 1) {
+    currentPage.value -= 1
   }
 })
 
@@ -469,8 +491,8 @@ async function renderSinglePage() {
 async function renderDualPages() {
   if (!pdfDocument.value || !leftCanvas.value || !rightCanvas.value) return
 
-  const leftPageNum = currentPage.value
-  const rightPageNum = currentPage.value + 1
+  const leftPageNum = dualLeftPage.value
+  const rightPageNum = dualRightPage.value ?? leftPageNum + 1
 
   const leftContext = leftCanvas.value.getContext('2d')
   const rightContext = rightCanvas.value.getContext('2d')
@@ -478,8 +500,12 @@ async function renderDualPages() {
 
   const renderTasks = []
 
-  const actualLeftPageNum = isRightToLeft.value ? rightPageNum : leftPageNum
-  const actualRightPageNum = isRightToLeft.value ? leftPageNum : rightPageNum
+  const actualLeftPageNum = isCoverPage.value
+    ? leftPageNum
+    : (isRightToLeft.value ? rightPageNum : leftPageNum)
+  const actualRightPageNum = isCoverPage.value
+    ? undefined
+    : (isRightToLeft.value ? leftPageNum : rightPageNum)
 
   const leftPageTask = pdfDocument.value.getPage(actualLeftPageNum).then(async (leftPage) => {
     const leftViewport = leftPage.getViewport({ scale: scale.value })
@@ -499,7 +525,7 @@ async function renderDualPages() {
   })
   renderTasks.push(leftPageTask)
 
-  if (actualRightPageNum <= totalPages.value) {
+  if (actualRightPageNum && actualRightPageNum <= totalPages.value) {
     const rightPageTask = pdfDocument.value.getPage(actualRightPageNum).then(async (rightPage) => {
       const rightViewport = rightPage.getViewport({ scale: scale.value })
       if (rightCanvas.value) {
@@ -520,20 +546,24 @@ async function renderDualPages() {
   }
   else {
     rightContext.clearRect(0, 0, rightCanvas.value.width, rightCanvas.value.height)
-    rightCanvas.value.width = leftCanvas.value.width
-    rightCanvas.value.height = leftCanvas.value.height
+    rightCanvas.value.width = 0
+    rightCanvas.value.height = 0
   }
 
   await Promise.all(renderTasks)
 }
 
 function nextPage() {
-  const step = isDualPageMode.value ? 2 : 1
+  const step = isDualPageMode.value
+    ? (currentPage.value === 1 ? 1 : 2)
+    : 1
   currentPage.value = Math.min(currentPage.value + step, totalPages.value)
 }
 
 function previousPage() {
-  const step = isDualPageMode.value ? 2 : 1
+  const step = isDualPageMode.value
+    ? (currentPage.value <= 2 ? 1 : 2)
+    : 1
   currentPage.value = Math.max(currentPage.value - step, 1)
 }
 
@@ -544,7 +574,7 @@ function togglePageMode(value?: 'single' | 'dual') {
   else {
     isDualPageMode.value = value === 'dual'
   }
-  if (isDualPageMode.value && currentPage.value % 2 === 0 && currentPage.value > 1) {
+  if (isDualPageMode.value && currentPage.value > 1 && currentPage.value % 2 === 1) {
     currentPage.value--
   }
   renderPages()
@@ -564,7 +594,12 @@ function zoomOut() {
 
 function goToPage(pageNumber: number) {
   if (pageNumber >= 1 && pageNumber <= totalPages.value) {
-    currentPage.value = pageNumber
+    if (isDualPageMode.value && pageNumber > 1 && pageNumber % 2 === 1) {
+      currentPage.value = pageNumber - 1
+    }
+    else {
+      currentPage.value = pageNumber
+    }
   }
 }
 

--- a/components/PDFReader.vue
+++ b/components/PDFReader.vue
@@ -302,40 +302,26 @@ const { pixelRatio } = useDevicePixelRatio()
 
 const isMobile = useMediaQuery('(max-width: 768px)')
 
-const dualLeftPage = computed(() => {
-  if (!isDualPageMode.value || totalPages.value <= 1) return currentPage.value
-  if (currentPage.value <= 1) return 1
-  return currentPage.value % 2 === 0 ? currentPage.value : currentPage.value - 1
-})
+const isCoverPage = computed(() =>
+  isDualPageMode.value && totalPages.value > 1 && currentPage.value === 1,
+)
+
 const dualRightPage = computed(() => {
-  if (!isDualPageMode.value || totalPages.value <= 1) return undefined
-  const rightPage = dualLeftPage.value + 1
-  return rightPage <= totalPages.value ? rightPage : undefined
-})
-const isCoverPage = computed(() => {
-  return isDualPageMode.value && totalPages.value > 1 && dualLeftPage.value === 1
+  if (!isDualPageMode.value || totalPages.value <= 1 || isCoverPage.value) return undefined
+  const right = currentPage.value + 1
+  return right <= totalPages.value ? right : undefined
 })
 
 const pageDisplayText = computed(() => {
-  if (isDualPageMode.value && totalPages.value > 1) {
-    const leftPage = dualLeftPage.value
-    const rightPage = dualRightPage.value
-    if (rightPage && !isCoverPage.value) {
-      return `${leftPage}-${rightPage} / ${totalPages.value}`
-    }
-    return `${leftPage} / ${totalPages.value}`
-  }
+  const right = dualRightPage.value
+  if (right) return `${currentPage.value}-${right} / ${totalPages.value}`
   return `${currentPage.value} / ${totalPages.value}`
 })
 
 const isAtFirstPage = computed(() => currentPage.value <= 1)
-const isAtLastPage = computed(() => {
-  if (!isDualPageMode.value || totalPages.value <= 1) {
-    return currentPage.value >= totalPages.value
-  }
-  const lastVisiblePage = dualRightPage.value ?? dualLeftPage.value
-  return lastVisiblePage >= totalPages.value
-})
+const isAtLastPage = computed(() =>
+  (dualRightPage.value ?? currentPage.value) >= totalPages.value,
+)
 
 async function loadPDFLib() {
   if (pdfjsLib.value) return pdfjsLib.value
@@ -491,9 +477,7 @@ async function renderSinglePage() {
 async function renderDualPages() {
   if (!pdfDocument.value || !leftCanvas.value || !rightCanvas.value) return
 
-  const leftPageNum = dualLeftPage.value
   const rightPageNum = dualRightPage.value
-  const hasRightPage = Boolean(rightPageNum)
 
   const leftContext = leftCanvas.value.getContext('2d')
   const rightContext = rightCanvas.value.getContext('2d')
@@ -501,16 +485,9 @@ async function renderDualPages() {
 
   const renderTasks = []
 
-  const actualLeftPageNum = isCoverPage.value
-    ? leftPageNum
-    : (isRightToLeft.value
-        ? (hasRightPage ? rightPageNum! : leftPageNum)
-        : leftPageNum)
-  const actualRightPageNum = isCoverPage.value
-    ? undefined
-    : (isRightToLeft.value
-        ? (hasRightPage ? leftPageNum : undefined)
-        : rightPageNum)
+  // In RTL mode with a right page, swap left/right display positions
+  const actualLeftPageNum = (isRightToLeft.value && rightPageNum) ? rightPageNum : currentPage.value
+  const actualRightPageNum = (isRightToLeft.value && rightPageNum) ? currentPage.value : rightPageNum
 
   const leftPageTask = pdfDocument.value.getPage(actualLeftPageNum).then(async (leftPage) => {
     const leftViewport = leftPage.getViewport({ scale: scale.value })
@@ -530,7 +507,7 @@ async function renderDualPages() {
   })
   renderTasks.push(leftPageTask)
 
-  if (actualRightPageNum && actualRightPageNum <= totalPages.value) {
+  if (actualRightPageNum) {
     const rightPageTask = pdfDocument.value.getPage(actualRightPageNum).then(async (rightPage) => {
       const rightViewport = rightPage.getViewport({ scale: scale.value })
       if (rightCanvas.value) {


### PR DESCRIPTION
Before:
<img width="826" height="740" alt="截圖 2026-02-22 23 35 16" src="https://github.com/user-attachments/assets/ad3c36c7-0199-42b6-8b6f-595421594944" />

After:
<img width="1247" height="897" alt="截圖 2026-02-22 23 35 36" src="https://github.com/user-attachments/assets/e590edc6-fe0f-4a3b-b17c-f49797124fd8" />
<img width="1255" height="755" alt="截圖 2026-02-22 23 35 50" src="https://github.com/user-attachments/assets/708942de-4da2-429d-84b6-41f517b919e3" />
