### PR TITLE
🐛 Fix TTS stuck on MEDIA_ERR_DECODE due to error/pause race condition

### DIFF
--- a/composables/use-text-to-speech.ts
+++ b/composables/use-text-to-speech.ts
@@ -126,7 +126,7 @@ export function useTextToSpeech(options: TTSOptions = {}) {
       return
     }
     setTimeout(() => {
-      if (isTextToSpeechOn.value && isTextToSpeechPlaying.value) {
+      if (isTextToSpeechOn.value) {
         playNextElement()
       }
     }, 1000)


### PR DESCRIPTION
When a decode error occurs mid-playback, the browser fires both onerror and onpause. The onpause handler was retrying the same broken audio via auto-resume, while the error handler's skip-to-next check failed because isTextToSpeechPlaying was already false. Added an errored flag to prevent auto-resume on errored audio and relaxed the retry condition to check isTextToSpeechOn only.