### PR TITLE
♻️ Add Valibot schema validation to server API routes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "pinia": "^3.0.1",
         "unstorage": "^1.17.1",
         "v-gsap-nuxt": "^1.4.4",
+        "valibot": "^1.2.0",
         "viem": "^2.39.3",
         "vue": "^3.5.13",
         "vue-router": "^4.5.0"

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "pdfjs-dist": "^5.3.31",
     "pinia": "^3.0.1",
     "unstorage": "^1.17.1",
+    "valibot": "^1.2.0",
     "v-gsap-nuxt": "^1.4.4",
     "viem": "^2.39.3",
     "vue": "^3.5.13",

--- a/server/api/account/delete.post.ts
+++ b/server/api/account/delete.post.ts
@@ -1,3 +1,5 @@
+import { AccountDeleteBodySchema } from '~/server/schemas/auth'
+
 export default defineEventHandler(async (event) => {
   const session = await requireUserSession(event)
   const { evmWallet, likerId } = session.user
@@ -15,22 +17,8 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  const body = await readBody<{
-    wallet: string
-    signMethod: string
-    authorizeSignature: string
-    authorizeMessage: string
-    deleteSignature: string
-    deleteMessage: string
-  }>(event)
-  if (!body?.wallet || !body?.signMethod
-    || !body?.authorizeSignature || !body?.authorizeMessage
-    || !body?.deleteSignature || !body?.deleteMessage) {
-    throw createError({
-      status: 400,
-      message: 'MISSING_SIGNATURE',
-    })
-  }
+  const body = await readValidatedBody(event, useValidation(AccountDeleteBodySchema))
+
   if (body.wallet.toLowerCase() !== evmWallet.toLowerCase()) {
     throw createError({
       status: 403,

--- a/server/api/account/delete.post.ts
+++ b/server/api/account/delete.post.ts
@@ -17,7 +17,7 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  const body = await readValidatedBody(event, useValidation(AccountDeleteBodySchema))
+  const body = await readValidatedBody(event, createValidator(AccountDeleteBodySchema))
 
   if (body.wallet.toLowerCase() !== evmWallet.toLowerCase()) {
     throw createError({

--- a/server/api/book-list/index.delete.ts
+++ b/server/api/book-list/index.delete.ts
@@ -3,7 +3,7 @@ import { BookListBodySchema } from '~/server/schemas/book-list'
 export default defineEventHandler(async (event) => {
   const session = await requireUserSession(event)
   const userWallet = session.user.evmWallet
-  const { nftClassId, priceIndex } = await readValidatedBody(event, useValidation(BookListBodySchema))
+  const { nftClassId, priceIndex } = await readValidatedBody(event, createValidator(BookListBodySchema))
 
   await deleteUserBookListItem(userWallet, nftClassId, priceIndex)
 })

--- a/server/api/book-list/index.delete.ts
+++ b/server/api/book-list/index.delete.ts
@@ -1,14 +1,9 @@
+import { BookListBodySchema } from '~/server/schemas/book-list'
+
 export default defineEventHandler(async (event) => {
   const session = await requireUserSession(event)
   const userWallet = session.user.evmWallet
-  const body = await readBody(event)
-  const { nftClassId, priceIndex = 0 } = body
-  if (!nftClassId) {
-    throw createError({
-      statusCode: 400,
-      statusMessage: 'nftClassId is required in body',
-    })
-  }
+  const { nftClassId, priceIndex } = await readValidatedBody(event, useValidation(BookListBodySchema))
 
   await deleteUserBookListItem(userWallet, nftClassId, priceIndex)
 })

--- a/server/api/book-list/index.get.ts
+++ b/server/api/book-list/index.get.ts
@@ -5,7 +5,7 @@ export default defineEventHandler(async (event) => {
   const session = await requireUserSession(event)
   setHeader(event, 'cache-control', 'private')
   const userWallet = session.user.evmWallet
-  const query = await getValidatedQuery(event, useValidation(BookListQuerySchema))
+  const query = await getValidatedQuery(event, createValidator(BookListQuerySchema))
 
   let priceIndex = 0
   if (query.price_index !== undefined) {

--- a/server/api/book-list/index.get.ts
+++ b/server/api/book-list/index.get.ts
@@ -1,20 +1,14 @@
+import { BookListQuerySchema } from '~/server/schemas/book-list'
 import { fetchUserBookListItem } from '~/server/utils/book-list'
 
 export default defineEventHandler(async (event) => {
   const session = await requireUserSession(event)
   setHeader(event, 'cache-control', 'private')
   const userWallet = session.user.evmWallet
-  const query = getQuery(event)
-  const nftClassId = query.nft_class_id as string
-  if (!nftClassId) {
-    throw createError({
-      statusCode: 400,
-      statusMessage: 'nft_class_id is required in query',
-    })
-  }
+  const query = await getValidatedQuery(event, useValidation(BookListQuerySchema))
 
   let priceIndex = 0
-  if (typeof query.price_index !== 'undefined') {
+  if (query.price_index !== undefined) {
     priceIndex = Number(query.price_index)
     if (isNaN(priceIndex)) {
       throw createError({
@@ -27,7 +21,7 @@ export default defineEventHandler(async (event) => {
   try {
     const bookListItem = await fetchUserBookListItem(
       userWallet,
-      nftClassId,
+      query.nft_class_id,
       priceIndex,
     )
 

--- a/server/api/book-list/index.post.ts
+++ b/server/api/book-list/index.post.ts
@@ -3,7 +3,7 @@ import { BookListBodySchema } from '~/server/schemas/book-list'
 export default defineEventHandler(async (event) => {
   const session = await requireUserSession(event)
   const userWallet = session.user.evmWallet
-  const { nftClassId, priceIndex } = await readValidatedBody(event, useValidation(BookListBodySchema))
+  const { nftClassId, priceIndex } = await readValidatedBody(event, createValidator(BookListBodySchema))
 
   const bookListItem = await addUserBookListItem(userWallet, nftClassId, priceIndex)
   return bookListItem

--- a/server/api/book-list/index.post.ts
+++ b/server/api/book-list/index.post.ts
@@ -1,14 +1,9 @@
+import { BookListBodySchema } from '~/server/schemas/book-list'
+
 export default defineEventHandler(async (event) => {
   const session = await requireUserSession(event)
   const userWallet = session.user.evmWallet
-  const body = await readBody(event)
-  const { nftClassId, priceIndex = 0 } = body
-  if (!nftClassId) {
-    throw createError({
-      statusCode: 400,
-      statusMessage: 'nftClassId is required in body',
-    })
-  }
+  const { nftClassId, priceIndex } = await readValidatedBody(event, useValidation(BookListBodySchema))
 
   const bookListItem = await addUserBookListItem(userWallet, nftClassId, priceIndex)
   return bookListItem

--- a/server/api/books/[nftClassId]/annotations/[annotationId].delete.ts
+++ b/server/api/books/[nftClassId]/annotations/[annotationId].delete.ts
@@ -12,7 +12,7 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  const { nftClassId, annotationId } = await getValidatedRouterParams(event, useValidation(AnnotationParamsSchema))
+  const { nftClassId, annotationId } = await getValidatedRouterParams(event, createValidator(AnnotationParamsSchema))
 
   try {
     const deleted = await deleteAnnotation(walletAddress, nftClassId, annotationId)

--- a/server/api/books/[nftClassId]/annotations/[annotationId].delete.ts
+++ b/server/api/books/[nftClassId]/annotations/[annotationId].delete.ts
@@ -1,5 +1,7 @@
 import { H3Error } from 'h3'
 
+import { AnnotationParamsSchema } from '~/server/schemas/params'
+
 export default defineEventHandler(async (event) => {
   const session = await requireUserSession(event)
   const walletAddress = session.user.evmWallet || session.user.likeWallet
@@ -10,21 +12,7 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  const nftClassId = getRouterParam(event, 'nftClassId')
-  if (!nftClassId) {
-    throw createError({
-      statusCode: 400,
-      message: 'MISSING_NFT_CLASS_ID',
-    })
-  }
-
-  const annotationId = getRouterParam(event, 'annotationId')
-  if (!annotationId) {
-    throw createError({
-      statusCode: 400,
-      message: 'MISSING_ANNOTATION_ID',
-    })
-  }
+  const { nftClassId, annotationId } = await getValidatedRouterParams(event, useValidation(AnnotationParamsSchema))
 
   try {
     const deleted = await deleteAnnotation(walletAddress, nftClassId, annotationId)

--- a/server/api/books/[nftClassId]/annotations/[annotationId].post.ts
+++ b/server/api/books/[nftClassId]/annotations/[annotationId].post.ts
@@ -13,8 +13,8 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  const { nftClassId, annotationId } = await getValidatedRouterParams(event, useValidation(AnnotationParamsSchema))
-  const body = await readValidatedBody(event, useValidation(AnnotationUpdateSchema))
+  const { nftClassId, annotationId } = await getValidatedRouterParams(event, createValidator(AnnotationParamsSchema))
+  const body = await readValidatedBody(event, createValidator(AnnotationUpdateSchema))
 
   try {
     const annotation = await updateAnnotation(walletAddress, nftClassId, annotationId, body)

--- a/server/api/books/[nftClassId]/annotations/export.get.ts
+++ b/server/api/books/[nftClassId]/annotations/export.get.ts
@@ -10,7 +10,7 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  const { nftClassId } = await getValidatedRouterParams(event, useValidation(NFTClassIdParamsSchema))
+  const { nftClassId } = await getValidatedRouterParams(event, createValidator(NFTClassIdParamsSchema))
 
   setHeader(event, 'Cache-Control', 'private, no-cache, no-store, must-revalidate')
 

--- a/server/api/books/[nftClassId]/annotations/export.get.ts
+++ b/server/api/books/[nftClassId]/annotations/export.get.ts
@@ -1,4 +1,4 @@
-import { NftClassIdParamsSchema } from '~/server/schemas/params'
+import { NFTClassIdParamsSchema } from '~/server/schemas/params'
 
 export default defineEventHandler(async (event) => {
   const session = await requireUserSession(event)
@@ -10,7 +10,7 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  const { nftClassId } = await getValidatedRouterParams(event, useValidation(NftClassIdParamsSchema))
+  const { nftClassId } = await getValidatedRouterParams(event, useValidation(NFTClassIdParamsSchema))
 
   setHeader(event, 'Cache-Control', 'private, no-cache, no-store, must-revalidate')
 

--- a/server/api/books/[nftClassId]/annotations/export.get.ts
+++ b/server/api/books/[nftClassId]/annotations/export.get.ts
@@ -1,3 +1,5 @@
+import { NftClassIdParamsSchema } from '~/server/schemas/params'
+
 export default defineEventHandler(async (event) => {
   const session = await requireUserSession(event)
   const walletAddress = session.user.evmWallet || session.user.likeWallet
@@ -8,13 +10,7 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  const nftClassId = getRouterParam(event, 'nftClassId')
-  if (!nftClassId) {
-    throw createError({
-      statusCode: 400,
-      message: 'MISSING_NFT_CLASS_ID',
-    })
-  }
+  const { nftClassId } = await getValidatedRouterParams(event, useValidation(NftClassIdParamsSchema))
 
   setHeader(event, 'Cache-Control', 'private, no-cache, no-store, must-revalidate')
 

--- a/server/api/books/[nftClassId]/annotations/index.get.ts
+++ b/server/api/books/[nftClassId]/annotations/index.get.ts
@@ -10,7 +10,7 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  const { nftClassId } = await getValidatedRouterParams(event, useValidation(NFTClassIdParamsSchema))
+  const { nftClassId } = await getValidatedRouterParams(event, createValidator(NFTClassIdParamsSchema))
 
   setHeader(event, 'Cache-Control', 'private, no-cache, no-store, must-revalidate')
 

--- a/server/api/books/[nftClassId]/annotations/index.get.ts
+++ b/server/api/books/[nftClassId]/annotations/index.get.ts
@@ -1,4 +1,4 @@
-import { NftClassIdParamsSchema } from '~/server/schemas/params'
+import { NFTClassIdParamsSchema } from '~/server/schemas/params'
 
 export default defineEventHandler(async (event) => {
   const session = await requireUserSession(event)
@@ -10,7 +10,7 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  const { nftClassId } = await getValidatedRouterParams(event, useValidation(NftClassIdParamsSchema))
+  const { nftClassId } = await getValidatedRouterParams(event, useValidation(NFTClassIdParamsSchema))
 
   setHeader(event, 'Cache-Control', 'private, no-cache, no-store, must-revalidate')
 

--- a/server/api/books/[nftClassId]/annotations/index.get.ts
+++ b/server/api/books/[nftClassId]/annotations/index.get.ts
@@ -1,3 +1,5 @@
+import { NftClassIdParamsSchema } from '~/server/schemas/params'
+
 export default defineEventHandler(async (event) => {
   const session = await requireUserSession(event)
   const walletAddress = session.user.evmWallet || session.user.likeWallet
@@ -8,13 +10,7 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  const nftClassId = getRouterParam(event, 'nftClassId')
-  if (!nftClassId) {
-    throw createError({
-      statusCode: 400,
-      message: 'MISSING_NFT_CLASS_ID',
-    })
-  }
+  const { nftClassId } = await getValidatedRouterParams(event, useValidation(NftClassIdParamsSchema))
 
   setHeader(event, 'Cache-Control', 'private, no-cache, no-store, must-revalidate')
 

--- a/server/api/books/[nftClassId]/annotations/index.post.ts
+++ b/server/api/books/[nftClassId]/annotations/index.post.ts
@@ -1,6 +1,6 @@
 import { GrpcStatus } from 'firebase-admin/firestore'
 
-import { NftClassIdParamsSchema } from '~/server/schemas/params'
+import { NFTClassIdParamsSchema } from '~/server/schemas/params'
 import { AnnotationCreateSchema } from '~/shared/schemas/annotation'
 
 export default defineEventHandler(async (event) => {
@@ -13,7 +13,7 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  const { nftClassId } = await getValidatedRouterParams(event, useValidation(NftClassIdParamsSchema))
+  const { nftClassId } = await getValidatedRouterParams(event, useValidation(NFTClassIdParamsSchema))
   const body = await readValidatedBody(event, useValidation(AnnotationCreateSchema))
 
   try {

--- a/server/api/books/[nftClassId]/annotations/index.post.ts
+++ b/server/api/books/[nftClassId]/annotations/index.post.ts
@@ -13,8 +13,8 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  const { nftClassId } = await getValidatedRouterParams(event, useValidation(NFTClassIdParamsSchema))
-  const body = await readValidatedBody(event, useValidation(AnnotationCreateSchema))
+  const { nftClassId } = await getValidatedRouterParams(event, createValidator(NFTClassIdParamsSchema))
+  const body = await readValidatedBody(event, createValidator(AnnotationCreateSchema))
 
   try {
     const annotation = await createAnnotation(walletAddress, nftClassId, {

--- a/server/api/books/[nftClassId]/settings.get.ts
+++ b/server/api/books/[nftClassId]/settings.get.ts
@@ -10,7 +10,7 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  const { nftClassId } = await getValidatedRouterParams(event, useValidation(NFTClassIdParamsSchema))
+  const { nftClassId } = await getValidatedRouterParams(event, createValidator(NFTClassIdParamsSchema))
 
   setHeader(event, 'Cache-Control', 'private, no-cache, no-store, must-revalidate')
 

--- a/server/api/books/[nftClassId]/settings.get.ts
+++ b/server/api/books/[nftClassId]/settings.get.ts
@@ -1,4 +1,4 @@
-import { NftClassIdParamsSchema } from '~/server/schemas/params'
+import { NFTClassIdParamsSchema } from '~/server/schemas/params'
 
 export default defineEventHandler(async (event) => {
   const session = await requireUserSession(event)
@@ -10,7 +10,7 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  const { nftClassId } = await getValidatedRouterParams(event, useValidation(NftClassIdParamsSchema))
+  const { nftClassId } = await getValidatedRouterParams(event, useValidation(NFTClassIdParamsSchema))
 
   setHeader(event, 'Cache-Control', 'private, no-cache, no-store, must-revalidate')
 

--- a/server/api/books/[nftClassId]/settings.get.ts
+++ b/server/api/books/[nftClassId]/settings.get.ts
@@ -1,3 +1,5 @@
+import { NftClassIdParamsSchema } from '~/server/schemas/params'
+
 export default defineEventHandler(async (event) => {
   const session = await requireUserSession(event)
   const walletAddress = session.user.evmWallet || session.user.likeWallet
@@ -8,13 +10,7 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  const nftClassId = getRouterParam(event, 'nftClassId')
-  if (!nftClassId) {
-    throw createError({
-      statusCode: 400,
-      message: 'MISSING_NFT_CLASS_ID',
-    })
-  }
+  const { nftClassId } = await getValidatedRouterParams(event, useValidation(NftClassIdParamsSchema))
 
   setHeader(event, 'Cache-Control', 'private, no-cache, no-store, must-revalidate')
 

--- a/server/api/books/[nftClassId]/settings.post.ts
+++ b/server/api/books/[nftClassId]/settings.post.ts
@@ -1,4 +1,5 @@
-import type { BookSettingsData } from '~/types/book-settings'
+import { NftClassIdParamsSchema } from '~/server/schemas/params'
+import { BookSettingsUpdateSchema } from '~/shared/schemas/book-settings'
 
 export default defineEventHandler(async (event) => {
   const session = await requireUserSession(event)
@@ -10,55 +11,8 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  const nftClassId = getRouterParam(event, 'nftClassId')
-  if (!nftClassId) {
-    throw createError({
-      statusCode: 400,
-      message: 'MISSING_NFT_CLASS_ID',
-    })
-  }
-
-  let body: Partial<BookSettingsData> | undefined
-  try {
-    body = await readBody(event)
-  }
-  catch (error) {
-    console.error(error)
-    throw createError({
-      statusCode: 400,
-      message: 'INVALID_BODY',
-    })
-  }
-
-  if (!body) {
-    throw createError({
-      statusCode: 400,
-      message: 'MISSING_BODY',
-    })
-  }
-
-  // Validate that only known keys are present
-  const allowedKeys: (keyof BookSettingsData)[] = [
-    'epub-cfi',
-    'epub-fontSize',
-    'epub-activeTTSElementIndex',
-    'pdf-currentPage',
-    'pdf-scale',
-    'pdf-isDualPageMode',
-    'pdf-isRightToLeft',
-    'progress',
-    'lastOpenedTime',
-  ]
-
-  const bodyKeys = Object.keys(body)
-  const invalidKeys = bodyKeys.filter(key => !allowedKeys.includes(key as keyof BookSettingsData))
-
-  if (invalidKeys.length > 0) {
-    throw createError({
-      statusCode: 400,
-      message: `INVALID_KEYS: ${invalidKeys.join(', ')}`,
-    })
-  }
+  const { nftClassId } = await getValidatedRouterParams(event, useValidation(NftClassIdParamsSchema))
+  const body = await readValidatedBody(event, useValidation(BookSettingsUpdateSchema))
 
   try {
     await updateBookSettings(walletAddress, nftClassId, body)

--- a/server/api/books/[nftClassId]/settings.post.ts
+++ b/server/api/books/[nftClassId]/settings.post.ts
@@ -1,4 +1,4 @@
-import { NftClassIdParamsSchema } from '~/server/schemas/params'
+import { NFTClassIdParamsSchema } from '~/server/schemas/params'
 import { BookSettingsUpdateSchema } from '~/shared/schemas/book-settings'
 
 export default defineEventHandler(async (event) => {
@@ -11,7 +11,7 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  const { nftClassId } = await getValidatedRouterParams(event, useValidation(NftClassIdParamsSchema))
+  const { nftClassId } = await getValidatedRouterParams(event, useValidation(NFTClassIdParamsSchema))
   const body = await readValidatedBody(event, useValidation(BookSettingsUpdateSchema))
 
   try {

--- a/server/api/books/[nftClassId]/settings.post.ts
+++ b/server/api/books/[nftClassId]/settings.post.ts
@@ -11,8 +11,8 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  const { nftClassId } = await getValidatedRouterParams(event, useValidation(NFTClassIdParamsSchema))
-  const body = await readValidatedBody(event, useValidation(BookSettingsUpdateSchema))
+  const { nftClassId } = await getValidatedRouterParams(event, createValidator(NFTClassIdParamsSchema))
+  const body = await readValidatedBody(event, createValidator(BookSettingsUpdateSchema))
 
   try {
     await updateBookSettings(walletAddress, nftClassId, body)

--- a/server/api/login.post.ts
+++ b/server/api/login.post.ts
@@ -1,54 +1,10 @@
 import { jwtDecode } from 'jwt-decode'
 import { FieldValue } from 'firebase-admin/firestore'
 
+import { LoginBodySchema } from '~/server/schemas/auth'
+
 export default defineEventHandler(async (event) => {
-  let body: {
-    walletAddress: string
-    message: string
-    signature: string
-    email?: string
-    loginMethod: string
-  } | undefined
-  try {
-    body = await readBody(event)
-  }
-  catch (error) {
-    console.error(error)
-    throw createError({
-      status: 400,
-      message: 'INVALID_BODY',
-    })
-  }
-  if (!body) {
-    throw createError({
-      status: 400,
-      message: 'MISSING_BODY',
-    })
-  }
-  if (!body.walletAddress) {
-    throw createError({
-      status: 400,
-      message: 'MISSING_ADDRESS',
-    })
-  }
-  if (!checkIsEVMAddress(body.walletAddress)) {
-    throw createError({
-      status: 400,
-      message: 'INVALID_ADDRESS',
-    })
-  }
-  if (!body.message) {
-    throw createError({
-      status: 400,
-      message: 'MISSING_MESSAGE',
-    })
-  }
-  if (!body.signature) {
-    throw createError({
-      status: 400,
-      message: 'MISSING_SIGNATURE',
-    })
-  }
+  const body = await readValidatedBody(event, useValidation(LoginBodySchema))
 
   let likeWallet: string | undefined
   let jwtId: string | undefined

--- a/server/api/login.post.ts
+++ b/server/api/login.post.ts
@@ -4,7 +4,7 @@ import { FieldValue } from 'firebase-admin/firestore'
 import { LoginBodySchema } from '~/server/schemas/auth'
 
 export default defineEventHandler(async (event) => {
-  const body = await readValidatedBody(event, useValidation(LoginBodySchema))
+  const body = await readValidatedBody(event, createValidator(LoginBodySchema))
 
   let likeWallet: string | undefined
   let jwtId: string | undefined

--- a/server/api/reader/tts.get.ts
+++ b/server/api/reader/tts.get.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto'
 import { AzureTTSProvider } from '~/server/utils/tts-azure'
+import { TTSQuerySchema } from '~/server/schemas/tts'
 
 function parseRangeHeader(rangeHeader: string, totalSize: number): { start: number, end: number } | null {
   const match = rangeHeader.match(/^bytes=(\d*)-(\d*)$/)
@@ -25,15 +26,8 @@ function parseRangeHeader(rangeHeader: string, totalSize: number): { start: numb
   return { start, end }
 }
 
-const LANG_MAPPING = {
-  'en-US': 'English',
-  'zh-TW': 'Chinese',
-  'zh-HK': 'Chinese,Yue',
-}
-
 // Voice mapping with provider information
 const VOICE_PROVIDER_MAPPING: Record<string, TTSProvider> = {
-  // Minimax voices
   0: TTSProvider.MINIMAX,
   1: TTSProvider.MINIMAX,
   aurora: TTSProvider.MINIMAX,
@@ -74,30 +68,9 @@ export default defineEventHandler(async (event) => {
     })
   }
   const config = useRuntimeConfig()
-  const { text, language: rawLanguage, voice_id: voiceId } = getQuery(event)
+  const { text, language, voice_id: voiceId } = await getValidatedQuery(event, useValidation(TTSQuerySchema))
 
-  if (!text || typeof text !== 'string') {
-    throw createError({
-      status: 400,
-      message: 'MISSING_TEXT',
-    })
-  }
-  if (!rawLanguage || typeof rawLanguage !== 'string' || !(rawLanguage in LANG_MAPPING)) {
-    throw createError({
-      status: 400,
-      message: 'INVALID_LANGUAGE',
-    })
-  }
-
-  const validVoiceId = voiceId as string
-  if (!voiceId) {
-    throw createError({
-      status: 400,
-      message: 'INVALID_VOICE_ID',
-    })
-  }
-
-  const isCustomVoice = validVoiceId === 'custom'
+  const isCustomVoice = voiceId === 'custom'
   let customMiniMaxVoiceId: string | undefined
   let provider: BaseTTSProvider
 
@@ -114,13 +87,12 @@ export default defineEventHandler(async (event) => {
     provider = new MinimaxTTSProvider()
   }
   else {
-    provider = getTTSProvider(validVoiceId)
+    provider = getTTSProvider(voiceId)
   }
 
-  const language = rawLanguage as keyof typeof LANG_MAPPING
   const customVoiceWallet = isCustomVoice ? session.user.evmWallet : undefined
   const logText = text.replace(/(\r\n|\n|\r)/gm, ' ')
-  console.log(`[Speech] User ${session.user.evmWallet} requested conversion. Language: ${language}, Text: "${logText.substring(0, 50)}${logText.length > 50 ? '...' : ''}", Voice: ${validVoiceId}${isCustomVoice ? ` (${customMiniMaxVoiceId})` : ''}, Provider: ${isCustomVoice ? 'minimax' : VOICE_PROVIDER_MAPPING[validVoiceId]}`)
+  console.log(`[Speech] User ${session.user.evmWallet} requested conversion. Language: ${language}, Text: "${logText.substring(0, 50)}${logText.length > 50 ? '...' : ''}", Voice: ${voiceId}${isCustomVoice ? ` (${customMiniMaxVoiceId})` : ''}, Provider: ${isCustomVoice ? 'minimax' : VOICE_PROVIDER_MAPPING[voiceId]}`)
 
   if (!await getUserTTSAvailable(event)) {
     throw createError({
@@ -133,13 +105,13 @@ export default defineEventHandler(async (event) => {
 
   const ttsModel = isCustomVoice
     ? getMinimaxModel(customMiniMaxVoiceId, language)
-    : (VOICE_PROVIDER_MAPPING[validVoiceId] === TTSProvider.MINIMAX ? getMinimaxModel() : 'azure')
+    : (VOICE_PROVIDER_MAPPING[voiceId] === TTSProvider.MINIMAX ? getMinimaxModel() : 'azure')
   const bucket = getTTSCacheBucket()
   const isCacheEnabled = !!bucket
   const cacheKey = isCacheEnabled
     ? (customVoiceWallet
         ? generateCustomVoiceTTSCacheKey(customVoiceWallet, language, text, ttsModel)
-        : generateTTSCacheKey(language, validVoiceId, text, ttsModel))
+        : generateTTSCacheKey(language, voiceId, text, ttsModel))
     : null
 
   if (isCacheEnabled) {
@@ -188,7 +160,7 @@ export default defineEventHandler(async (event) => {
     const buffer = await provider.processRequest({
       text,
       language,
-      voiceId: validVoiceId,
+      voiceId,
       customMiniMaxVoiceId,
       session,
       config,
@@ -211,7 +183,7 @@ export default defineEventHandler(async (event) => {
           contentType: provider.format,
           customMetadata: {
             language,
-            voiceId: validVoiceId,
+            voiceId,
             provider: provider.provider,
             text: truncatedText,
             textLength: text.length.toString(),

--- a/server/api/reader/tts.get.ts
+++ b/server/api/reader/tts.get.ts
@@ -68,7 +68,7 @@ export default defineEventHandler(async (event) => {
     })
   }
   const config = useRuntimeConfig()
-  const { text, language, voice_id: voiceId } = await getValidatedQuery(event, useValidation(TTSQuerySchema))
+  const { text, language, voice_id: voiceId } = await getValidatedQuery(event, createValidator(TTSQuerySchema))
 
   const isCustomVoice = voiceId === 'custom'
   let customMiniMaxVoiceId: string | undefined

--- a/server/api/register.post.ts
+++ b/server/api/register.post.ts
@@ -1,58 +1,10 @@
 import { FetchError } from 'ofetch'
 import { FieldValue } from 'firebase-admin/firestore'
 
+import { RegisterBodySchema } from '~/server/schemas/auth'
+
 export default defineEventHandler(async (event) => {
-  let body: {
-    walletAddress: string
-    message: string
-    signature: string
-    email?: string
-    accountId?: string
-    loginMethod: string
-    magicUserId?: string
-    magicDIDToken?: string
-    locale?: string
-  } | undefined
-  try {
-    body = await readBody(event)
-  }
-  catch (error) {
-    console.error(error)
-    throw createError({
-      status: 400,
-      message: 'REGISTER_INVALID_BODY',
-    })
-  }
-  if (!body) {
-    throw createError({
-      status: 400,
-      message: 'REGISTER_MISSING_BODY',
-    })
-  }
-  if (!body.walletAddress) {
-    throw createError({
-      status: 400,
-      message: 'REGISTER_MISSING_ADDRESS',
-    })
-  }
-  if (!checkIsEVMAddress(body.walletAddress)) {
-    throw createError({
-      status: 400,
-      message: 'REGISTER_INVALID_ADDRESS',
-    })
-  }
-  if (!body.message) {
-    throw createError({
-      status: 400,
-      message: 'REGISTER_MISSING_MESSAGE',
-    })
-  }
-  if (!body.signature) {
-    throw createError({
-      status: 400,
-      message: 'REGISTER_MISSING_SIGNATURE',
-    })
-  }
+  const body = await readValidatedBody(event, useValidation(RegisterBodySchema))
 
   try {
     await getLikeCoinAPIFetch()('/users/new', {

--- a/server/api/register.post.ts
+++ b/server/api/register.post.ts
@@ -4,7 +4,7 @@ import { FieldValue } from 'firebase-admin/firestore'
 import { RegisterBodySchema } from '~/server/schemas/auth'
 
 export default defineEventHandler(async (event) => {
-  const body = await readValidatedBody(event, useValidation(RegisterBodySchema))
+  const body = await readValidatedBody(event, createValidator(RegisterBodySchema))
 
   try {
     await getLikeCoinAPIFetch()('/users/new', {

--- a/server/api/store/genre.get.ts
+++ b/server/api/store/genre.get.ts
@@ -1,18 +1,13 @@
 import { FetchError } from 'ofetch'
 
+import { StoreGenreQuerySchema } from '~/server/schemas/store'
+
 export default defineEventHandler(async (event) => {
   try {
-    const query = getQuery(event)
-    const genre = (Array.isArray(query.q) ? query.q[0] : query.q) || undefined
-    const pageSize = (Array.isArray(query.limit) ? query.limit[0] : query.limit) || 100
+    const query = await getValidatedQuery(event, useValidation(StoreGenreQuerySchema))
+    const genre = (Array.isArray(query.q) ? query.q[0] : query.q)!
+    const pageSize = Number((Array.isArray(query.limit) ? query.limit[0] : query.limit)) || 100
     const offset = (Array.isArray(query.offset) ? query.offset[0] : query.offset) || undefined
-
-    if (!genre) {
-      throw createError({
-        status: 400,
-        message: 'GENRE_REQUIRED',
-      })
-    }
 
     const result = await fetchAirtableCMSPublicationsByGenre(genre, {
       pageSize,

--- a/server/api/store/genre.get.ts
+++ b/server/api/store/genre.get.ts
@@ -4,7 +4,7 @@ import { StoreGenreQuerySchema } from '~/server/schemas/store'
 
 export default defineEventHandler(async (event) => {
   try {
-    const query = await getValidatedQuery(event, useValidation(StoreGenreQuerySchema))
+    const query = await getValidatedQuery(event, createValidator(StoreGenreQuerySchema))
     const genre = (Array.isArray(query.q) ? query.q[0] : query.q)!
     const pageSize = Number((Array.isArray(query.limit) ? query.limit[0] : query.limit)) || 100
     const offset = (Array.isArray(query.offset) ? query.offset[0] : query.offset) || undefined

--- a/server/api/store/products.get.ts
+++ b/server/api/store/products.get.ts
@@ -1,10 +1,12 @@
 import { FetchError } from 'ofetch'
 
+import { StoreProductsQuerySchema } from '~/server/schemas/store'
+
 export default defineEventHandler(async (event) => {
   try {
-    const query = getQuery(event)
+    const query = await getValidatedQuery(event, useValidation(StoreProductsQuerySchema))
     const tagId = (Array.isArray(query.tag) ? query.tag[0] : query.tag) || 'latest'
-    const pageSize = (Array.isArray(query.limit) ? query.limit[0] : query.limit) || 100
+    const pageSize = Number((Array.isArray(query.limit) ? query.limit[0] : query.limit)) || 100
     const offset = (Array.isArray(query.offset) ? query.offset[0] : query.offset) || undefined
     const result = await fetchAirtableCMSProductsByTagId(tagId, {
       pageSize,

--- a/server/api/store/products.get.ts
+++ b/server/api/store/products.get.ts
@@ -4,7 +4,7 @@ import { StoreProductsQuerySchema } from '~/server/schemas/store'
 
 export default defineEventHandler(async (event) => {
   try {
-    const query = await getValidatedQuery(event, useValidation(StoreProductsQuerySchema))
+    const query = await getValidatedQuery(event, createValidator(StoreProductsQuerySchema))
     const tagId = (Array.isArray(query.tag) ? query.tag[0] : query.tag) || 'latest'
     const pageSize = Number((Array.isArray(query.limit) ? query.limit[0] : query.limit)) || 100
     const offset = (Array.isArray(query.offset) ? query.offset[0] : query.offset) || undefined

--- a/server/api/store/search.get.ts
+++ b/server/api/store/search.get.ts
@@ -4,7 +4,7 @@ import { StoreSearchQuerySchema } from '~/server/schemas/store'
 
 export default defineEventHandler(async (event) => {
   try {
-    const query = await getValidatedQuery(event, useValidation(StoreSearchQuerySchema))
+    const query = await getValidatedQuery(event, createValidator(StoreSearchQuerySchema))
     const searchTerm = (Array.isArray(query.q) ? query.q[0] : query.q)!
     const pageSize = Number((Array.isArray(query.limit) ? query.limit[0] : query.limit)) || 100
     const offset = (Array.isArray(query.offset) ? query.offset[0] : query.offset) || undefined

--- a/server/api/store/search.get.ts
+++ b/server/api/store/search.get.ts
@@ -1,18 +1,13 @@
 import { FetchError } from 'ofetch'
 
+import { StoreSearchQuerySchema } from '~/server/schemas/store'
+
 export default defineEventHandler(async (event) => {
   try {
-    const query = getQuery(event)
-    const searchTerm = (Array.isArray(query.q) ? query.q[0] : query.q) || undefined
-    const pageSize = (Array.isArray(query.limit) ? query.limit[0] : query.limit) || 100
+    const query = await getValidatedQuery(event, useValidation(StoreSearchQuerySchema))
+    const searchTerm = (Array.isArray(query.q) ? query.q[0] : query.q)!
+    const pageSize = Number((Array.isArray(query.limit) ? query.limit[0] : query.limit)) || 100
     const offset = (Array.isArray(query.offset) ? query.offset[0] : query.offset) || undefined
-
-    if (!searchTerm) {
-      throw createError({
-        status: 400,
-        message: 'SEARCH_TERM_REQUIRED',
-      })
-    }
 
     const result = await fetchAirtableCMSPublicationsBySearchTerm(searchTerm, {
       pageSize,

--- a/server/api/store/tags/[id].get.ts
+++ b/server/api/store/tags/[id].get.ts
@@ -1,15 +1,11 @@
 import { H3Error } from 'h3'
 import { FetchError } from 'ofetch'
 
+import { TagIdParamsSchema } from '~/server/schemas/params'
+
 export default defineEventHandler(async (event) => {
   try {
-    const tagId = getRouterParams(event).id
-    if (!tagId) {
-      throw createError({
-        statusCode: 400,
-        statusMessage: 'MISSING_TAG_ID',
-      })
-    }
+    const { id: tagId } = await getValidatedRouterParams(event, useValidation(TagIdParamsSchema))
 
     const result = await fetchAirtableCMSTagById(tagId)
     if (!result) {

--- a/server/api/store/tags/[id].get.ts
+++ b/server/api/store/tags/[id].get.ts
@@ -5,7 +5,7 @@ import { TagIdParamsSchema } from '~/server/schemas/params'
 
 export default defineEventHandler(async (event) => {
   try {
-    const { id: tagId } = await getValidatedRouterParams(event, useValidation(TagIdParamsSchema))
+    const { id: tagId } = await getValidatedRouterParams(event, createValidator(TagIdParamsSchema))
 
     const result = await fetchAirtableCMSTagById(tagId)
     if (!result) {

--- a/server/api/store/tags/index.get.ts
+++ b/server/api/store/tags/index.get.ts
@@ -1,9 +1,11 @@
 import { FetchError } from 'ofetch'
 
+import { StoreTagsQuerySchema } from '~/server/schemas/store'
+
 export default defineEventHandler(async (event) => {
   try {
-    const query = getQuery(event)
-    const pageSize = (Array.isArray(query.limit) ? query.limit[0] : query.limit) || 100
+    const query = await getValidatedQuery(event, useValidation(StoreTagsQuerySchema))
+    const pageSize = Number((Array.isArray(query.limit) ? query.limit[0] : query.limit)) || 100
     const offset = (Array.isArray(query.offset) ? query.offset[0] : query.offset) || undefined
     const result = await fetchAirtableCMSTagsForAll({
       pageSize,

--- a/server/api/store/tags/index.get.ts
+++ b/server/api/store/tags/index.get.ts
@@ -4,7 +4,7 @@ import { StoreTagsQuerySchema } from '~/server/schemas/store'
 
 export default defineEventHandler(async (event) => {
   try {
-    const query = await getValidatedQuery(event, useValidation(StoreTagsQuerySchema))
+    const query = await getValidatedQuery(event, createValidator(StoreTagsQuerySchema))
     const pageSize = Number((Array.isArray(query.limit) ? query.limit[0] : query.limit)) || 100
     const offset = (Array.isArray(query.offset) ? query.offset[0] : query.offset) || undefined
     const result = await fetchAirtableCMSTagsForAll({

--- a/server/api/user/custom-voice.patch.ts
+++ b/server/api/user/custom-voice.patch.ts
@@ -1,4 +1,4 @@
-const ALLOWED_LANGUAGES = ['zh-HK', 'zh-TW']
+import { CustomVoicePatchSchema } from '~/server/schemas/custom-voice'
 
 export default defineEventHandler(async (event) => {
   const session = await requireUserSession(event)
@@ -17,12 +17,9 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 404, message: 'NO_CUSTOM_VOICE' })
   }
 
-  const body = await readBody<{ voiceLanguage?: string }>(event)
-  if (!body.voiceLanguage || !ALLOWED_LANGUAGES.includes(body.voiceLanguage)) {
-    throw createError({ statusCode: 400, message: 'INVALID_VOICE_LANGUAGE' })
-  }
+  const { voiceLanguage } = await readValidatedBody(event, useValidation(CustomVoicePatchSchema))
 
-  await updateCustomVoiceLanguage(wallet, body.voiceLanguage)
+  await updateCustomVoiceLanguage(wallet, voiceLanguage)
 
-  return { voiceLanguage: body.voiceLanguage }
+  return { voiceLanguage }
 })

--- a/server/api/user/custom-voice.patch.ts
+++ b/server/api/user/custom-voice.patch.ts
@@ -17,7 +17,7 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 404, message: 'NO_CUSTOM_VOICE' })
   }
 
-  const { voiceLanguage } = await readValidatedBody(event, useValidation(CustomVoicePatchSchema))
+  const { voiceLanguage } = await readValidatedBody(event, createValidator(CustomVoicePatchSchema))
 
   await updateCustomVoiceLanguage(wallet, voiceLanguage)
 

--- a/server/api/user/custom-voice.post.ts
+++ b/server/api/user/custom-voice.post.ts
@@ -1,13 +1,13 @@
 import type { CustomVoiceData } from '~/shared/types/custom-voice'
 import { LANG_MAPPING } from '~/server/utils/tts-minimax'
-
-const ALLOWED_VOICE_LANGUAGES = ['zh-HK', 'zh-TW', 'en-US']
-const ALLOWED_AUDIO_TYPES = ['audio/mpeg', 'audio/wav', 'audio/x-wav', 'audio/mp4', 'audio/x-m4a', 'audio/mp3']
-const ALLOWED_AVATAR_TYPES = ['image/jpeg', 'image/png']
-const MAX_AUDIO_SIZE = 20 * 1024 * 1024 // 20MB
-const MAX_PROMPT_AUDIO_SIZE = 2 * 1024 * 1024 // 2MB
-const MAX_PROMPT_TEXT_LENGTH = 500
-const MAX_AVATAR_SIZE = 2 * 1024 * 1024 // 2MB
+import {
+  CUSTOM_VOICE_ALLOWED_AUDIO_TYPES,
+  CUSTOM_VOICE_ALLOWED_AVATAR_TYPES,
+  CUSTOM_VOICE_MAX_AUDIO_SIZE,
+  CUSTOM_VOICE_MAX_AVATAR_SIZE,
+  CUSTOM_VOICE_MAX_PROMPT_AUDIO_SIZE,
+  CustomVoiceFieldsSchema,
+} from '~/server/schemas/custom-voice'
 
 function getExtFromMime(mime: string): string {
   const map: Record<string, string> = {
@@ -43,9 +43,7 @@ export default defineEventHandler(async (event): Promise<CustomVoiceData> => {
   let audioPart: { data: Buffer, type?: string, filename?: string } | undefined
   let avatarPart: { data: Buffer, type?: string, filename?: string } | undefined
   let promptAudioPart: { data: Buffer, type?: string, filename?: string } | undefined
-  let voiceName = ''
-  let voiceLanguage = ''
-  let promptText = ''
+  const textFields: Record<string, string> = {}
 
   for (const part of formData) {
     if (part.name === 'audio') {
@@ -57,61 +55,34 @@ export default defineEventHandler(async (event): Promise<CustomVoiceData> => {
     else if (part.name === 'promptAudio') {
       promptAudioPart = part
     }
-    else if (part.name === 'voiceName') {
-      voiceName = part.data.toString('utf-8')
-    }
-    else if (part.name === 'voiceLanguage') {
-      voiceLanguage = part.data.toString('utf-8')
-    }
-    else if (part.name === 'promptText') {
-      promptText = part.data.toString('utf-8').trim()
+    else if (part.name && ['voiceName', 'voiceLanguage', 'promptText'].includes(part.name)) {
+      textFields[part.name] = part.data.toString('utf-8').trim()
     }
   }
 
-  if (!audioPart?.data) {
-    throw createError({ statusCode: 400, message: 'MISSING_AUDIO' })
-  }
+  // Validate text fields with schema
+  const { voiceName, voiceLanguage, promptText } = useValidation(CustomVoiceFieldsSchema)(textFields)
 
-  if (!audioPart.type || !ALLOWED_AUDIO_TYPES.includes(audioPart.type)) {
-    throw createError({ statusCode: 400, message: 'INVALID_AUDIO_FORMAT' })
-  }
-
-  if (audioPart.data.length > MAX_AUDIO_SIZE) {
-    throw createError({ statusCode: 400, message: 'AUDIO_TOO_LARGE' })
-  }
-
-  if (avatarPart?.data) {
-    if (!avatarPart.type || !ALLOWED_AVATAR_TYPES.includes(avatarPart.type)) {
-      throw createError({ statusCode: 400, message: 'INVALID_AVATAR_FORMAT' })
-    }
-    if (avatarPart.data.length > MAX_AVATAR_SIZE) {
-      throw createError({ statusCode: 400, message: 'AVATAR_TOO_LARGE' })
-    }
-  }
-
-  if (!voiceName) {
-    throw createError({ statusCode: 400, message: 'MISSING_VOICE_NAME' })
-  }
-
-  if (voiceLanguage && !ALLOWED_VOICE_LANGUAGES.includes(voiceLanguage)) {
-    throw createError({ statusCode: 400, message: 'INVALID_VOICE_LANGUAGE' })
-  }
-
-  if (!promptAudioPart?.data) {
-    throw createError({ statusCode: 400, message: 'MISSING_PROMPT_AUDIO' })
-  }
-  if (!promptAudioPart.type || !ALLOWED_AUDIO_TYPES.includes(promptAudioPart.type)) {
-    throw createError({ statusCode: 400, message: 'INVALID_PROMPT_AUDIO_FORMAT' })
-  }
-  if (promptAudioPart.data.length > MAX_PROMPT_AUDIO_SIZE) {
-    throw createError({ statusCode: 400, message: 'PROMPT_AUDIO_TOO_LARGE' })
-  }
-  if (!promptText) {
-    throw createError({ statusCode: 400, message: 'MISSING_PROMPT_TEXT' })
-  }
-  if (promptText.length > MAX_PROMPT_TEXT_LENGTH) {
-    throw createError({ statusCode: 400, message: 'PROMPT_TEXT_TOO_LONG' })
-  }
+  // Validate file parts
+  validateFilePart(audioPart, {
+    fieldName: 'audio',
+    allowedTypes: CUSTOM_VOICE_ALLOWED_AUDIO_TYPES,
+    maxSize: CUSTOM_VOICE_MAX_AUDIO_SIZE,
+    errorMessages: { missing: 'MISSING_AUDIO', invalidFormat: 'INVALID_AUDIO_FORMAT', tooLarge: 'AUDIO_TOO_LARGE' },
+  })
+  validateFilePart(avatarPart, {
+    fieldName: 'avatar',
+    allowedTypes: CUSTOM_VOICE_ALLOWED_AVATAR_TYPES,
+    maxSize: CUSTOM_VOICE_MAX_AVATAR_SIZE,
+    required: false,
+    errorMessages: { invalidFormat: 'INVALID_AVATAR_FORMAT', tooLarge: 'AVATAR_TOO_LARGE' },
+  })
+  validateFilePart(promptAudioPart, {
+    fieldName: 'promptAudio',
+    allowedTypes: CUSTOM_VOICE_ALLOWED_AUDIO_TYPES,
+    maxSize: CUSTOM_VOICE_MAX_PROMPT_AUDIO_SIZE,
+    errorMessages: { missing: 'MISSING_PROMPT_AUDIO', invalidFormat: 'INVALID_PROMPT_AUDIO_FORMAT', tooLarge: 'PROMPT_AUDIO_TOO_LARGE' },
+  })
 
   const existingVoice = await getCustomVoice(wallet)
   if (existingVoice?.voiceId) {
@@ -154,11 +125,11 @@ export default defineEventHandler(async (event): Promise<CustomVoiceData> => {
   }
 
   const client = getMiniMaxSpeechClient()
-  const audioExt = getExtFromMime(audioPart.type!)
-  const audioBlob = new File([audioPart.data], `voice.${audioExt}`, { type: audioPart.type })
+  const audioExt = getExtFromMime(audioPart!.type!)
+  const audioBlob = new File([audioPart!.data], `voice.${audioExt}`, { type: audioPart!.type })
 
-  const promptExt = getExtFromMime(promptAudioPart.type!)
-  const promptBlob = new File([promptAudioPart.data], `prompt.${promptExt}`, { type: promptAudioPart.type })
+  const promptExt = getExtFromMime(promptAudioPart!.type!)
+  const promptBlob = new File([promptAudioPart!.data], `prompt.${promptExt}`, { type: promptAudioPart!.type })
 
   const [uploadResult, promptUploadResult] = await Promise.all([
     client.uploadFile(audioBlob, 'voice_clone'),
@@ -194,16 +165,16 @@ export default defineEventHandler(async (event): Promise<CustomVoiceData> => {
   if (bucket) {
     audioPath = getCustomVoiceAudioPath(wallet, audioExt)
     const audioFile = bucket.file(audioPath)
-    await audioFile.save(audioPart.data, {
-      metadata: { contentType: audioPart.type },
+    await audioFile.save(audioPart!.data, {
+      metadata: { contentType: audioPart!.type },
     })
 
     try {
-      const promptStorageExt = getExtFromMime(promptAudioPart.type!)
+      const promptStorageExt = getExtFromMime(promptAudioPart!.type!)
       const promptPath = getCustomVoicePromptAudioPath(wallet, promptStorageExt)
       const promptStorageFile = bucket.file(promptPath)
-      await promptStorageFile.save(promptAudioPart.data, {
-        metadata: { contentType: promptAudioPart.type },
+      await promptStorageFile.save(promptAudioPart!.data, {
+        metadata: { contentType: promptAudioPart!.type },
       })
     }
     catch (error) {

--- a/server/api/user/custom-voice.post.ts
+++ b/server/api/user/custom-voice.post.ts
@@ -61,7 +61,7 @@ export default defineEventHandler(async (event): Promise<CustomVoiceData> => {
   }
 
   // Validate text fields with schema
-  const { voiceName, voiceLanguage, promptText } = useValidation(CustomVoiceFieldsSchema)(textFields)
+  const { voiceName, voiceLanguage, promptText } = createValidator(CustomVoiceFieldsSchema)(textFields)
 
   // Validate file parts
   validateFilePart(audioPart, {

--- a/server/api/user/settings.post.ts
+++ b/server/api/user/settings.post.ts
@@ -1,6 +1,6 @@
 import { jwtDecode } from 'jwt-decode'
 
-const ALLOWED_KEYS = ['locale', 'currency', 'colorMode', 'isAdultContentEnabled'] as const satisfies readonly UserSettingKey[]
+import { UserSettingsUpdateSchema } from '~/shared/schemas/user-settings'
 
 export default defineEventHandler(async (event) => {
   const session = await requireUserSession(event)
@@ -12,15 +12,7 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  const body = await readBody(event)
-
-  const invalidKeys = Object.keys(body).filter(key => !ALLOWED_KEYS.includes(key as UserSettingKey))
-  if (invalidKeys.length > 0) {
-    throw createError({
-      statusCode: 400,
-      message: `INVALID_KEYS: ${invalidKeys.join(', ')}`,
-    })
-  }
+  const body = await readValidatedBody(event, useValidation(UserSettingsUpdateSchema))
 
   // Enforce color mode restriction for non-Plus users
   const isLikerPlus = session.user.isLikerPlus || false

--- a/server/api/user/settings.post.ts
+++ b/server/api/user/settings.post.ts
@@ -12,7 +12,7 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  const body = await readValidatedBody(event, useValidation(UserSettingsUpdateSchema))
+  const body = await readValidatedBody(event, createValidator(UserSettingsUpdateSchema))
 
   // Enforce color mode restriction for non-Plus users
   const isLikerPlus = session.user.isLikerPlus || false

--- a/server/plugins/validate-env.ts
+++ b/server/plugins/validate-env.ts
@@ -7,11 +7,11 @@ export default defineNitroPlugin(() => {
   }
 
   const optionalVars: Record<string, string | undefined> = {
-    minimaxApiKey: config.minimaxApiKey as string | undefined,
+    minimaxAPIKey: config.minimaxAPIKey as string | undefined,
     minimaxGroupId: config.minimaxGroupId as string | undefined,
-    azureSpeechKey: config.azureSpeechKey as string | undefined,
-    azureSpeechRegion: config.azureSpeechRegion as string | undefined,
-    airtableApiKey: config.airtableApiKey as string | undefined,
+    azureSubscriptionKey: config.azureSubscriptionKey as string | undefined,
+    azureServiceRegion: config.azureServiceRegion as string | undefined,
+    airtableAPISecret: config.airtableAPISecret as string | undefined,
   }
 
   for (const [name, value] of Object.entries(optionalVars)) {

--- a/server/plugins/validate-env.ts
+++ b/server/plugins/validate-env.ts
@@ -1,0 +1,22 @@
+export default defineNitroPlugin(() => {
+  const config = useRuntimeConfig()
+
+  const sessionPassword = config.session?.password
+  if (!import.meta.dev && (!sessionPassword || sessionPassword.length < 32)) {
+    throw new Error('[env] NUXT_SESSION_PASSWORD must be at least 32 characters')
+  }
+
+  const optionalVars: Record<string, string | undefined> = {
+    minimaxApiKey: config.minimaxApiKey as string | undefined,
+    minimaxGroupId: config.minimaxGroupId as string | undefined,
+    azureSpeechKey: config.azureSpeechKey as string | undefined,
+    azureSpeechRegion: config.azureSpeechRegion as string | undefined,
+    airtableApiKey: config.airtableApiKey as string | undefined,
+  }
+
+  for (const [name, value] of Object.entries(optionalVars)) {
+    if (!value) {
+      console.warn(`[env] Missing optional var: ${name} — related features will be unavailable`)
+    }
+  }
+})

--- a/server/schemas/auth.ts
+++ b/server/schemas/auth.ts
@@ -1,0 +1,68 @@
+import * as v from 'valibot'
+
+export const LoginBodySchema = v.object({
+  walletAddress: v.pipe(
+    v.string('MISSING_ADDRESS'),
+    v.nonEmpty('MISSING_ADDRESS'),
+    v.regex(/^0x[a-fA-F0-9]{40}$/, 'INVALID_ADDRESS'),
+  ),
+  message: v.pipe(
+    v.string('MISSING_MESSAGE'),
+    v.nonEmpty('MISSING_MESSAGE'),
+  ),
+  signature: v.pipe(
+    v.string('MISSING_SIGNATURE'),
+    v.nonEmpty('MISSING_SIGNATURE'),
+  ),
+  email: v.optional(v.string()),
+  loginMethod: v.optional(v.string()),
+})
+
+export const RegisterBodySchema = v.object({
+  walletAddress: v.pipe(
+    v.string('REGISTER_MISSING_ADDRESS'),
+    v.nonEmpty('REGISTER_MISSING_ADDRESS'),
+    v.regex(/^0x[a-fA-F0-9]{40}$/, 'REGISTER_INVALID_ADDRESS'),
+  ),
+  message: v.pipe(
+    v.string('REGISTER_MISSING_MESSAGE'),
+    v.nonEmpty('REGISTER_MISSING_MESSAGE'),
+  ),
+  signature: v.pipe(
+    v.string('REGISTER_MISSING_SIGNATURE'),
+    v.nonEmpty('REGISTER_MISSING_SIGNATURE'),
+  ),
+  email: v.optional(v.string()),
+  accountId: v.optional(v.string()),
+  loginMethod: v.optional(v.string()),
+  magicUserId: v.optional(v.string()),
+  magicDIDToken: v.optional(v.string()),
+  locale: v.optional(v.string()),
+})
+
+export const AccountDeleteBodySchema = v.object({
+  wallet: v.pipe(
+    v.string('MISSING_SIGNATURE'),
+    v.nonEmpty('MISSING_SIGNATURE'),
+  ),
+  signMethod: v.pipe(
+    v.string('MISSING_SIGNATURE'),
+    v.nonEmpty('MISSING_SIGNATURE'),
+  ),
+  authorizeSignature: v.pipe(
+    v.string('MISSING_SIGNATURE'),
+    v.nonEmpty('MISSING_SIGNATURE'),
+  ),
+  authorizeMessage: v.pipe(
+    v.string('MISSING_SIGNATURE'),
+    v.nonEmpty('MISSING_SIGNATURE'),
+  ),
+  deleteSignature: v.pipe(
+    v.string('MISSING_SIGNATURE'),
+    v.nonEmpty('MISSING_SIGNATURE'),
+  ),
+  deleteMessage: v.pipe(
+    v.string('MISSING_SIGNATURE'),
+    v.nonEmpty('MISSING_SIGNATURE'),
+  ),
+})

--- a/server/schemas/auth.ts
+++ b/server/schemas/auth.ts
@@ -42,27 +42,27 @@ export const RegisterBodySchema = v.object({
 
 export const AccountDeleteBodySchema = v.object({
   wallet: v.pipe(
-    v.string('MISSING_SIGNATURE'),
-    v.nonEmpty('MISSING_SIGNATURE'),
+    v.string('MISSING_WALLET'),
+    v.nonEmpty('MISSING_WALLET'),
   ),
   signMethod: v.pipe(
-    v.string('MISSING_SIGNATURE'),
-    v.nonEmpty('MISSING_SIGNATURE'),
+    v.string('MISSING_SIGN_METHOD'),
+    v.nonEmpty('MISSING_SIGN_METHOD'),
   ),
   authorizeSignature: v.pipe(
-    v.string('MISSING_SIGNATURE'),
-    v.nonEmpty('MISSING_SIGNATURE'),
+    v.string('MISSING_AUTHORIZE_SIGNATURE'),
+    v.nonEmpty('MISSING_AUTHORIZE_SIGNATURE'),
   ),
   authorizeMessage: v.pipe(
-    v.string('MISSING_SIGNATURE'),
-    v.nonEmpty('MISSING_SIGNATURE'),
+    v.string('MISSING_AUTHORIZE_MESSAGE'),
+    v.nonEmpty('MISSING_AUTHORIZE_MESSAGE'),
   ),
   deleteSignature: v.pipe(
-    v.string('MISSING_SIGNATURE'),
-    v.nonEmpty('MISSING_SIGNATURE'),
+    v.string('MISSING_DELETE_SIGNATURE'),
+    v.nonEmpty('MISSING_DELETE_SIGNATURE'),
   ),
   deleteMessage: v.pipe(
-    v.string('MISSING_SIGNATURE'),
-    v.nonEmpty('MISSING_SIGNATURE'),
+    v.string('MISSING_DELETE_MESSAGE'),
+    v.nonEmpty('MISSING_DELETE_MESSAGE'),
   ),
 })

--- a/server/schemas/book-list.ts
+++ b/server/schemas/book-list.ts
@@ -2,16 +2,16 @@ import * as v from 'valibot'
 
 export const BookListBodySchema = v.object({
   nftClassId: v.pipe(
-    v.string('nftClassId is required in body'),
-    v.nonEmpty('nftClassId is required in body'),
+    v.string('MISSING_NFT_CLASS_ID'),
+    v.nonEmpty('MISSING_NFT_CLASS_ID'),
   ),
   priceIndex: v.optional(v.number(), 0),
 })
 
 export const BookListQuerySchema = v.object({
   nft_class_id: v.pipe(
-    v.string('nft_class_id is required in query'),
-    v.nonEmpty('nft_class_id is required in query'),
+    v.string('MISSING_NFT_CLASS_ID'),
+    v.nonEmpty('MISSING_NFT_CLASS_ID'),
   ),
   price_index: v.optional(v.string()),
 })

--- a/server/schemas/book-list.ts
+++ b/server/schemas/book-list.ts
@@ -1,0 +1,17 @@
+import * as v from 'valibot'
+
+export const BookListBodySchema = v.object({
+  nftClassId: v.pipe(
+    v.string('nftClassId is required in body'),
+    v.nonEmpty('nftClassId is required in body'),
+  ),
+  priceIndex: v.optional(v.number(), 0),
+})
+
+export const BookListQuerySchema = v.object({
+  nft_class_id: v.pipe(
+    v.string('nft_class_id is required in query'),
+    v.nonEmpty('nft_class_id is required in query'),
+  ),
+  price_index: v.optional(v.string()),
+})

--- a/server/schemas/custom-voice.ts
+++ b/server/schemas/custom-voice.ts
@@ -1,0 +1,27 @@
+import * as v from 'valibot'
+
+export const CUSTOM_VOICE_ALLOWED_LANGUAGES = ['zh-HK', 'zh-TW'] as const
+export const CUSTOM_VOICE_ALLOWED_VOICE_LANGUAGES = ['zh-HK', 'zh-TW', 'en-US'] as const
+export const CUSTOM_VOICE_ALLOWED_AUDIO_TYPES = ['audio/mpeg', 'audio/wav', 'audio/x-wav', 'audio/mp4', 'audio/x-m4a', 'audio/mp3']
+export const CUSTOM_VOICE_ALLOWED_AVATAR_TYPES = ['image/jpeg', 'image/png']
+export const CUSTOM_VOICE_MAX_AUDIO_SIZE = 20 * 1024 * 1024 // 20MB
+export const CUSTOM_VOICE_MAX_PROMPT_AUDIO_SIZE = 2 * 1024 * 1024 // 2MB
+export const CUSTOM_VOICE_MAX_PROMPT_TEXT_LENGTH = 500
+export const CUSTOM_VOICE_MAX_AVATAR_SIZE = 2 * 1024 * 1024 // 2MB
+
+export const CustomVoicePatchSchema = v.object({
+  voiceLanguage: v.picklist(CUSTOM_VOICE_ALLOWED_LANGUAGES, 'INVALID_VOICE_LANGUAGE'),
+})
+
+export const CustomVoiceFieldsSchema = v.object({
+  voiceName: v.pipe(
+    v.string('MISSING_VOICE_NAME'),
+    v.nonEmpty('MISSING_VOICE_NAME'),
+  ),
+  voiceLanguage: v.optional(v.picklist([...CUSTOM_VOICE_ALLOWED_VOICE_LANGUAGES], 'INVALID_VOICE_LANGUAGE')),
+  promptText: v.pipe(
+    v.string('MISSING_PROMPT_TEXT'),
+    v.nonEmpty('MISSING_PROMPT_TEXT'),
+    v.maxLength(CUSTOM_VOICE_MAX_PROMPT_TEXT_LENGTH, 'PROMPT_TEXT_TOO_LONG'),
+  ),
+})

--- a/server/schemas/params.ts
+++ b/server/schemas/params.ts
@@ -1,0 +1,26 @@
+import * as v from 'valibot'
+
+export const NftClassIdParamsSchema = v.object({
+  nftClassId: v.pipe(
+    v.string('MISSING_NFT_CLASS_ID'),
+    v.nonEmpty('MISSING_NFT_CLASS_ID'),
+  ),
+})
+
+export const TagIdParamsSchema = v.object({
+  id: v.pipe(
+    v.string('MISSING_TAG_ID'),
+    v.nonEmpty('MISSING_TAG_ID'),
+  ),
+})
+
+export const AnnotationParamsSchema = v.object({
+  nftClassId: v.pipe(
+    v.string('MISSING_NFT_CLASS_ID'),
+    v.nonEmpty('MISSING_NFT_CLASS_ID'),
+  ),
+  annotationId: v.pipe(
+    v.string('MISSING_ANNOTATION_ID'),
+    v.nonEmpty('MISSING_ANNOTATION_ID'),
+  ),
+})

--- a/server/schemas/params.ts
+++ b/server/schemas/params.ts
@@ -1,6 +1,6 @@
 import * as v from 'valibot'
 
-export const NftClassIdParamsSchema = v.object({
+export const NFTClassIdParamsSchema = v.object({
   nftClassId: v.pipe(
     v.string('MISSING_NFT_CLASS_ID'),
     v.nonEmpty('MISSING_NFT_CLASS_ID'),

--- a/server/schemas/store.ts
+++ b/server/schemas/store.ts
@@ -1,0 +1,37 @@
+import * as v from 'valibot'
+
+const PaginationFields = {
+  limit: v.optional(v.union([v.string(), v.array(v.string())])),
+  offset: v.optional(v.union([v.string(), v.array(v.string())])),
+}
+
+export const StoreProductsQuerySchema = v.object({
+  tag: v.optional(v.union([v.string(), v.array(v.string())])),
+  ...PaginationFields,
+})
+
+export const StoreSearchQuerySchema = v.object({
+  q: v.pipe(
+    v.union([v.string(), v.array(v.string())]),
+    v.check(
+      val => !!(Array.isArray(val) ? val[0] : val),
+      'SEARCH_TERM_REQUIRED',
+    ),
+  ),
+  ...PaginationFields,
+})
+
+export const StoreGenreQuerySchema = v.object({
+  q: v.pipe(
+    v.union([v.string(), v.array(v.string())]),
+    v.check(
+      val => !!(Array.isArray(val) ? val[0] : val),
+      'GENRE_REQUIRED',
+    ),
+  ),
+  ...PaginationFields,
+})
+
+export const StoreTagsQuerySchema = v.object({
+  ...PaginationFields,
+})

--- a/server/schemas/tts.ts
+++ b/server/schemas/tts.ts
@@ -1,0 +1,16 @@
+import * as v from 'valibot'
+
+export const TTSQuerySchema = v.object({
+  text: v.pipe(
+    v.string('MISSING_TEXT'),
+    v.nonEmpty('MISSING_TEXT'),
+  ),
+  language: v.pipe(
+    v.string('INVALID_LANGUAGE'),
+    v.picklist(['en-US', 'zh-TW', 'zh-HK'], 'INVALID_LANGUAGE'),
+  ),
+  voice_id: v.pipe(
+    v.string('INVALID_VOICE_ID'),
+    v.nonEmpty('INVALID_VOICE_ID'),
+  ),
+})

--- a/server/schemas/tts.ts
+++ b/server/schemas/tts.ts
@@ -5,10 +5,7 @@ export const TTSQuerySchema = v.object({
     v.string('MISSING_TEXT'),
     v.nonEmpty('MISSING_TEXT'),
   ),
-  language: v.pipe(
-    v.string('INVALID_LANGUAGE'),
-    v.picklist(['en-US', 'zh-TW', 'zh-HK'], 'INVALID_LANGUAGE'),
-  ),
+  language: v.picklist(['en-US', 'zh-TW', 'zh-HK'], 'INVALID_LANGUAGE'),
   voice_id: v.pipe(
     v.string('INVALID_VOICE_ID'),
     v.nonEmpty('INVALID_VOICE_ID'),

--- a/server/utils/validation.ts
+++ b/server/utils/validation.ts
@@ -5,7 +5,7 @@ import * as v from 'valibot'
  * Creates an h3-compatible validation function from a Valibot schema.
  * Use with `readValidatedBody()`, `getValidatedQuery()`, or `getValidatedRouterParams()`.
  */
-export function useValidation<T extends v.GenericSchema>(schema: T) {
+export function createValidator<T extends v.GenericSchema>(schema: T) {
   return (data: unknown): v.InferOutput<T> => {
     const result = v.safeParse(schema, data)
     if (result.success) {

--- a/server/utils/validation.ts
+++ b/server/utils/validation.ts
@@ -1,0 +1,66 @@
+import type { MultiPartData } from 'h3'
+import * as v from 'valibot'
+
+/**
+ * Creates an h3-compatible validation function from a Valibot schema.
+ * Use with `readValidatedBody()`, `getValidatedQuery()`, or `getValidatedRouterParams()`.
+ */
+export function useValidation<T extends v.GenericSchema>(schema: T) {
+  return (data: unknown): v.InferOutput<T> => {
+    const result = v.safeParse(schema, data)
+    if (result.success) {
+      return result.output
+    }
+    const firstIssue = result.issues[0]
+    throw createError({
+      statusCode: 400,
+      message: firstIssue.message,
+    })
+  }
+}
+
+/**
+ * Validates a multipart file part for MIME type and size.
+ */
+export function validateFilePart(
+  part: MultiPartData | undefined,
+  options: {
+    fieldName: string
+    allowedTypes: string[]
+    maxSize: number
+    required?: boolean
+    errorMessages?: {
+      missing?: string
+      invalidFormat?: string
+      tooLarge?: string
+    }
+  },
+): void {
+  const {
+    fieldName,
+    allowedTypes,
+    maxSize,
+    required = true,
+    errorMessages,
+  } = options
+
+  const upperField = fieldName.replace(/([A-Z])/g, '_$1').toUpperCase()
+  const missingMsg = errorMessages?.missing ?? `MISSING_${upperField}`
+  const formatMsg = errorMessages?.invalidFormat ?? `INVALID_${upperField}_FORMAT`
+  const sizeMsg = errorMessages?.tooLarge ?? `${upperField}_TOO_LARGE`
+
+  if (!part?.data) {
+    if (required) {
+      throw createError({ statusCode: 400, message: missingMsg })
+    }
+    return
+  }
+
+  if (!part.type || !allowedTypes.includes(part.type)) {
+    throw createError({ statusCode: 400, message: formatMsg })
+  }
+
+  if (part.data.length > maxSize) {
+    throw createError({ statusCode: 400, message: sizeMsg })
+  }
+}

--- a/shared/schemas/annotation.ts
+++ b/shared/schemas/annotation.ts
@@ -1,0 +1,40 @@
+import * as v from 'valibot'
+
+import { ANNOTATION_NOTE_MAX_LENGTH, ANNOTATION_TEXT_MAX_LENGTH } from '~/constants/annotations'
+
+const AnnotationColorSchema = v.picklist(
+  ['yellow', 'red', 'green', 'blue'] as const,
+  'MISSING_OR_INVALID_COLOR',
+)
+
+export const AnnotationCreateSchema = v.object({
+  cfi: v.pipe(
+    v.string('MISSING_OR_INVALID_CFI'),
+    v.nonEmpty('MISSING_OR_INVALID_CFI'),
+  ),
+  text: v.pipe(
+    v.string('MISSING_OR_INVALID_TEXT'),
+    v.nonEmpty('MISSING_OR_INVALID_TEXT'),
+    v.maxLength(ANNOTATION_TEXT_MAX_LENGTH, 'TEXT_TOO_LONG'),
+  ),
+  color: AnnotationColorSchema,
+  note: v.optional(v.pipe(
+    v.string('INVALID_NOTE'),
+    v.maxLength(ANNOTATION_NOTE_MAX_LENGTH, 'INVALID_NOTE'),
+  )),
+  chapterTitle: v.optional(v.string('INVALID_CHAPTER_TITLE')),
+})
+
+export const AnnotationUpdateSchema = v.pipe(
+  v.object({
+    color: v.optional(AnnotationColorSchema),
+    note: v.optional(v.pipe(
+      v.string('INVALID_NOTE'),
+      v.maxLength(ANNOTATION_NOTE_MAX_LENGTH, 'INVALID_NOTE'),
+    )),
+  }),
+  v.check(
+    input => input.color !== undefined || input.note !== undefined,
+    'MISSING_UPDATE_FIELDS',
+  ),
+)

--- a/shared/schemas/annotation.ts
+++ b/shared/schemas/annotation.ts
@@ -27,7 +27,10 @@ export const AnnotationCreateSchema = v.object({
 
 export const AnnotationUpdateSchema = v.pipe(
   v.object({
-    color: v.optional(AnnotationColorSchema),
+    color: v.optional(v.picklist(
+      ['yellow', 'red', 'green', 'blue'] as const,
+      'INVALID_COLOR',
+    )),
     note: v.optional(v.pipe(
       v.string('INVALID_NOTE'),
       v.maxLength(ANNOTATION_NOTE_MAX_LENGTH, 'INVALID_NOTE'),

--- a/shared/schemas/book-settings.ts
+++ b/shared/schemas/book-settings.ts
@@ -12,9 +12,6 @@ export const BookSettingsUpdateSchema = v.pipe(
     'pdf-isRightToLeft': v.optional(v.boolean()),
     'progress': v.optional(v.number()),
     'lastOpenedTime': v.optional(v.number()),
-  }, (issue) => {
-    const key = issue.path?.[0]?.key
-    return `INVALID_KEYS: ${key}`
-  }),
+  }, 'INVALID_KEYS'),
   v.check(input => Object.keys(input).length > 0, 'MISSING_BODY'),
 )

--- a/shared/schemas/book-settings.ts
+++ b/shared/schemas/book-settings.ts
@@ -1,0 +1,20 @@
+import * as v from 'valibot'
+
+export const BookSettingsUpdateSchema = v.pipe(
+  v.strictObject({
+    'epub-cfi': v.optional(v.string()),
+    'epub-fontSize': v.optional(v.number()),
+    'epub-lineHeight': v.optional(v.number()),
+    'epub-activeTTSElementIndex': v.optional(v.number()),
+    'pdf-currentPage': v.optional(v.number()),
+    'pdf-scale': v.optional(v.number()),
+    'pdf-isDualPageMode': v.optional(v.boolean()),
+    'pdf-isRightToLeft': v.optional(v.boolean()),
+    'progress': v.optional(v.number()),
+    'lastOpenedTime': v.optional(v.number()),
+  }, (issue) => {
+    const key = issue.path?.[0]?.key
+    return `INVALID_KEYS: ${key}`
+  }),
+  v.check(input => Object.keys(input).length > 0, 'MISSING_BODY'),
+)

--- a/shared/schemas/user-settings.ts
+++ b/shared/schemas/user-settings.ts
@@ -1,0 +1,14 @@
+import * as v from 'valibot'
+
+export const UserSettingsUpdateSchema = v.pipe(
+  v.strictObject({
+    locale: v.optional(v.nullable(v.picklist(['en', 'zh-Hant']))),
+    currency: v.optional(v.picklist(['auto', 'hkd', 'twd', 'usd'])),
+    colorMode: v.optional(v.picklist(['light', 'dark', 'system'])),
+    isAdultContentEnabled: v.optional(v.boolean()),
+  }, (issue) => {
+    const key = issue.path?.[0]?.key
+    return `INVALID_KEYS: ${key}`
+  }),
+  v.check(input => Object.keys(input).length > 0, 'MISSING_BODY'),
+)

--- a/shared/schemas/user-settings.ts
+++ b/shared/schemas/user-settings.ts
@@ -6,9 +6,6 @@ export const UserSettingsUpdateSchema = v.pipe(
     currency: v.optional(v.picklist(['auto', 'hkd', 'twd', 'usd'])),
     colorMode: v.optional(v.picklist(['light', 'dark', 'system'])),
     isAdultContentEnabled: v.optional(v.boolean()),
-  }, (issue) => {
-    const key = issue.path?.[0]?.key
-    return `INVALID_KEYS: ${key}`
-  }),
+  }, 'INVALID_KEYS'),
   v.check(input => Object.keys(input).length > 0, 'MISSING_BODY'),
 )


### PR DESCRIPTION
Replace manual if/throw createError() validation across 22 server API routes with Valibot schemas and h3's readValidatedBody(), getValidatedQuery(), and getValidatedRouterParams(). Add valibot as explicit dependency and create reusable schemas for annotations, user settings, book settings, auth, book lists, store queries, TTS, custom voice, and route params. Add startup env validation plugin.