### PR TITLE
🐛 Fix TTS last segment repeating infinitely

### DIFF
--- a/composables/use-text-to-speech.ts
+++ b/composables/use-text-to-speech.ts
@@ -92,8 +92,10 @@ export function useTextToSpeech(options: TTSOptions = {}) {
   })
 
   player.on('trackChanged', (index) => {
+    if (index !== currentTTSSegmentIndex.value) {
+      consecutiveAudioErrors.value = 0
+    }
     currentTTSSegmentIndex.value = index
-    consecutiveAudioErrors.value = 0
   })
 
   player.on('allEnded', () => {

--- a/composables/use-text-to-speech.ts
+++ b/composables/use-text-to-speech.ts
@@ -118,8 +118,21 @@ export function useTextToSpeech(options: TTSOptions = {}) {
       return
     }
 
-    options.onError?.(error)
     consecutiveAudioErrors.value += 1
+
+    // On first error, silently retry the current segment before escalating.
+    // Transient network issues (e.g. ERR_CONNECTION_CLOSED) often manifest as
+    // MEDIA_ERR_SRC_NOT_SUPPORTED and resolve on retry.
+    if (consecutiveAudioErrors.value <= 1) {
+      setTimeout(() => {
+        if (isTextToSpeechOn.value) {
+          player.skipTo(currentTTSSegmentIndex.value)
+        }
+      }, 1000)
+      return
+    }
+
+    options.onError?.(error)
     if (consecutiveAudioErrors.value >= MAX_CONSECUTIVE_ERRORS) {
       console.warn(`TTS paused after ${MAX_CONSECUTIVE_ERRORS} consecutive audio errors`)
       pauseTextToSpeech()

--- a/composables/use-web-audio-player.ts
+++ b/composables/use-web-audio-player.ts
@@ -74,7 +74,7 @@ export function useWebAudioPlayer(): TTSAudioPlayer {
       if (active && autoResumeRetries < MAX_AUTO_RESUME_RETRIES) {
         autoResumeRetries += 1
         setTimeout(() => {
-          if (!playing && activeAudio.value) {
+          if (!playing && activeAudio.value && !activeAudio.value.ended) {
             activeAudio.value.play()?.catch((e: unknown) => {
               if (e instanceof DOMException && e.name === 'NotAllowedError') {
                 handlers.error?.('NotAllowedError')


### PR DESCRIPTION
Skip auto-resume when audio has naturally ended, preventing the pause→play loop that caused the last segment to replay forever.