### PR TITLE
⚡ Swap dual audio elements for gapless TTS playback

### DIFF
--- a/composables/use-web-audio-player.ts
+++ b/composables/use-web-audio-player.ts
@@ -162,16 +162,21 @@ export function useWebAudioPlayer(): TTSAudioPlayer {
     const nextElement = segments[currentIndex + 1]
     if (!nextElement) return
 
-    const idle = getIdleAudio()
-    if (!idle) return
-
     const src = getAudioSrc(nextElement)
-    if (idle.getAttribute('data-src') !== src) {
-      idle.setAttribute('data-src', src)
-      idle.src = src
-      idle.playbackRate = currentRate
-      idle.defaultPlaybackRate = currentRate
-      idle.load()
+
+    const idle = getIdleAudio()
+    if (idle) {
+      if (idle.getAttribute('data-src') !== src) {
+        idle.setAttribute('data-src', src)
+        idle.src = src
+        idle.playbackRate = currentRate
+        idle.defaultPlaybackRate = currentRate
+        idle.load()
+      }
+    }
+    else {
+      // Single mode — warm the HTTP cache so the next segment loads faster
+      fetch(src).catch(() => {})
     }
   }
 


### PR DESCRIPTION
Replace single activeAudio/preloadAudio with two audio elements (A/B) that swap roles — the preloaded element becomes the active player directly, eliminating the inter-segment gap caused by re-fetching streaming responses. Gracefully falls back to single-element mode if iOS doesn't unlock the idle element.