### PR TITLE
🐛 Fix loading indicator clearing before audio is audible

### DIFF
--- a/composables/use-web-audio-player.ts
+++ b/composables/use-web-audio-player.ts
@@ -50,6 +50,10 @@ export function useWebAudioPlayer(): TTSAudioPlayer {
       errored = false
       autoResumeRetries = 0
       clearStuckTimer()
+    }
+
+    audio.onplaying = () => {
+      if (audio !== getActiveAudio() || swapping) return
       handlers.play?.()
     }
 
@@ -139,6 +143,7 @@ export function useWebAudioPlayer(): TTSAudioPlayer {
     audio.removeAttribute('data-src')
     audio.load()
     audio.onplay = null
+    audio.onplaying = null
     audio.onpause = null
     audio.onended = null
     audio.onerror = null


### PR DESCRIPTION
Use the `playing` event instead of `play` to fire handlers.play(). The `play` event fires when play() is called (before buffering), while `playing` fires when audio is actually ready and audible.