### PR TITLE
⚡ Fix PDF reader memory crash on large files

### DIFF
--- a/components/PDFReader.vue
+++ b/components/PDFReader.vue
@@ -194,7 +194,7 @@ import type { PDFDocumentProxy } from 'pdfjs-dist'
 
 interface Props {
   bookName?: string
-  pdfBuffer: ArrayBuffer
+  pdfBuffer?: ArrayBuffer | null
   isAudioHidden?: boolean
   bookFileCacheKey: string
   bookProgressKeyPrefix: string
@@ -347,6 +347,12 @@ onMounted(async () => {
   }
 })
 
+onBeforeUnmount(() => {
+  renderQueue.value = []
+  pdfDocument.value?.destroy()
+  pdfDocument.value = undefined
+})
+
 watch(isMobile, async (value) => {
   if (value && isDualPageMode.value) {
     isDualPageMode.value = false
@@ -394,6 +400,12 @@ async function loadPDF() {
     console.error('PDF.js library not loaded')
     return
   }
+
+  if (pdfDocument.value) {
+    pdfDocument.value.destroy()
+    pdfDocument.value = undefined
+  }
+
   try {
     const loadingTask = pdfjsLib.value.getDocument({
       data: props.pdfBuffer,
@@ -472,6 +484,7 @@ async function renderSinglePage() {
   }
 
   await page.render(renderContext).promise
+  page.cleanup()
 }
 
 async function renderDualPages() {
@@ -497,13 +510,14 @@ async function renderDualPages() {
       leftCanvas.value.style.width = `${leftViewport.width}px`
       leftCanvas.value.style.height = `${leftViewport.height}px`
     }
-    return leftPage.render({
+    await leftPage.render({
       canvasContext: leftContext,
       transform: pixelRatio.value !== 1
         ? [pixelRatio.value, 0, 0, pixelRatio.value, 0, 0]
         : undefined,
       viewport: leftViewport,
     }).promise
+    leftPage.cleanup()
   })
   renderTasks.push(leftPageTask)
 
@@ -516,13 +530,14 @@ async function renderDualPages() {
         rightCanvas.value.style.width = `${rightViewport.width}px`
         rightCanvas.value.style.height = `${rightViewport.height}px`
       }
-      return rightPage.render({
+      await rightPage.render({
         canvasContext: rightContext,
         transform: pixelRatio.value !== 1
           ? [pixelRatio.value, 0, 0, pixelRatio.value, 0, 0]
           : undefined,
         viewport: rightViewport,
       }).promise
+      rightPage.cleanup()
     })
     renderTasks.push(rightPageTask)
   }

--- a/composables/use-book-file-loader.ts
+++ b/composables/use-book-file-loader.ts
@@ -72,13 +72,54 @@ export default function () {
     const streamReader = res?.body?.getReader()
     if (!streamReader) return
 
-    const contentLength = Number(res?.headers?.get('X-Original-Content-Length'))
+    const contentLength = Number(
+      res?.headers?.get('X-Original-Content-Length')
+      || res?.headers?.get('Content-Length'),
+    )
     if (contentLength) {
       loadingFilesize.value = contentLength
     }
 
+    // When content length is known, write directly into a pre-allocated buffer
+    // to avoid holding both chunks[] and combinedChunks simultaneously (~2x peak memory).
+    // Falls back to chunk accumulation if the header was unreliable.
+    if (contentLength) {
+      const buffer = new Uint8Array(contentLength)
+      let offset = 0
+      let overflow: Uint8Array[] | undefined
+      while (true) {
+        const { done, value } = await streamReader.read()
+        if (done) break
+        if (!overflow && offset + value.length <= buffer.length) {
+          buffer.set(value, offset)
+        }
+        else {
+          if (!overflow) {
+            overflow = [buffer.subarray(0, offset)]
+          }
+          overflow.push(value)
+        }
+        offset += value.length
+        loadedFilesize.value = offset
+      }
+      if (!overflow) {
+        return offset < buffer.length
+          ? buffer.buffer.slice(0, offset)
+          : buffer.buffer
+      }
+      // Content-Length was wrong — combine overflow chunks
+      const combined = new Uint8Array(offset)
+      let pos = 0
+      for (const chunk of overflow) {
+        combined.set(chunk, pos)
+        pos += chunk.length
+      }
+      return combined.buffer
+    }
+
+    // Fallback: accumulate chunks when content length is unknown
     let receivedLength = 0
-    const chunks = []
+    const chunks: Uint8Array[] = []
     while (true) {
       const { done, value } = await streamReader.read()
       if (done) break
@@ -89,10 +130,10 @@ export default function () {
 
     const combinedChunks = new Uint8Array(receivedLength)
     let position = 0
-    chunks.forEach((chunk) => {
+    for (const chunk of chunks) {
       combinedChunks.set(chunk, position)
       position += chunk.length
-    })
+    }
 
     return combinedChunks.buffer
   }

--- a/pages/reader/pdf.vue
+++ b/pages/reader/pdf.vue
@@ -10,7 +10,7 @@
         :loading-progress="loadingPercentage"
       />
     </Transition>
-    <ClientOnly v-if="fileBuffer && !isReaderLoading">
+    <ClientOnly v-if="(fileBuffer || isPDFReady) && !isReaderLoading">
       <PDFReader
         ref="pdfReaderRef"
         class="grow w-full"
@@ -53,6 +53,9 @@ const {
 const { handleError } = useErrorHandler()
 
 const fileBuffer = ref<ArrayBuffer | null>(null)
+const isPDFReady = ref(false)
+const loadedPDFDocument = shallowRef<PDFDocumentProxy>()
+const isTTSExtracted = ref(false)
 const activeTTSElementIndex = ref<number | undefined>()
 const currentPageIndex = ref(1)
 const pdfReaderRef = ref()
@@ -113,16 +116,12 @@ async function loadPDF() {
   fileBuffer.value = buffer
 }
 
-async function handlePDFLoaded(pdfDocument: PDFDocumentProxy) {
-  try {
-    const { segments, chapterTitles } = await extractTTSSegmentsFromPDF(pdfDocument)
-    setTTSSegments(segments)
-    setChapterTitles(chapterTitles)
-    currentPageIndex.value = pdfReaderRef.value?.currentPage || 1
-  }
-  catch (error) {
-    console.warn('Failed to extract TTS segments from PDF:', error)
-  }
+function handlePDFLoaded(pdfDocument: PDFDocumentProxy) {
+  isPDFReady.value = true
+  loadedPDFDocument.value = pdfDocument
+  currentPageIndex.value = pdfReaderRef.value?.currentPage || 1
+  // Release the ArrayBuffer — PDF.js has its own internal copy
+  fileBuffer.value = null
 }
 
 async function extractTTSSegmentsFromPDF(pdfDocument: PDFDocumentProxy) {
@@ -165,6 +164,8 @@ async function extractTTSSegmentsFromPDF(pdfDocument: PDFDocumentProxy) {
         // Use page number as chapter title for PDFs
         chapterTitles[pageNum] = `Page ${pageNum}`
       }
+
+      page.cleanup()
     }
     catch (error) {
       console.warn(`Failed to extract text from PDF page ${pageNum}:`, error)
@@ -179,7 +180,25 @@ function handlePageChanged(pageNumber: number) {
   activeTTSElementIndex.value = undefined
 }
 
-function handleTTSPlay() {
+let ttsExtractionPromise: Promise<void> | undefined
+async function handleTTSPlay() {
+  if (!isTTSExtracted.value && loadedPDFDocument.value) {
+    if (!ttsExtractionPromise) {
+      ttsExtractionPromise = extractTTSSegmentsFromPDF(loadedPDFDocument.value)
+        .then(({ segments, chapterTitles }) => {
+          setTTSSegments(segments)
+          setChapterTitles(chapterTitles)
+          isTTSExtracted.value = true
+        })
+        .catch((error) => {
+          console.warn('Failed to extract TTS segments from PDF:', error)
+        })
+        .finally(() => {
+          ttsExtractionPromise = undefined
+        })
+    }
+    await ttsExtractionPromise
+  }
   openPlayer({
     ttsIndex: activeTTSElementIndex.value,
     sectionIndex: currentPageIndex.value,


### PR DESCRIPTION
- Pre-allocate buffer when Content-Length is known to halve peak memory during download (with overflow guard for unreliable headers)
- Release ArrayBuffer after PDF.js loads (it transfers via zero-copy)
- Destroy PDF document and clear render queue on unmount
- Clean up page caches after each render and TTS text extraction
- Defer TTS segment extraction to first play instead of on PDF load