### PR TITLE
🚸 Add loading UI and editable voice name for custom voice

### DIFF
--- a/components/CustomVoiceUploadModal.vue
+++ b/components/CustomVoiceUploadModal.vue
@@ -42,7 +42,15 @@
             size="lg"
             :src="previewAvatarUrl || customDefaultAvatar"
           />
-          <span class="text-base font-medium">{{ previewVoiceName }}</span>
+          <UInput
+            v-model="previewVoiceNameInput"
+            class="flex-1"
+            :maxlength="100"
+            :placeholder="$t('tts_custom_voice_default_name')"
+            :loading="isLoading"
+            :disabled="isLoading"
+            @blur="handleVoiceNameBlur"
+          />
         </div>
 
         <div
@@ -56,6 +64,7 @@
           <URadioGroup
             :model-value="voiceLanguage"
             :items="voiceLanguageOptions"
+            :disabled="isLoading"
             orientation="horizontal"
             @update:model-value="handleVoiceLanguageChange"
           />
@@ -334,6 +343,7 @@
           block
           size="xl"
           color="error"
+          :loading="isLoading"
           @click="confirmDelete"
         />
         <UButton
@@ -341,6 +351,7 @@
           block
           size="xl"
           variant="link"
+          :disabled="isLoading"
           @click="showDeleteConfirm = false"
         />
       </template>
@@ -352,6 +363,7 @@
           block
           size="xl"
           variant="outline"
+          :disabled="isLoading"
           @click="showUploadForm = true"
         />
         <UButton
@@ -361,6 +373,7 @@
           size="xl"
           variant="link"
           color="error"
+          :disabled="isLoading"
           @click="handleDelete"
         />
         <UButton
@@ -382,8 +395,8 @@
           :label="existingVoice ? $t('tts_custom_voice_replace_button') : $t('tts_custom_voice_upload_button')"
           block
           size="xl"
-          :loading="isUploading"
-          :disabled="!mainAudio.file.value || isUploading || !isAudioDurationValid || !isPromptAudioDurationValid"
+          :loading="isLoading"
+          :disabled="!mainAudio.file.value || isLoading || !isAudioDurationValid || !isPromptAudioDurationValid"
           @click="handleUpload"
         />
         <UButton
@@ -393,6 +406,7 @@
           size="xl"
           variant="link"
           color="error"
+          :disabled="isLoading"
           @click="handleDelete"
         />
       </template>
@@ -415,7 +429,7 @@ const emit = defineEmits<{
 }>()
 
 const { t: $t, locale } = useI18n()
-const { isUploading, uploadCustomVoice, updateVoiceLanguage, removeCustomVoice } = useCustomVoice()
+const { customVoice, isLoading, uploadCustomVoice, updateCustomVoiceInfo, removeCustomVoice } = useCustomVoice()
 
 const voiceName = ref(props.existingVoice?.voiceName || '')
 const voiceLanguage = ref(props.existingVoice?.voiceLanguage || (locale.value === 'en' ? 'en-US' : 'zh-HK'))
@@ -428,7 +442,7 @@ const showUploadForm = ref(!props.existingVoice)
 const previewCacheBuster = ref(Date.now())
 
 const showPreview = computed(() => uploadSuccess.value || (!!props.existingVoice && !showUploadForm.value))
-const previewVoiceName = computed(() => voiceName.value || props.existingVoice?.voiceName || '')
+const previewVoiceNameInput = ref(props.existingVoice?.voiceName || '')
 const { getResizedImageURL } = useImageResize()
 const previewAvatarUrl = computed(() => {
   if (avatarPreview.value) return avatarPreview.value
@@ -598,14 +612,31 @@ async function handleAvatarChange(e: Event) {
 }
 
 async function handleVoiceLanguageChange(value: string) {
+  const prevLanguage = voiceLanguage.value
   voiceLanguage.value = value
   if (props.existingVoice && !showUploadForm.value) {
     try {
-      await updateVoiceLanguage(value)
+      await updateCustomVoiceInfo({ voiceLanguage: value })
     }
     catch (error) {
+      voiceLanguage.value = prevLanguage
       console.error('[CustomVoice] Failed to update language:', error)
     }
+  }
+}
+
+async function handleVoiceNameBlur() {
+  const newName = previewVoiceNameInput.value.trim()
+  previewVoiceNameInput.value = newName
+  if (!newName) return
+  if ((!props.existingVoice || showUploadForm.value) && !uploadSuccess.value) return
+  if (newName === customVoice.value?.voiceName) return
+  try {
+    await updateCustomVoiceInfo({ voiceName: newName })
+  }
+  catch (error) {
+    previewVoiceNameInput.value = customVoice.value?.voiceName || props.existingVoice?.voiceName || ''
+    console.error('[CustomVoice] Failed to update name:', error)
   }
 }
 
@@ -626,6 +657,7 @@ async function handleUpload() {
     if (data) {
       uploadSuccess.value = true
       previewCacheBuster.value = Date.now()
+      previewVoiceNameInput.value = data.voiceName
       emit('uploaded', data)
     }
   }

--- a/composables/use-custom-voice.ts
+++ b/composables/use-custom-voice.ts
@@ -3,7 +3,6 @@ import type { CustomVoiceData } from '~/shared/types/custom-voice'
 export function useCustomVoice() {
   const customVoice = useState<CustomVoiceData | null>('custom-voice', () => null)
   const isLoading = useState<boolean>('custom-voice-loading', () => false)
-  const isUploading = useState<boolean>('custom-voice-uploading', () => false)
 
   const hasCustomVoice = computed(() => !!customVoice.value?.voiceId)
 
@@ -22,8 +21,8 @@ export function useCustomVoice() {
   }
 
   async function uploadCustomVoice(params: { audio: File, voiceName: string, voiceLanguage?: string, avatar?: File, promptAudio?: File, promptText?: string }) {
-    if (isUploading.value) return
-    isUploading.value = true
+    if (isLoading.value) return
+    isLoading.value = true
     try {
       const formData = new FormData()
       formData.append('audio', params.audio)
@@ -48,33 +47,46 @@ export function useCustomVoice() {
       return data
     }
     finally {
-      isUploading.value = false
+      isLoading.value = false
     }
   }
 
-  async function updateVoiceLanguage(voiceLanguage: string) {
-    await $fetch('/api/user/custom-voice', {
-      method: 'PATCH',
-      body: { voiceLanguage },
-    })
-    if (customVoice.value) {
-      customVoice.value = { ...customVoice.value, voiceLanguage }
+  async function updateCustomVoiceInfo(fields: { voiceName?: string, voiceLanguage?: string }) {
+    if (isLoading.value) return
+    isLoading.value = true
+    try {
+      await $fetch('/api/user/custom-voice', {
+        method: 'PATCH',
+        body: fields,
+      })
+      if (customVoice.value) {
+        customVoice.value = { ...customVoice.value, ...fields }
+      }
+    }
+    finally {
+      isLoading.value = false
     }
   }
 
   async function removeCustomVoice() {
-    await $fetch('/api/user/custom-voice', { method: 'DELETE' })
-    customVoice.value = null
+    if (isLoading.value) return
+    isLoading.value = true
+    try {
+      await $fetch('/api/user/custom-voice', { method: 'DELETE' })
+      customVoice.value = null
+    }
+    finally {
+      isLoading.value = false
+    }
   }
 
   return {
     customVoice,
     hasCustomVoice,
     isLoading,
-    isUploading,
     fetchCustomVoice,
     uploadCustomVoice,
-    updateVoiceLanguage,
+    updateCustomVoiceInfo,
     removeCustomVoice,
   }
 }

--- a/server/api/user/custom-voice.patch.ts
+++ b/server/api/user/custom-voice.patch.ts
@@ -17,15 +17,19 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 404, message: 'NO_CUSTOM_VOICE' })
   }
 
-  const { voiceLanguage } = await readValidatedBody(event, createValidator(CustomVoicePatchSchema))
+  const fields = await readValidatedBody(event, createValidator(CustomVoicePatchSchema))
 
-  await updateCustomVoiceLanguage(wallet, voiceLanguage)
+  if (fields.voiceName === undefined && fields.voiceLanguage === undefined) {
+    throw createError({ statusCode: 400, message: 'NO_FIELDS_TO_UPDATE' })
+  }
+
+  await updateCustomVoice(wallet, fields)
 
   publishEvent(event, 'CustomVoiceUpdate', {
     evmWallet: wallet,
     voiceId: customVoice.voiceId,
-    voiceLanguage,
+    ...fields,
   })
 
-  return { voiceLanguage }
+  return fields
 })

--- a/server/schemas/custom-voice.ts
+++ b/server/schemas/custom-voice.ts
@@ -8,16 +8,21 @@ export const CUSTOM_VOICE_MAX_AUDIO_SIZE = 20 * 1024 * 1024 // 20MB
 export const CUSTOM_VOICE_MAX_PROMPT_AUDIO_SIZE = 2 * 1024 * 1024 // 2MB
 export const CUSTOM_VOICE_MAX_PROMPT_TEXT_LENGTH = 500
 export const CUSTOM_VOICE_MAX_AVATAR_SIZE = 2 * 1024 * 1024 // 2MB
+export const CUSTOM_VOICE_MAX_NAME_LENGTH = 100
+
+const VoiceNameSchema = v.pipe(
+  v.string('MISSING_VOICE_NAME'),
+  v.nonEmpty('MISSING_VOICE_NAME'),
+  v.maxLength(CUSTOM_VOICE_MAX_NAME_LENGTH, 'VOICE_NAME_TOO_LONG'),
+)
 
 export const CustomVoicePatchSchema = v.object({
-  voiceLanguage: v.picklist(CUSTOM_VOICE_ALLOWED_LANGUAGES, 'INVALID_VOICE_LANGUAGE'),
+  voiceName: v.optional(VoiceNameSchema),
+  voiceLanguage: v.optional(v.picklist(CUSTOM_VOICE_ALLOWED_LANGUAGES, 'INVALID_VOICE_LANGUAGE')),
 })
 
 export const CustomVoiceFieldsSchema = v.object({
-  voiceName: v.pipe(
-    v.string('MISSING_VOICE_NAME'),
-    v.nonEmpty('MISSING_VOICE_NAME'),
-  ),
+  voiceName: VoiceNameSchema,
   voiceLanguage: v.optional(v.picklist([...CUSTOM_VOICE_ALLOWED_VOICE_LANGUAGES], 'INVALID_VOICE_LANGUAGE')),
   promptText: v.optional(v.pipe(
     v.string('MISSING_PROMPT_TEXT'),

--- a/server/utils/api-user.ts
+++ b/server/utils/api-user.ts
@@ -180,14 +180,16 @@ export async function setCustomVoice(
   }, { merge: true })
 }
 
-export async function updateCustomVoiceLanguage(
+export async function updateCustomVoice(
   userWallet: string,
-  voiceLanguage: string,
+  fields: { voiceName?: string, voiceLanguage?: string },
 ): Promise<void> {
-  await getUserCollection().doc(userWallet).update({
-    'customVoice.voiceLanguage': voiceLanguage,
+  const update: Record<string, unknown> = {
     'customVoice.updatedAt': FieldValue.serverTimestamp(),
-  })
+  }
+  if (fields.voiceName !== undefined) update['customVoice.voiceName'] = fields.voiceName
+  if (fields.voiceLanguage !== undefined) update['customVoice.voiceLanguage'] = fields.voiceLanguage
+  await getUserCollection().doc(userWallet).update(update)
 }
 
 export async function deleteCustomVoice(


### PR DESCRIPTION
Add loading feedback to all custom voice async operations (upload, update, delete) using a unified isLoading state. Allow editing voice name from the preview screen with auto-save on blur. Generalize the PATCH API to accept both voiceName and voiceLanguage fields.