### PR TITLE
🐛 Fix reading progress not restored after navigating back to reader

### DIFF
--- a/composables/use-reader-progress.ts
+++ b/composables/use-reader-progress.ts
@@ -28,6 +28,12 @@ export function useReaderProgress({
     lastOpenedTime.value = Date.now()
   })
 
+  useEventListener(document, 'visibilitychange', () => {
+    if (document.visibilityState === 'hidden') {
+      useBookSettingsStore().flushBatch(nftClassId)
+    }
+  })
+
   onBeforeUnmount(() => {
     bookshelfStore.updateProgress(
       nftClassId,

--- a/composables/use-reader-progress.ts
+++ b/composables/use-reader-progress.ts
@@ -28,11 +28,13 @@ export function useReaderProgress({
     lastOpenedTime.value = Date.now()
   })
 
-  useEventListener(document, 'visibilitychange', () => {
-    if (document.visibilityState === 'hidden') {
-      useBookSettingsStore().flushBatch(nftClassId)
-    }
-  })
+  if (import.meta.client) {
+    useEventListener(document, 'visibilitychange', () => {
+      if (document.visibilityState === 'hidden') {
+        useBookSettingsStore().flushBatch(nftClassId)
+      }
+    })
+  }
 
   onBeforeUnmount(() => {
     bookshelfStore.updateProgress(

--- a/stores/book-settings.ts
+++ b/stores/book-settings.ts
@@ -179,6 +179,14 @@ export const useBookSettingsStore = defineStore('book-settings', () => {
   }
 
   function queueUpdate(nftClassId: string, dbKey: string, value: unknown) {
+    if (!hasLoggedIn.value) return
+
+    const key = getKey(nftClassId)
+    const entry = settingsMap.value[key]
+    if (entry) {
+      ;(entry.data as Record<string, unknown>)[dbKey] = value
+    }
+
     addToBatch(nftClassId, dbKey, value)
     const debouncedFlush = getDebouncedFlush(nftClassId)
     debouncedFlush()


### PR DESCRIPTION
queueUpdate wrote to the batch queue for server sync but never updated settingsMap. When re-entering the reader, isInitialized was already true so syncFromStore read stale cached data instead of re-fetching.