### PR TITLE
[TAS-4186] 📈 Add reading session tracking and analytics data collection

### DIFF
--- a/components/TTSPlayerModal.vue
+++ b/components/TTSPlayerModal.vue
@@ -362,6 +362,12 @@ const {
   },
 })
 
+const { isTTSPlaying } = useTTSPlayingState()
+watch(isTextToSpeechPlaying, playing => isTTSPlaying.value = playing, { immediate: true })
+onBeforeUnmount(() => {
+  isTTSPlaying.value = false
+})
+
 interface VisibleParagraph {
   key: string
   segments: Array<TTSSegment & { index: number }>

--- a/composables/use-reading-session.ts
+++ b/composables/use-reading-session.ts
@@ -1,0 +1,207 @@
+import { useDocumentVisibility, useIdle } from '@vueuse/core'
+import { HEARTBEAT_INTERVAL_MS, MAX_HEARTBEAT_DELTA_MS, MAX_SESSION_DURATION_MS } from '~/constants/analytics'
+
+const IDLE_TIMEOUT_MS = 2 * 60 * 1000
+
+interface ReadingSessionOptions {
+  nftClassId: string | Ref<string>
+  readerType: 'epub' | 'pdf'
+  progress: Ref<number>
+  isTextToSpeechPlaying?: Ref<boolean>
+  chapterIndex?: Ref<number | undefined>
+}
+
+export function useReadingSession(options: ReadingSessionOptions) {
+  const { readerType, progress, isTextToSpeechPlaying, chapterIndex } = options
+  const nftClassId = toRef(options.nftClassId)
+
+  const { loggedIn } = useUserSession()
+  let sessionId = ''
+  let startProgress = 0
+  let pagesViewed = new Set<number | string>()
+  let sessionFlushed = false
+
+  let activeReadingTimeMs = 0
+  let ttsActiveTimeMs = 0
+  let sessionActiveReadingTimeMs = 0
+  let sessionTtsActiveTimeMs = 0
+  let lastActiveTimestamp: number | null = null
+  let lastTTSTimestamp: number | null = null
+
+  function resetSession() {
+    sessionId = crypto.randomUUID()
+    startProgress = progress.value
+    pagesViewed = new Set<number | string>()
+    sessionFlushed = false
+    activeReadingTimeMs = 0
+    ttsActiveTimeMs = 0
+    sessionActiveReadingTimeMs = 0
+    sessionTtsActiveTimeMs = 0
+    lastActiveTimestamp = null
+    lastTTSTimestamp = null
+  }
+
+  resetSession()
+  const { idle } = useIdle(IDLE_TIMEOUT_MS, {
+    events: ['scroll', 'touchstart', 'keydown', 'pointermove'],
+  })
+  const visibility = useDocumentVisibility()
+  const isTabVisible = computed(() => visibility.value === 'visible')
+
+  const isActivelyReading = computed(() =>
+    isTabVisible.value && !idle.value,
+  )
+
+  watch(isActivelyReading, (active) => {
+    if (active) {
+      lastActiveTimestamp = Date.now()
+    }
+    else if (lastActiveTimestamp) {
+      activeReadingTimeMs += Date.now() - lastActiveTimestamp
+      lastActiveTimestamp = null
+    }
+  }, { immediate: true })
+
+  if (isTextToSpeechPlaying) {
+    watch(isTextToSpeechPlaying, (playing) => {
+      if (playing) {
+        lastTTSTimestamp = Date.now()
+      }
+      else if (lastTTSTimestamp) {
+        ttsActiveTimeMs += Date.now() - lastTTSTimestamp
+        lastTTSTimestamp = null
+      }
+    }, { immediate: true })
+  }
+
+  if (chapterIndex) {
+    watch(chapterIndex, (index) => {
+      if (index !== undefined) {
+        pagesViewed.add(`ch:${index}`)
+      }
+    }, { immediate: true })
+  }
+  watch(progress, () => {
+    if (startProgress === 0 && progress.value !== 0 && sessionActiveReadingTimeMs === 0) {
+      startProgress = progress.value
+    }
+    if (!chapterIndex) {
+      pagesViewed.add(Math.floor(progress.value))
+    }
+  }, { immediate: true })
+
+  function drainAccumulators(cap: number) {
+    const now = Date.now()
+    let drainedActiveTime = activeReadingTimeMs
+    let drainedTTSTime = ttsActiveTimeMs
+
+    if (lastActiveTimestamp) {
+      drainedActiveTime += now - lastActiveTimestamp
+      lastActiveTimestamp = now
+    }
+    if (lastTTSTimestamp) {
+      drainedTTSTime += now - lastTTSTimestamp
+      lastTTSTimestamp = now
+    }
+
+    const capped = {
+      activeReadingTimeMs: Math.min(drainedActiveTime, cap),
+      ttsActiveTimeMs: Math.min(drainedTTSTime, cap),
+    }
+
+    sessionActiveReadingTimeMs += capped.activeReadingTimeMs
+    sessionTtsActiveTimeMs += capped.ttsActiveTimeMs
+
+    activeReadingTimeMs = Math.max(0, drainedActiveTime - capped.activeReadingTimeMs)
+    ttsActiveTimeMs = Math.max(0, drainedTTSTime - capped.ttsActiveTimeMs)
+
+    return capped
+  }
+
+  function buildSessionPayload() {
+    const finalDelta = drainAccumulators(MAX_SESSION_DURATION_MS)
+    const totalActiveReadingTimeMs = Math.min(sessionActiveReadingTimeMs, MAX_SESSION_DURATION_MS)
+    const totalTtsActiveTimeMs = Math.min(sessionTtsActiveTimeMs, MAX_SESSION_DURATION_MS)
+    if (totalActiveReadingTimeMs < 1000 && totalTtsActiveTimeMs < 1000) return null
+
+    return {
+      nftClassId: toValue(nftClassId),
+      sessionId,
+      activeReadingTimeMs: totalActiveReadingTimeMs,
+      ttsActiveTimeMs: totalTtsActiveTimeMs,
+      activeReadingTimeMsDelta: finalDelta.activeReadingTimeMs,
+      ttsActiveTimeMsDelta: finalDelta.ttsActiveTimeMs,
+      pagesViewed: pagesViewed.size,
+      startProgress,
+      endProgress: progress.value,
+      readerType,
+      chapterIndex: chapterIndex?.value,
+    }
+  }
+
+  function flushSessionBeacon() {
+    if (sessionFlushed || !loggedIn.value) return
+    sessionFlushed = true
+
+    const payload = buildSessionPayload()
+    if (!payload) return
+
+    navigator.sendBeacon(
+      '/api/analytics/session',
+      new Blob([JSON.stringify(payload)], { type: 'application/json' }),
+    )
+
+    useLogEvent('reading_session_end', {
+      nft_class_id: toValue(nftClassId),
+      active_reading_time_ms: payload.activeReadingTimeMs,
+      tts_active_time_ms: payload.ttsActiveTimeMs,
+      pages_viewed: payload.pagesViewed,
+    })
+  }
+
+  async function sendHeartbeat() {
+    if (!loggedIn.value) return
+
+    const drained = drainAccumulators(MAX_HEARTBEAT_DELTA_MS)
+    if (drained.activeReadingTimeMs < 1000 && drained.ttsActiveTimeMs < 1000) return
+
+    try {
+      await $fetch('/api/analytics/heartbeat', {
+        method: 'POST',
+        body: {
+          nftClassId: toValue(nftClassId),
+          sessionId,
+          activeReadingTimeMsDelta: drained.activeReadingTimeMs,
+          ttsActiveTimeMsDelta: drained.ttsActiveTimeMs,
+        },
+      })
+    }
+    catch (error) {
+      console.warn('[ReadingSession] Failed to send heartbeat:', error)
+    }
+  }
+
+  const { pause: pauseHeartbeat, resume: resumeHeartbeat } = useIntervalFn(sendHeartbeat, HEARTBEAT_INTERVAL_MS, { immediate: false })
+
+  onMounted(() => {
+    resumeHeartbeat()
+  })
+
+  watch(isTabVisible, (visible) => {
+    if (!visible) {
+      pauseHeartbeat()
+      flushSessionBeacon()
+    }
+    else {
+      resetSession()
+      resumeHeartbeat()
+    }
+  })
+
+  onBeforeUnmount(() => {
+    pauseHeartbeat()
+    flushSessionBeacon()
+  })
+
+  return {}
+}

--- a/composables/use-reading-session.ts
+++ b/composables/use-reading-session.ts
@@ -9,10 +9,11 @@ interface ReadingSessionOptions {
   progress: Ref<number>
   isTextToSpeechPlaying?: Ref<boolean>
   chapterIndex?: Ref<number | undefined>
+  pageIndex?: Ref<number | undefined>
 }
 
 export function useReadingSession(options: ReadingSessionOptions) {
-  const { readerType, progress, isTextToSpeechPlaying, chapterIndex } = options
+  const { readerType, progress, isTextToSpeechPlaying, chapterIndex, pageIndex } = options
   const nftClassId = toRef(options.nftClassId)
 
   const { loggedIn } = useUserSession()
@@ -24,7 +25,7 @@ export function useReadingSession(options: ReadingSessionOptions) {
   let activeReadingTimeMs = 0
   let ttsActiveTimeMs = 0
   let sessionActiveReadingTimeMs = 0
-  let sessionTtsActiveTimeMs = 0
+  let sessionTTSActiveTimeMs = 0
   let lastActiveTimestamp: number | null = null
   let lastTTSTimestamp: number | null = null
 
@@ -36,7 +37,7 @@ export function useReadingSession(options: ReadingSessionOptions) {
     activeReadingTimeMs = 0
     ttsActiveTimeMs = 0
     sessionActiveReadingTimeMs = 0
-    sessionTtsActiveTimeMs = 0
+    sessionTTSActiveTimeMs = 0
     lastActiveTimestamp = null
     lastTTSTimestamp = null
   }
@@ -62,30 +63,31 @@ export function useReadingSession(options: ReadingSessionOptions) {
     }
   }, { immediate: true })
 
-  if (isTextToSpeechPlaying) {
-    watch(isTextToSpeechPlaying, (playing) => {
-      if (playing) {
-        lastTTSTimestamp = Date.now()
-      }
-      else if (lastTTSTimestamp) {
-        ttsActiveTimeMs += Date.now() - lastTTSTimestamp
-        lastTTSTimestamp = null
-      }
-    }, { immediate: true })
-  }
+  watch(() => isTextToSpeechPlaying?.value, (playing) => {
+    if (playing) {
+      lastTTSTimestamp = Date.now()
+    }
+    else if (lastTTSTimestamp) {
+      ttsActiveTimeMs += Date.now() - lastTTSTimestamp
+      lastTTSTimestamp = null
+    }
+  }, { immediate: true })
 
-  if (chapterIndex) {
-    watch(chapterIndex, (index) => {
-      if (index !== undefined) {
-        pagesViewed.add(`ch:${index}`)
-      }
-    }, { immediate: true })
-  }
+  watch(() => chapterIndex?.value, (index) => {
+    if (index !== undefined) {
+      pagesViewed.add(`ch:${index}`)
+    }
+  }, { immediate: true })
+  watch(() => pageIndex?.value, (index) => {
+    if (index !== undefined) {
+      pagesViewed.add(`pg:${index}`)
+    }
+  }, { immediate: true })
   watch(progress, () => {
     if (startProgress === 0 && progress.value !== 0 && sessionActiveReadingTimeMs === 0) {
       startProgress = progress.value
     }
-    if (!chapterIndex) {
+    if (!chapterIndex && !pageIndex) {
       pagesViewed.add(Math.floor(progress.value))
     }
   }, { immediate: true })
@@ -110,7 +112,7 @@ export function useReadingSession(options: ReadingSessionOptions) {
     }
 
     sessionActiveReadingTimeMs += capped.activeReadingTimeMs
-    sessionTtsActiveTimeMs += capped.ttsActiveTimeMs
+    sessionTTSActiveTimeMs += capped.ttsActiveTimeMs
 
     activeReadingTimeMs = Math.max(0, drainedActiveTime - capped.activeReadingTimeMs)
     ttsActiveTimeMs = Math.max(0, drainedTTSTime - capped.ttsActiveTimeMs)
@@ -121,14 +123,14 @@ export function useReadingSession(options: ReadingSessionOptions) {
   function buildSessionPayload() {
     const finalDelta = drainAccumulators(MAX_SESSION_DURATION_MS)
     const totalActiveReadingTimeMs = Math.min(sessionActiveReadingTimeMs, MAX_SESSION_DURATION_MS)
-    const totalTtsActiveTimeMs = Math.min(sessionTtsActiveTimeMs, MAX_SESSION_DURATION_MS)
-    if (totalActiveReadingTimeMs < 1000 && totalTtsActiveTimeMs < 1000) return null
+    const totalTTSActiveTimeMs = Math.min(sessionTTSActiveTimeMs, MAX_SESSION_DURATION_MS)
+    if (totalActiveReadingTimeMs < 1000 && totalTTSActiveTimeMs < 1000) return null
 
     return {
       nftClassId: toValue(nftClassId),
       sessionId,
       activeReadingTimeMs: totalActiveReadingTimeMs,
-      ttsActiveTimeMs: totalTtsActiveTimeMs,
+      ttsActiveTimeMs: totalTTSActiveTimeMs,
       activeReadingTimeMsDelta: finalDelta.activeReadingTimeMs,
       ttsActiveTimeMsDelta: finalDelta.ttsActiveTimeMs,
       pagesViewed: pagesViewed.size,

--- a/composables/use-text-to-speech.ts
+++ b/composables/use-text-to-speech.ts
@@ -345,14 +345,14 @@ export function useTextToSpeech(options: TTSOptions = {}) {
         language,
         voice_id: 'custom',
       })
+      if (nftClassId) {
+        params.set('nft_class_id', nftClassId)
+      }
       if (customVoice?.updatedAt) {
         params.set('_t', customVoice.updatedAt.toString())
       }
       if (isNativeBridge.value) {
         params.set('blocking', '1')
-      }
-      if (nftClassId) {
-        params.set('nft_class_id', nftClassId)
       }
       return `/api/reader/tts?${params.toString()}`
     }
@@ -363,11 +363,11 @@ export function useTextToSpeech(options: TTSOptions = {}) {
       language: language || 'zh-HK',
       voice_id: voiceIdParts.join('_'),
     })
-    if (isNativeBridge.value) {
-      params.set('blocking', '1')
-    }
     if (nftClassId) {
       params.set('nft_class_id', nftClassId)
+    }
+    if (isNativeBridge.value) {
+      params.set('blocking', '1')
     }
     return `/api/reader/tts?${params.toString()}`
   }

--- a/composables/use-tts-playing-state.ts
+++ b/composables/use-tts-playing-state.ts
@@ -1,0 +1,4 @@
+export function useTTSPlayingState() {
+  const isPlaying = useState('tts-playing', () => false)
+  return { isTTSPlaying: isPlaying }
+}

--- a/constants/analytics.ts
+++ b/constants/analytics.ts
@@ -1,0 +1,3 @@
+export const MAX_SESSION_DURATION_MS = 4 * 60 * 60 * 1000
+export const HEARTBEAT_INTERVAL_MS = 5 * 60 * 1000
+export const MAX_HEARTBEAT_DELTA_MS = 10 * 60 * 1000

--- a/docs/analytics-roadmap.md
+++ b/docs/analytics-roadmap.md
@@ -17,7 +17,7 @@
 
 ### Firestore Schema Additions
 - **`book-users/{wallet}`:** `totalReadingTimeMs`, `totalTTSListeningTimeMs`, `totalBooksCompleted`, `readingStreak { currentDays, longestDays, lastActiveDate }`
-- **`book-users/{wallet}/books/{nftClassId}`:** `totalReadingTimeMs`, `totalTTSTimeMs`, `ttsCharactersUsed`, `completedAt`, `sessionCount`
+- **`book-users/{wallet}/books/{nftClassId}`:** `totalReadingTimeMs`, `totalTTSListeningTimeMs`, `ttsCharactersUsed`, `completedAt`, `sessionCount`
 
 ---
 

--- a/docs/analytics-roadmap.md
+++ b/docs/analytics-roadmap.md
@@ -1,0 +1,114 @@
+# Analytics Roadmap
+
+## Implemented (Data Collection Layer)
+
+### Client-Side
+- `composables/use-reading-session.ts` — Core session tracker with idle detection, TTS time tracking, heartbeat, and flush strategies
+- `composables/use-tts-playing-state.ts` — Shared global TTS playing state
+- Integration in `pages/reader/epub.vue` and `pages/reader/pdf.vue`
+- Per-book TTS character tracking via `nft_class_id` param on TTS endpoint
+- Client-side events: `reading_session_end`
+
+### Server-Side
+- `POST /api/analytics/session` — Full session flush with Firestore writes and PubSub events
+- `POST /api/analytics/heartbeat` — Lightweight periodic time increment
+- Firestore helpers: `incrementBookReadingTime()` (full session + heartbeat delta), `updateReadingStreak()`, `markBookCompleted()`, `incrementBookTTSCharacterUsage()`
+- PubSub events: `3ook_ReadingSession`, `3ook_BookCompleted` (published when `endProgress >= 95%`)
+
+### Firestore Schema Additions
+- **`book-users/{wallet}`:** `totalReadingTimeMs`, `totalTTSListeningTimeMs`, `totalBooksCompleted`, `readingStreak { currentDays, longestDays, lastActiveDate }`
+- **`book-users/{wallet}/books/{nftClassId}`:** `totalReadingTimeMs`, `totalTTSTimeMs`, `ttsCharactersUsed`, `completedAt`, `sessionCount`
+
+---
+
+## Planned: Reader Statistics Page
+
+**Page:** `/pages/account/stats.vue`
+
+Content:
+- Summary cards: total reading time, books completed, current streak, TTS usage
+- Top books by reading time (list with progress bars)
+- Category and author breakdowns
+- Per-book detail view
+
+**API:** `GET /api/analytics/reader-stats` — reads from Firestore user/book docs, joins with book metadata
+
+**Composables:** `use-reader-stats.ts`, `use-reading-streak.ts`
+
+Link from `/pages/account/index.vue`.
+
+---
+
+## Planned: Reading Trends
+
+**API:** `GET /api/analytics/reader-stats/trends?period=daily|weekly|monthly&range=30d|90d|1y`
+
+Queries Elasticsearch `ReadingSession` events aggregated by time bucket. Returns `{ date, readingTimeMs, sessionsCount, booksRead }[]`.
+
+UI: Activity chart on stats page (chart library TBD).
+
+---
+
+## Planned: Publisher Dashboard (nft-book-press)
+
+3ook.com exposes API endpoints, publisher portal consumes them.
+
+### 3ook.com APIs
+- `GET /api/analytics/publisher/book/[nftClassId]` — per-book: uniqueReaders, completionRate, avgProgress, progressDistribution, ttsUsageRatio
+- `GET /api/analytics/publisher/overview` — all books for authenticated publisher
+
+### Aggregation
+Cloud Function consumes `ReadingSession`/`BookCompleted` events → updates `book-analytics/{nftClassId}` Firestore docs.
+
+### nft-book-press Pages
+- `/pages/reading-analytics/index.vue` — overview across all books
+- `/pages/reading-analytics/[classId].vue` — per-book engagement detail
+
+Privacy: aggregates only, no individual reader identities, minimum 5 readers threshold.
+
+---
+
+## Planned: Reports (Cronjob-Based)
+
+Pre-computed by scheduled Cloud Functions, not on-demand.
+
+| Report | Schedule | Data Source |
+|---|---|---|
+| Daily | Every day 00:05 UTC | ES: yesterday's ReadingSession events |
+| Weekly | Every Monday 01:00 UTC | ES: last 7 days aggregated |
+| Monthly | 1st of month 02:00 UTC | ES: last month aggregated |
+| Annual | Jan 1st 03:00 UTC | ES: full year aggregated |
+
+Storage: `reports/{period}/{date}` Firestore collections with per-user sub-docs.
+
+### Per-User Report Fields
+`readingTimeMs`, `ttsTimeMs`, `booksRead`, `booksCompleted`, `pagesViewed`, `sessionsCount`, `topBooks[]`, `topCategories[]`, `topAuthors[]`, `streakDays`
+
+### Annual Report Extras
+`equivalentBookStackCm`, `wordsReadEstimate`, `hoursEquivalent`, `readingTimePeakHour`, `totalReadingDays`, `avgDailyReadingTimeMs`
+
+### Serving APIs
+- `GET /api/analytics/report/reader?period=daily|weekly|monthly|annual&date=YYYY-MM-DD`
+- `GET /api/analytics/report/author?period=...&date=...`
+- `GET /api/analytics/platform?period=...&date=...` (public)
+
+Shareable annual report page: `/pages/account/annual-report/[year].vue`
+
+---
+
+## Planned: Recommendation Foundation
+
+Data from reading sessions naturally builds:
+- Category affinity scores from reading time distribution across genres
+- Author preference from completed books / reading time
+- Collaborative filtering from similar reading patterns in Elasticsearch
+
+No application code needed beyond data collection. Future `GET /api/recommendations` would query a pre-computed model.
+
+---
+
+## Open Questions
+
+1. **Cross-origin auth (Publisher Dashboard):** How should the publisher portal authenticate with 3ook.com's publisher analytics API?
+2. **Book completion threshold:** Is 95% progress the right threshold for "completed"? Some books have front/back matter.
+3. **Report timezone:** Should daily/weekly/monthly reports use UTC or user's local timezone for day boundaries?

--- a/pages/reader/epub.vue
+++ b/pages/reader/epub.vue
@@ -548,6 +548,16 @@ const {
 })
 
 const currentSectionIndex = ref(0)
+
+const { isTTSPlaying } = useTTSPlayingState()
+useReadingSession({
+  nftClassId,
+  readerType: 'epub',
+  progress: computed(() => Math.min(readingProgress.value * 100, 100)),
+  isTextToSpeechPlaying: isTTSPlaying,
+  chapterIndex: currentSectionIndex,
+})
+
 const lastSectionIndex = ref(0)
 const percentage = ref(0)
 const percentageLabel = computed(() => `${Math.round(percentage.value * 100)}%`)

--- a/pages/reader/pdf.vue
+++ b/pages/reader/pdf.vue
@@ -62,7 +62,7 @@ const {
 const { handleError } = useErrorHandler()
 
 const pdfProgress = ref(0)
-function updatePdfProgress(page: number) {
+function updatePDFProgress(page: number) {
   const totalPages = loadedPDFDocument.value?.numPages || 1
   pdfProgress.value = Math.round((page / totalPages) * 100)
 }
@@ -142,7 +142,7 @@ function handlePDFLoaded(pdfDocument: PDFDocumentProxy) {
   isPDFReady.value = true
   loadedPDFDocument.value = pdfDocument
   currentPageIndex.value = pdfReaderRef.value?.currentPage || 1
-  updatePdfProgress(currentPageIndex.value)
+  updatePDFProgress(currentPageIndex.value)
   // Release the ArrayBuffer — PDF.js has its own internal copy
   fileBuffer.value = null
 }
@@ -201,7 +201,7 @@ async function extractTTSSegmentsFromPDF(pdfDocument: PDFDocumentProxy) {
 function handlePageChanged(pageNumber: number) {
   currentPageIndex.value = pageNumber
   activeTTSElementIndex.value = undefined
-  updatePdfProgress(pageNumber)
+  updatePDFProgress(pageNumber)
 }
 
 let ttsExtractionPromise: Promise<void> | undefined

--- a/pages/reader/pdf.vue
+++ b/pages/reader/pdf.vue
@@ -61,6 +61,19 @@ const {
 } = useReader()
 const { handleError } = useErrorHandler()
 
+const pdfProgress = ref(0)
+function updatePdfProgress(page: number) {
+  const totalPages = loadedPDFDocument.value?.numPages || 1
+  pdfProgress.value = Math.round((page / totalPages) * 100)
+}
+const { isTTSPlaying } = useTTSPlayingState()
+useReadingSession({
+  nftClassId,
+  readerType: 'pdf',
+  progress: pdfProgress,
+  isTextToSpeechPlaying: isTTSPlaying,
+})
+
 const fileBuffer = ref<ArrayBuffer | null>(null)
 const isPDFReady = ref(false)
 const loadedPDFDocument = shallowRef<PDFDocumentProxy>()
@@ -129,6 +142,7 @@ function handlePDFLoaded(pdfDocument: PDFDocumentProxy) {
   isPDFReady.value = true
   loadedPDFDocument.value = pdfDocument
   currentPageIndex.value = pdfReaderRef.value?.currentPage || 1
+  updatePdfProgress(currentPageIndex.value)
   // Release the ArrayBuffer — PDF.js has its own internal copy
   fileBuffer.value = null
 }
@@ -187,6 +201,7 @@ async function extractTTSSegmentsFromPDF(pdfDocument: PDFDocumentProxy) {
 function handlePageChanged(pageNumber: number) {
   currentPageIndex.value = pageNumber
   activeTTSElementIndex.value = undefined
+  updatePdfProgress(pageNumber)
 }
 
 let ttsExtractionPromise: Promise<void> | undefined

--- a/server/api/analytics/heartbeat.post.ts
+++ b/server/api/analytics/heartbeat.post.ts
@@ -1,0 +1,23 @@
+import { HeartbeatSchema } from '~/server/schemas/analytics'
+
+export default defineEventHandler(async (event) => {
+  const wallet = await requireUserWallet(event)
+  const body = await readValidatedBody(event, createValidator(HeartbeatSchema))
+
+  const {
+    nftClassId,
+    activeReadingTimeMsDelta,
+    ttsActiveTimeMsDelta,
+  } = body
+
+  if (activeReadingTimeMsDelta > 0 || ttsActiveTimeMsDelta > 0) {
+    await incrementBookReadingTime(
+      wallet,
+      nftClassId,
+      activeReadingTimeMsDelta,
+      ttsActiveTimeMsDelta,
+    )
+  }
+
+  return { success: true }
+})

--- a/server/api/analytics/session.post.ts
+++ b/server/api/analytics/session.post.ts
@@ -1,0 +1,71 @@
+import { ReadingSessionSchema } from '~/server/schemas/analytics'
+
+const COMPLETION_THRESHOLD = 95
+
+export default defineEventHandler(async (event) => {
+  const wallet = await requireUserWallet(event)
+  const body = await readValidatedBody(event, createValidator(ReadingSessionSchema))
+
+  const {
+    nftClassId,
+    sessionId,
+    activeReadingTimeMs,
+    ttsActiveTimeMs,
+    activeReadingTimeMsDelta,
+    ttsActiveTimeMsDelta,
+    pagesViewed,
+    startProgress,
+    endProgress,
+    readerType,
+    chapterIndex,
+  } = body
+
+  const hasActivity = activeReadingTimeMs > 0 || ttsActiveTimeMs > 0
+
+  if (hasActivity) {
+    // Run batch write first to avoid Firestore transaction contention on user doc
+    await incrementBookReadingTime(wallet, nftClassId, activeReadingTimeMsDelta, ttsActiveTimeMsDelta, { countSession: true })
+  }
+
+  const tasks: Promise<unknown>[] = []
+  if (hasActivity) {
+    tasks.push(updateReadingStreak(wallet))
+  }
+
+  let isNewCompletion = false
+  if (hasActivity && endProgress >= COMPLETION_THRESHOLD) {
+    tasks.push(
+      markBookCompleted(wallet, nftClassId).then((result) => { isNewCompletion = result }),
+    )
+  }
+
+  await Promise.all(tasks)
+
+  try {
+    publishEvent(event, 'ReadingSession', {
+      evmWallet: wallet,
+      nftClassId,
+      sessionId,
+      activeReadingTimeMs,
+      ttsActiveTimeMs,
+      pagesViewed,
+      startProgress,
+      endProgress,
+      readerType,
+      chapterIndex,
+    })
+
+    if (isNewCompletion) {
+      publishEvent(event, 'BookCompleted', {
+        evmWallet: wallet,
+        nftClassId,
+        completionProgress: endProgress,
+      })
+    }
+  }
+  catch (err) {
+    console.warn('[Session] Failed to publish event:', err)
+  }
+
+  return { success: true, bookCompleted: isNewCompletion }
+})

--- a/server/api/reader/tts.get.ts
+++ b/server/api/reader/tts.get.ts
@@ -216,6 +216,11 @@ export default defineEventHandler(async (event) => {
 
   publishEvent(event, 'TTSRequest', ttsEventBase)
 
+  if (nftClassId) {
+    incrementBookTTSCharacterUsage(session.user.evmWallet, nftClassId, text.length)
+      .catch(err => console.warn('[TTS] Failed to increment per-book TTS usage:', err))
+  }
+
   const isBlocking = blocking === '1'
   const requestParams: TTSRequestParams = {
     text,

--- a/server/schemas/analytics.ts
+++ b/server/schemas/analytics.ts
@@ -1,0 +1,70 @@
+import * as v from 'valibot'
+import { MAX_HEARTBEAT_DELTA_MS, MAX_SESSION_DURATION_MS } from '~/constants/analytics'
+import { nftClassIdField } from '~/server/schemas/params'
+
+export const ReadingSessionSchema = v.object({
+  nftClassId: nftClassIdField,
+  sessionId: v.pipe(
+    v.string('MISSING_SESSION_ID'),
+    v.nonEmpty('MISSING_SESSION_ID'),
+  ),
+  activeReadingTimeMs: v.pipe(
+    v.number('INVALID_ACTIVE_READING_TIME'),
+    v.minValue(0, 'INVALID_ACTIVE_READING_TIME'),
+    v.maxValue(MAX_SESSION_DURATION_MS, 'ACTIVE_READING_TIME_TOO_LARGE'),
+  ),
+  ttsActiveTimeMs: v.pipe(
+    v.number('INVALID_TTS_ACTIVE_TIME'),
+    v.minValue(0, 'INVALID_TTS_ACTIVE_TIME'),
+    v.maxValue(MAX_SESSION_DURATION_MS, 'TTS_ACTIVE_TIME_TOO_LARGE'),
+  ),
+  activeReadingTimeMsDelta: v.pipe(
+    v.number('INVALID_ACTIVE_READING_TIME_DELTA'),
+    v.minValue(0, 'INVALID_ACTIVE_READING_TIME_DELTA'),
+    v.maxValue(MAX_SESSION_DURATION_MS, 'ACTIVE_READING_TIME_DELTA_TOO_LARGE'),
+  ),
+  ttsActiveTimeMsDelta: v.pipe(
+    v.number('INVALID_TTS_ACTIVE_TIME_DELTA'),
+    v.minValue(0, 'INVALID_TTS_ACTIVE_TIME_DELTA'),
+    v.maxValue(MAX_SESSION_DURATION_MS, 'TTS_ACTIVE_TIME_DELTA_TOO_LARGE'),
+  ),
+  pagesViewed: v.pipe(
+    v.number('INVALID_PAGES_VIEWED'),
+    v.minValue(0, 'INVALID_PAGES_VIEWED'),
+    v.integer('INVALID_PAGES_VIEWED'),
+  ),
+  startProgress: v.pipe(
+    v.number('INVALID_START_PROGRESS'),
+    v.minValue(0, 'INVALID_START_PROGRESS'),
+    v.maxValue(100, 'INVALID_START_PROGRESS'),
+  ),
+  endProgress: v.pipe(
+    v.number('INVALID_END_PROGRESS'),
+    v.minValue(0, 'INVALID_END_PROGRESS'),
+    v.maxValue(100, 'INVALID_END_PROGRESS'),
+  ),
+  readerType: v.picklist(['epub', 'pdf'], 'INVALID_READER_TYPE'),
+  chapterIndex: v.optional(v.pipe(
+    v.number('INVALID_CHAPTER_INDEX'),
+    v.minValue(0, 'INVALID_CHAPTER_INDEX'),
+    v.integer('INVALID_CHAPTER_INDEX'),
+  )),
+})
+
+export const HeartbeatSchema = v.object({
+  nftClassId: nftClassIdField,
+  sessionId: v.pipe(
+    v.string('MISSING_SESSION_ID'),
+    v.nonEmpty('MISSING_SESSION_ID'),
+  ),
+  activeReadingTimeMsDelta: v.pipe(
+    v.number('INVALID_ACTIVE_READING_TIME_DELTA'),
+    v.minValue(0, 'INVALID_ACTIVE_READING_TIME_DELTA'),
+    v.maxValue(MAX_HEARTBEAT_DELTA_MS, 'ACTIVE_READING_TIME_DELTA_TOO_LARGE'),
+  ),
+  ttsActiveTimeMsDelta: v.pipe(
+    v.number('INVALID_TTS_ACTIVE_TIME_DELTA'),
+    v.minValue(0, 'INVALID_TTS_ACTIVE_TIME_DELTA'),
+    v.maxValue(MAX_HEARTBEAT_DELTA_MS, 'TTS_ACTIVE_TIME_DELTA_TOO_LARGE'),
+  ),
+})

--- a/server/schemas/book-list.ts
+++ b/server/schemas/book-list.ts
@@ -1,17 +1,12 @@
 import * as v from 'valibot'
+import { nftClassIdField } from '~/server/schemas/params'
 
 export const BookListBodySchema = v.object({
-  nftClassId: v.pipe(
-    v.string('MISSING_NFT_CLASS_ID'),
-    v.nonEmpty('MISSING_NFT_CLASS_ID'),
-  ),
+  nftClassId: nftClassIdField,
   priceIndex: v.optional(v.number(), 0),
 })
 
 export const BookListQuerySchema = v.object({
-  nft_class_id: v.pipe(
-    v.string('MISSING_NFT_CLASS_ID'),
-    v.nonEmpty('MISSING_NFT_CLASS_ID'),
-  ),
+  nft_class_id: nftClassIdField,
   price_index: v.optional(v.string()),
 })

--- a/server/schemas/params.ts
+++ b/server/schemas/params.ts
@@ -1,10 +1,13 @@
 import * as v from 'valibot'
 
+export const nftClassIdField = v.pipe(
+  v.string('MISSING_NFT_CLASS_ID'),
+  v.nonEmpty('MISSING_NFT_CLASS_ID'),
+  v.regex(/^0x[0-9a-fA-F]{40}$/, 'INVALID_NFT_CLASS_ID'),
+)
+
 export const NFTClassIdParamsSchema = v.object({
-  nftClassId: v.pipe(
-    v.string('MISSING_NFT_CLASS_ID'),
-    v.nonEmpty('MISSING_NFT_CLASS_ID'),
-  ),
+  nftClassId: nftClassIdField,
 })
 
 export const TagIdParamsSchema = v.object({
@@ -15,10 +18,7 @@ export const TagIdParamsSchema = v.object({
 })
 
 export const AnnotationParamsSchema = v.object({
-  nftClassId: v.pipe(
-    v.string('MISSING_NFT_CLASS_ID'),
-    v.nonEmpty('MISSING_NFT_CLASS_ID'),
-  ),
+  nftClassId: nftClassIdField,
   annotationId: v.pipe(
     v.string('MISSING_ANNOTATION_ID'),
     v.nonEmpty('MISSING_ANNOTATION_ID'),

--- a/server/schemas/tts.ts
+++ b/server/schemas/tts.ts
@@ -1,4 +1,5 @@
 import * as v from 'valibot'
+import { nftClassIdField } from '~/server/schemas/params'
 
 export const TTSQuerySchema = v.object({
   text: v.pipe(
@@ -11,8 +12,5 @@ export const TTSQuerySchema = v.object({
     v.nonEmpty('INVALID_VOICE_ID'),
   ),
   blocking: v.optional(v.string()),
-  nft_class_id: v.optional(v.pipe(
-    v.string('INVALID_NFT_CLASS_ID'),
-    v.nonEmpty('INVALID_NFT_CLASS_ID'),
-  )),
+  nft_class_id: v.optional(nftClassIdField),
 })

--- a/server/types/book-settings.d.ts
+++ b/server/types/book-settings.d.ts
@@ -2,4 +2,9 @@ import type { Timestamp } from 'firebase-admin/firestore'
 
 export interface BookSettingsFirestoreData extends BaseBookSettingsData {
   updatedAt?: Timestamp
+  totalReadingTimeMs?: number
+  totalTTSListeningTimeMs?: number
+  ttsCharactersUsed?: number
+  completedAt?: Timestamp | null
+  sessionCount?: number
 }

--- a/server/utils/api-user.ts
+++ b/server/utils/api-user.ts
@@ -36,6 +36,14 @@ export interface UserDocData {
   accessTimestamp?: typeof FieldValue.serverTimestamp
   loginMethod?: string
   customVoice?: CustomVoiceDocData
+  totalReadingTimeMs?: number
+  totalTTSListeningTimeMs?: number
+  totalBooksCompleted?: number
+  readingStreak?: {
+    currentDays: number
+    longestDays: number
+    lastActiveDate: string
+  }
 }
 
 export async function getUserDoc(
@@ -72,6 +80,7 @@ export async function getBookSettings(
   return {
     ...data,
     updatedAt: data.updatedAt instanceof Timestamp ? data.updatedAt.toMillis() : undefined,
+    completedAt: data.completedAt instanceof Timestamp ? data.completedAt.toMillis() : undefined,
   } as BookSettingsData
 }
 
@@ -121,6 +130,7 @@ export async function getBatchBookSettings(
       result[doc.id] = {
         ...data,
         updatedAt: data.updatedAt instanceof Timestamp ? data.updatedAt.toMillis() : undefined,
+        completedAt: data.completedAt instanceof Timestamp ? data.completedAt.toMillis() : undefined,
       } as BookSettingsData
     })
   }
@@ -198,4 +208,110 @@ export async function deleteCustomVoice(
   await getUserCollection().doc(userWallet).update({
     customVoice: FieldValue.delete(),
   })
+}
+
+export async function incrementBookReadingTime(
+  userWallet: string,
+  nftClassId: string,
+  activeReadingTimeMs: number,
+  ttsActiveTimeMs: number,
+  options?: { countSession?: boolean },
+): Promise<void> {
+  const userDocRef = getUserCollection().doc(userWallet)
+  const bookDocRef = userDocRef.collection('books').doc(nftClassId.toLowerCase())
+
+  const batch = getFirestoreDb().batch()
+
+  batch.set(userDocRef, {
+    totalReadingTimeMs: FieldValue.increment(activeReadingTimeMs),
+    totalTTSListeningTimeMs: FieldValue.increment(ttsActiveTimeMs),
+  }, { merge: true })
+
+  batch.set(bookDocRef, {
+    totalReadingTimeMs: FieldValue.increment(activeReadingTimeMs),
+    totalTTSListeningTimeMs: FieldValue.increment(ttsActiveTimeMs),
+    ...(options?.countSession && { sessionCount: FieldValue.increment(1) }),
+    updatedAt: FieldValue.serverTimestamp(),
+  }, { merge: true })
+
+  await batch.commit()
+}
+
+export async function updateReadingStreak(
+  userWallet: string,
+): Promise<void> {
+  const userDocRef = getUserCollection().doc(userWallet)
+
+  await getFirestoreDb().runTransaction(async (transaction) => {
+    const doc = await transaction.get(userDocRef)
+    const data = doc.data()
+    const streak = data?.readingStreak || { currentDays: 0, longestDays: 0, lastActiveDate: '' }
+
+    const now = new Date()
+    const today = now.toISOString().split('T')[0]
+    if (streak.lastActiveDate === today) return
+
+    const yesterday = new Date(now)
+    yesterday.setUTCDate(yesterday.getUTCDate() - 1)
+    const yesterdayStr = yesterday.toISOString().split('T')[0]
+
+    let newCurrentDays: number
+    if (streak.lastActiveDate === yesterdayStr) {
+      newCurrentDays = (streak.currentDays || 0) + 1
+    }
+    else {
+      newCurrentDays = 1
+    }
+
+    const newLongestDays = Math.max(newCurrentDays, streak.longestDays || 0)
+
+    transaction.set(userDocRef, {
+      readingStreak: {
+        currentDays: newCurrentDays,
+        longestDays: newLongestDays,
+        lastActiveDate: today,
+      },
+    }, { merge: true })
+  })
+}
+
+export async function markBookCompleted(
+  userWallet: string,
+  nftClassId: string,
+): Promise<boolean> {
+  const bookDocRef = getUserCollection()
+    .doc(userWallet)
+    .collection('books')
+    .doc(nftClassId.toLowerCase())
+  const userDocRef = getUserCollection().doc(userWallet)
+
+  const isNewCompletion = await getFirestoreDb().runTransaction(async (transaction) => {
+    const doc = await transaction.get(bookDocRef)
+    if (doc.data()?.completedAt) return false
+    transaction.set(bookDocRef, {
+      completedAt: FieldValue.serverTimestamp(),
+    }, { merge: true })
+    transaction.set(userDocRef, {
+      totalBooksCompleted: FieldValue.increment(1),
+    }, { merge: true })
+    return true
+  })
+
+  return isNewCompletion
+}
+
+export async function incrementBookTTSCharacterUsage(
+  userWallet: string,
+  nftClassId: string,
+  charactersUsed: number,
+): Promise<void> {
+  const bookDocRef = getUserCollection()
+    .doc(userWallet)
+    .collection('books')
+    .doc(nftClassId.toLowerCase())
+
+  await bookDocRef.set({
+    ttsCharactersUsed: FieldValue.increment(charactersUsed),
+    updatedAt: FieldValue.serverTimestamp(),
+  }, { merge: true })
 }

--- a/types/book-settings.d.ts
+++ b/types/book-settings.d.ts
@@ -1,5 +1,6 @@
 export interface BookSettingsData extends BaseBookSettingsData {
   updatedAt?: number
+  completedAt?: number
 }
 
 export type BookSettingKey =


### PR DESCRIPTION
- Track active reading time, TTS listening time, pages viewed per session
- Idle detection (2min timeout) and tab visibility pausing
- Heartbeat every 5min + beacon flush on page close/unmount
- Server endpoints: POST /api/analytics/session and /heartbeat
- Firestore: reading time, streak, book completion (95% threshold)
- PubSub events: ReadingSession, BookCompleted for ES pipeline
- Per-book TTS character tracking via nft_class_id on TTS endpoint
- Future roadmap documented in docs/analytics-roadmap.md