### PR TITLE
🐛 Fix TTS playback failure on iOS Chrome

### DIFF
--- a/components/TTSPlayerModal.vue
+++ b/components/TTSPlayerModal.vue
@@ -227,9 +227,8 @@ import type { TTSPlayerModalProps } from './TTSPlayerModal.props'
 const { user } = useUserSession()
 const subscription = useSubscription()
 const { errorModal, handleError } = useErrorHandler()
-const toast = useToast()
 
-const { customVoice, hasCustomVoice, fetchCustomVoice } = useCustomVoice()
+const { customVoice, hasCustomVoice, isLoading: isCustomVoiceLoading, fetchCustomVoice } = useCustomVoice()
 const localeRoute = useLocaleRoute()
 
 const emit = defineEmits<{
@@ -308,15 +307,6 @@ const {
   bookLanguage: props.bookLanguage,
   customVoice,
   onError: (error: string | Event | MediaError) => {
-    if (error === TTS_ERROR_NOT_ALLOWED) {
-      toast.add({
-        title: $t('tts_play_blocked_title'),
-        description: $t('tts_play_blocked_description'),
-        icon: 'i-material-symbols-play-arrow-rounded',
-        color: 'warning',
-      })
-      return
-    }
     if (error instanceof MediaError
       && error.code === MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED
       && !user.value?.isLikerPlus) {
@@ -403,13 +393,12 @@ watch(currentTTSSegmentIndex, async (newIndex: number) => {
 })
 
 const hasStartedPlaying = ref(false)
-const isCustomVoiceReady = ref(!user.value)
 
 watch(
-  [() => props.segments, isCustomVoiceReady],
-  ([newSegments, ready]) => {
+  () => props.segments,
+  (newSegments) => {
     setTTSSegments(newSegments)
-    if (ready && newSegments.length > 0 && !hasStartedPlaying.value) {
+    if (newSegments.length > 0 && !hasStartedPlaying.value) {
       hasStartedPlaying.value = true
       startTextToSpeech(props.startIndex || 0)
     }
@@ -417,12 +406,11 @@ watch(
   { immediate: true },
 )
 
-onMounted(async () => {
+onMounted(() => {
   setTTSLanguageVoice(props.specificLanguageVoice)
-  if (user.value) {
-    await fetchCustomVoice()
+  if (user.value && !customVoice.value && !isCustomVoiceLoading.value) {
+    fetchCustomVoice()
   }
-  isCustomVoiceReady.value = true
 })
 
 function setSegmentRef(

--- a/composables/use-text-to-speech.ts
+++ b/composables/use-text-to-speech.ts
@@ -129,6 +129,12 @@ export function useTextToSpeech(options: TTSOptions = {}) {
     isTextToSpeechLoading.value = false
     console.warn('Audio playback error:', error)
 
+    if (error === TTS_ERROR_NOT_ALLOWED) {
+      stopTextToSpeech()
+      options.onError?.(error)
+      return
+    }
+
     // Check if this is a network error (require both error code AND offline status to avoid misjudgment)
     const isNetworkError = error instanceof MediaError
       && error.code === MediaError.MEDIA_ERR_NETWORK

--- a/composables/use-web-audio-player.ts
+++ b/composables/use-web-audio-player.ts
@@ -1,9 +1,6 @@
 const MAX_AUTO_RESUME_RETRIES = 3
 const STUCK_DETECTION_TIMEOUT_MS = 5000
 
-const SILENCE_WAV_DATA_URI
-  = 'data:audio/wav;base64,UklGRiYAAABXQVZFZm10IBAAAAABAAEARKwAABCxAgACABAAZGF0YQIAAAAAAA=='
-
 export function useWebAudioPlayer(): TTSAudioPlayer {
   const audioA = ref<HTMLAudioElement | null>(null)
   const audioB = ref<HTMLAudioElement | null>(null)
@@ -332,20 +329,6 @@ export function useWebAudioPlayer(): TTSAudioPlayer {
 
     dualMode = true
     ensureAudioPool()
-
-    const idle = getIdleAudio()
-    if (idle) {
-      idle.src = SILENCE_WAV_DATA_URI
-      idle.play()
-        ?.then(() => idle.pause())
-        ?.catch((err) => {
-          // AbortError is expected — playAtIndex() interrupts the silence priming
-          if (err instanceof DOMException && err.name === 'AbortError') return
-          console.error('Error priming audio element for dual mode:', err)
-          dualMode = false
-          console.warn('Dual audio element not supported, falling back to single element')
-        })
-    }
 
     playAtIndex(options.startIndex)
   }

--- a/pages/reader/epub.vue
+++ b/pages/reader/epub.vue
@@ -351,6 +351,13 @@ const localeRoute = useLocaleRoute()
 if (!hasLoggedIn.value) {
   await navigateTo(localeRoute({ name: 'account', query: route.query }))
 }
+
+const { customVoice, isLoading: isCustomVoiceLoading, fetchCustomVoice } = useCustomVoice()
+onMounted(() => {
+  if (hasLoggedIn.value && !customVoice.value && !isCustomVoiceLoading.value) {
+    fetchCustomVoice()
+  }
+})
 const toast = useToast()
 const { value: colorModeValue } = useColorModeSync()
 const { t: $t } = useI18n()

--- a/pages/reader/pdf.vue
+++ b/pages/reader/pdf.vue
@@ -41,6 +41,13 @@ if (!hasLoggedIn.value) {
   await navigateTo(localeRoute({ name: 'account', query: route.query }))
 }
 
+const { customVoice, isLoading: isCustomVoiceLoading, fetchCustomVoice } = useCustomVoice()
+onMounted(() => {
+  if (hasLoggedIn.value && !customVoice.value && !isCustomVoiceLoading.value) {
+    fetchCustomVoice()
+  }
+})
+
 const { t: $t } = useI18n()
 const nftStore = useNFTStore()
 const {


### PR DESCRIPTION
Remove idle audio element priming that consumed the user gesture before the real play() call. Short-circuit NotAllowedError to stop immediately instead of retrying without a gesture. Pre-fetch custom voice data in reader pages so the TTS modal can auto-play without an async gap.