### PR TITLE
🚸 Reorder deposit rewards UI to clarify claim button scope

### DIFF
--- a/pages/account/deposit.vue
+++ b/pages/account/deposit.vue
@@ -142,6 +142,34 @@
           </div>
         </div>
 
+        <!-- Claim Rewards Button -->
+        <div class="px-4 py-4">
+          <UButton
+            :label="(
+              isAutoRestakeEnabled
+                ? $t('governance_page_claim_rewards_and_restake')
+                : $t('governance_page_claim_rewards')
+            )"
+            color="primary"
+            size="lg"
+            block
+            :loading="isLoading"
+            :disabled="!isClaimRewardButtonEnabled"
+            @click="handleClaimRewards"
+          />
+
+          <div class="flex items-center justify-between mt-2">
+            <span
+              class="text-sm font-semibold"
+              v-text="$t('governance_page_auto_restake')"
+            />
+            <USwitch
+              v-model="isAutoRestakeEnabled"
+              @update:model-value="handleAutoRestakeSwitchChange"
+            />
+          </div>
+        </div>
+
         <!-- Legacy Rewards -->
         <div
           v-if="governanceData.hasLegacyReward.value"
@@ -168,35 +196,6 @@
               size="sm"
               :loading="isLoading"
               @click="handleClaimLegacyRewards"
-            />
-          </div>
-        </div>
-
-        <!-- Claim Rewards Button -->
-        <div class="px-4 py-4">
-          <UButton
-            :label="(
-              isAutoRestakeEnabledStorage
-                ? $t('governance_page_claim_rewards_and_restake')
-                : $t('governance_page_claim_rewards')
-            )"
-            color="primary"
-            size="lg"
-            block
-            :loading="isLoading"
-            :disabled="!isClaimRewardButtonEnabled"
-            @click="handleClaimRewards"
-          />
-
-          <!-- Auto Restake Checkbox -->
-          <div class="flex items-center justify-between mt-2">
-            <span
-              class="text-sm font-semibold"
-              v-text="$t('governance_page_auto_restake')"
-            />
-            <USwitch
-              v-model="isAutoRestakeEnabled"
-              @update:model-value="handleAutoRestakeSwitchChange"
             />
           </div>
         </div>


### PR DESCRIPTION
Move claim rewards button + auto-restake toggle directly below accumulated/estimated rewards, and push legacy rewards section to the bottom, so it's clear the auto-restake option only applies to current rewards.

<img width="1406" height="906" alt="image" src="https://github.com/user-attachments/assets/869dfa0d-9256-4787-938d-fdb783bc2007" />
