### PR TITLE
[TAS-5422] 🐛 Fix TTS error at chapter transitions with Azure voice

### DIFF
--- a/composables/use-web-audio-player.ts
+++ b/composables/use-web-audio-player.ts
@@ -247,6 +247,7 @@ export function useWebAudioPlayer(): TTSAudioPlayer {
     if (dualMode) {
       const idle = getIdleAudio()!
       const idleReady = idle.getAttribute('data-src') === targetSrc
+        && idle.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA
 
       if (idleReady) {
         swapSlots()


### PR DESCRIPTION
Check audio readyState before swapping to preloaded element, falling back to single-element mode when data hasn't buffered.