### PR TITLE
[TAS-5419] 🐛 Fix TTS chapter title showing "Unknown" from EPUB metadata

### DIFF
--- a/pages/reader/epub.vue
+++ b/pages/reader/epub.vue
@@ -896,7 +896,10 @@ async function extractTTSSegments(book: Book) {
         continue
       }
 
-      const chapterTitle = chapter.querySelector('title')?.textContent?.trim() || ''
+      const titleText = chapter.querySelector('title')?.textContent?.trim() || ''
+      const chapterTitle = (titleText && titleText.toLowerCase() !== 'unknown')
+        ? titleText
+        : chapter.querySelector('h1, h2, h3')?.textContent?.trim() || ''
       chapterTitles[section.index ?? 0] = chapterTitle
 
       const elements = Array.from(


### PR DESCRIPTION
Fall back to first heading element (h1/h2/h3) when the EPUB section <title> is missing or contains the generic "Unknown" value commonly set by Calibre-generated EPUBs.