### PR TITLE
[TAS-5421 🐛 Fix TTS resume playing unexpectedly after user pause

### DIFF
--- a/composables/use-web-audio-player.ts
+++ b/composables/use-web-audio-player.ts
@@ -219,6 +219,7 @@ export function useWebAudioPlayer(): TTSAudioPlayer {
   }
 
   function playAtIndex(index: number) {
+    active = true
     currentIndex = index
     errored = false
     stuckRetried = false
@@ -336,11 +337,17 @@ export function useWebAudioPlayer(): TTSAudioPlayer {
   function resume(): boolean {
     const audio = getActiveAudio()
     if (!audio) return false
-    audio.play()?.catch(handlePlayError)
+    active = true
+    audio.play()?.catch((e) => {
+      active = false
+      clearAutoResumeTimer()
+      handlePlayError(e)
+    })
     return true
   }
 
   function pause() {
+    active = false
     clearStuckTimer()
     clearAutoResumeTimer()
     audible = false


### PR DESCRIPTION
Disable auto-resume by setting active=false in pause() so the onpause handler's OS-interruption recovery does not re-trigger playback. Re-enable on resume/playAtIndex; revert on play rejection.