### PR TITLE
[TAS-5427] 💱 Support multi-currency for Plus subscription and gift checkout

### DIFF
--- a/components/PricingLimitedOfferAlert.vue
+++ b/components/PricingLimitedOfferAlert.vue
@@ -96,7 +96,7 @@
             />
             <span
               class="text-2xl laptop:text-4xl font-bold"
-              v-text="`$${price}`"
+              v-text="`$${convertedPrice}`"
             />
           </span>
         </template>
@@ -111,9 +111,9 @@
 import brushCircle from '~/assets/images/brush-circle.png'
 import { DEFAULT_TRIAL_PERIOD_DAYS, PAID_TRIAL_PRICE } from '~/constants/pricing'
 
-const { currency } = useSubscriptionPricing()
+const { currency, convertToDisplayCurrency } = useSubscriptionPricing()
 
-withDefaults(
+const props = withDefaults(
   defineProps<{
     isHidden?: boolean
     trialPeriodDays?: number
@@ -125,4 +125,6 @@ withDefaults(
     price: PAID_TRIAL_PRICE,
   },
 )
+
+const convertedPrice = computed(() => convertToDisplayCurrency(props.price))
 </script>

--- a/components/PricingPlanSelect.vue
+++ b/components/PricingPlanSelect.vue
@@ -159,6 +159,7 @@ const {
   hasMonthlyDiscount,
   hasYearlyDiscount,
   currency,
+  convertToDisplayCurrency,
 } = useSubscriptionPricing()
 
 const selectedPlan = defineModel({
@@ -183,7 +184,7 @@ const plans = computed(() => {
       hint = $t('plan_select_trial_for_price_hint', {
         days: props.trialPeriodDays,
         currency: currency.value,
-        price: props.trialPrice,
+        price: convertToDisplayCurrency(props.trialPrice),
       })
     }
 

--- a/components/UpsellPlusModal.vue
+++ b/components/UpsellPlusModal.vue
@@ -89,7 +89,7 @@ const emit = defineEmits<{
 
 const { t: $t } = useI18n()
 const route = useRoute()
-const { currency } = useSubscriptionPricing()
+const { currency, convertToDisplayCurrency } = useSubscriptionPricing()
 
 const selectedPlan = ref<SubscriptionPlan>('yearly')
 
@@ -122,7 +122,7 @@ const subscribeButtonLabel = computed(() => {
       if (isPaidTrial.value) {
         return $t('plus_subscribe_cta_trial_for_price', {
           days: props.trialPeriodDays,
-          price: props.trialPrice,
+          price: convertToDisplayCurrency(props.trialPrice),
           currency: currency.value,
         })
       }
@@ -134,7 +134,7 @@ const subscribeButtonLabel = computed(() => {
     if (isPaidTrial.value) {
       return $t('plus_subscribe_cta_trial_for_price', {
         days: props.trialPeriodDays,
-        price: props.trialPrice,
+        price: convertToDisplayCurrency(props.trialPrice),
         currency: currency.value,
       })
     }

--- a/composables/use-likecoin-session-api.ts
+++ b/composables/use-likecoin-session-api.ts
@@ -242,6 +242,7 @@ export function useLikeCoinSessionAPI() {
     mustCollectPaymentMethod,
     giftNFTClassId,
     from,
+    currency,
     referrer,
     utmCampaign,
     utmMedium,
@@ -260,6 +261,7 @@ export function useLikeCoinSessionAPI() {
     mustCollectPaymentMethod?: boolean
     giftNFTClassId?: string
     from?: string
+    currency?: string
     referrer?: string
     utmCampaign?: string
     utmMedium?: string
@@ -275,7 +277,7 @@ export function useLikeCoinSessionAPI() {
   }) {
     return fetch.value<FetchLikerPlusCheckoutLinkResponseData>(`/plus/new`, {
       method: 'POST',
-      query: { period, from },
+      query: { period, from, currency },
       body: {
         trialPeriodDays,
         mustCollectPaymentMethod,
@@ -320,6 +322,7 @@ export function useLikeCoinSessionAPI() {
     giftInfo,
     coupon,
     from,
+    currency,
     referrer,
     utmCampaign,
     utmMedium,
@@ -341,6 +344,7 @@ export function useLikeCoinSessionAPI() {
     }
     coupon?: string
     from?: string
+    currency?: string
     referrer?: string
     utmCampaign?: string
     utmMedium?: string
@@ -355,7 +359,7 @@ export function useLikeCoinSessionAPI() {
   }) {
     return fetch.value<FetchLikerPlusCheckoutLinkResponseData>(`/plus/gift/new`, {
       method: 'POST',
-      query: { period, from },
+      query: { period, from, currency },
       body: {
         giftInfo,
         referrer,

--- a/composables/use-subscription-pricing.ts
+++ b/composables/use-subscription-pricing.ts
@@ -1,12 +1,26 @@
+import { convertUSDPriceToCurrency } from '~/utils/pricing'
+
 export default function useSubscriptionPricing() {
   const config = useRuntimeConfig()
   const { yearly, monthly } = config.public.subscription.pricing
-  const originalYearlyPrice = ref(Number(yearly.original))
-  const actualYearlyPrice = ref(Number(yearly.actual))
-  const originalMonthlyPrice = ref(Number(monthly.original))
-  const actualMonthlyPrice = ref(Number(monthly.actual))
+  const { displayCurrency } = usePaymentCurrency()
 
-  const currency = ref('US')
+  const originalYearlyPrice = computed(() => convertUSDPriceToCurrency(Number(yearly.original), displayCurrency.value))
+  const actualYearlyPrice = computed(() => convertUSDPriceToCurrency(Number(yearly.actual), displayCurrency.value))
+  const originalMonthlyPrice = computed(() => convertUSDPriceToCurrency(Number(monthly.original), displayCurrency.value))
+  const actualMonthlyPrice = computed(() => convertUSDPriceToCurrency(Number(monthly.actual), displayCurrency.value))
+
+  const currency = computed(() => {
+    switch (displayCurrency.value) {
+      case 'hkd': return 'HK'
+      case 'twd': return 'NT'
+      default: return 'US'
+    }
+  })
+
+  function convertToDisplayCurrency(usdPrice: number) {
+    return convertUSDPriceToCurrency(usdPrice, displayCurrency.value)
+  }
 
   const hasMonthlyDiscount = computed(() => actualMonthlyPrice.value < originalMonthlyPrice.value)
   const hasYearlyDiscount = computed(() => actualYearlyPrice.value < originalYearlyPrice.value)
@@ -26,6 +40,7 @@ export default function useSubscriptionPricing() {
     originalYearlyPrice: readonly(originalYearlyPrice),
     originalMonthlyPrice: readonly(originalMonthlyPrice),
     currency,
+    convertToDisplayCurrency,
     yearlyDiscountPercent,
     hasYearlyDiscount,
     hasMonthlyDiscount,

--- a/composables/use-subscription.ts
+++ b/composables/use-subscription.ts
@@ -18,6 +18,7 @@ export function useSubscription() {
   const isProcessingSubscription = ref(false)
 
   const { handleError } = useErrorHandler()
+  const { getCheckoutCurrency, displayCurrency } = usePaymentCurrency()
 
   const {
     monthlyPrice,
@@ -25,7 +26,7 @@ export function useSubscription() {
   } = useSubscriptionPricing()
 
   const paywallModalProps = ref<PaywallModalProps>({})
-  const currency = ref('USD')
+  const currency = computed(() => displayCurrency.value.toUpperCase())
   const PLUS_BOOK_PURCHASE_DISCOUNT = 0.2 // 20% discount
   const isLikerPlus = computed(() => {
     if (!hasLoggedIn.value) return false
@@ -193,6 +194,7 @@ export function useSubscription() {
         const { url } = await likeCoinSessionAPI.fetchLikerPlusCheckoutLink({
           period: subscribePlan,
           from: getRouteQuery('from'),
+          currency: getCheckoutCurrency(),
           trialPeriodDays,
           mustCollectPaymentMethod,
           giftNFTClassId: isYearly ? nftClassId : undefined,

--- a/pages/gift/plus/index.vue
+++ b/pages/gift/plus/index.vue
@@ -174,6 +174,7 @@ const { handleError } = useErrorHandler()
 const likeCoinSessionAPI = useLikeCoinSessionAPI()
 const { loggedIn: hasLoggedIn, user } = useUserSession()
 const accountStore = useAccountStore()
+const { getCheckoutCurrency } = usePaymentCurrency()
 
 useHead({
   title: $t('gift_plus_page_title'),
@@ -233,6 +234,7 @@ async function handleCheckout() {
         fromName: formData.fromName || undefined,
         message: formData.message || undefined,
       },
+      currency: getCheckoutCurrency(),
       utmCampaign: 'gift_plus',
       utmSource: 'website',
       utmMedium: 'web',


### PR DESCRIPTION
Pass currency setting to Plus checkout and gift checkout API calls. Display trial, monthly, and yearly pricing in local currency (USD/HKD/TWD) across PricingPlanSelect, UpsellPlusModal, and PricingLimitedOfferAlert.