### PR TITLE
🚸 Support prefilling registration email via query string

### DIFF
--- a/components/LoginPanel.vue
+++ b/components/LoginPanel.vue
@@ -101,8 +101,9 @@ const emit = defineEmits<{ connect: [{ id: string, email?: string }] }>()
 const { t: $t } = useI18n()
 const { connectors, error } = useConnect()
 const { isApp } = useAppDetection()
+const getRouteQuery = useRouteQuery()
 
-const emailInput = ref('')
+const emailInput = ref(getRouteQuery('email'))
 
 const isEmailValid = computed(() => validateEmail(emailInput.value.trim()))
 


### PR DESCRIPTION
Read `?email=` query param in LoginPanel to prefill the email input, so any page showing the login panel (claim page, login modal) can pre-populate the field without extra prop plumbing.