### PR TITLE
🚸 Show progressive status during login flow

### DIFF
--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -115,6 +115,8 @@
   "account_register_error_email_already_used_with_like_wallet": "{email} was bound to {likeWallet} and cannot be used to register a new account. Please migrate your account.",
   "account_register_error_invalid_account_id": "Account ID {id} is invalid.",
   "account_register_timeout": "Registration has timed out, please start again.",
+  "account_signing_in": "Signing in",
+  "account_verifying": "Verifying account",
   "affiliate_alert_description": "Recommended by {name} ✨",
   "amount_available": "Available: {amount}",
   "amount_input_confirm": "Confirm",

--- a/i18n/locales/zh-Hant.json
+++ b/i18n/locales/zh-Hant.json
@@ -115,6 +115,8 @@
   "account_register_error_email_already_used_with_like_wallet": "{email} 已綁定至 {likeWallet}，無法用作註冊新帳戶，請先遷移你的帳戶。",
   "account_register_error_invalid_account_id": "不接受 {id} 為帳戶 ID。",
   "account_register_timeout": "註冊帳戶已逾時，請重新開始。",
+  "account_signing_in": "正在簽署",
+  "account_verifying": "正在驗證帳戶",
   "affiliate_alert_description": "{name} 推薦給你 ✨",
   "amount_available": "可使用：{amount}",
   "amount_input_confirm": "確認",

--- a/stores/account.ts
+++ b/stores/account.ts
@@ -431,7 +431,7 @@ export const useAccountStore = defineStore('account', () => {
 
       useLogEvent('login_wallet_connected', { method: connector.id })
 
-      blockingModal.open({ title: $t('account_logging_in') })
+      blockingModal.open({ title: $t('account_verifying') })
 
       const walletAddress = address.value
       if (status.value !== 'success' || !walletAddress) {
@@ -493,8 +493,10 @@ export const useAccountStore = defineStore('account', () => {
         2,
       )
 
+      blockingModal.patch({ title: $t('account_signing_in') })
       const signature = await signMessageAsync({ message })
 
+      blockingModal.patch({ title: $t('account_logging_in') })
       await $fetch('/api/login', {
         method: 'POST',
         body: {


### PR DESCRIPTION
Display distinct blocking modal messages for each login phase: verifying account → signing → logging in → success.