### PR TITLE
🐛 Fix TTS play button flashing during segment transitions

### DIFF
--- a/composables/use-text-to-speech.ts
+++ b/composables/use-text-to-speech.ts
@@ -108,8 +108,13 @@ export function useTextToSpeech(options: TTSOptions = {}) {
   })
 
   player.on('ended', () => {
-    isTextToSpeechPlaying.value = false
     consecutiveAudioErrors.value = 0
+    // Set loading before clearing playing so the UI never briefly shows
+    // the play button while the next segment is being fetched.
+    if (hasMoreTracks()) {
+      isTextToSpeechLoading.value = true
+    }
+    isTextToSpeechPlaying.value = false
     playNextElement()
   })
 


### PR DESCRIPTION
Set isTextToSpeechLoading before clearing isTextToSpeechPlaying in the ended handler so the UI stays in loading state instead of briefly showing the play button while the next segment loads.