### PR TITLE
[TAS-5462] 🐛 Fix TTS rate display desync when Safari forces 1.0x on stall

### DIFF
--- a/components/TTSPlayerModal.vue
+++ b/components/TTSPlayerModal.vue
@@ -287,7 +287,7 @@ const {
   activeTTSLanguageVoiceAvatar,
   activeTTSLanguageVoiceLabel,
   ttsPlaybackRateOptions,
-  ttsPlaybackRate,
+  effectivePlaybackRate,
   isTextToSpeechOn,
   isTextToSpeechPlaying,
   currentTTSSegment,
@@ -427,8 +427,8 @@ const sectionTitle = computed(() => {
 })
 
 const getTTSPlaybackRateLabel = computed(() => {
-  const rate = ttsPlaybackRate.value
-  return ttsPlaybackRateOptions.value.find(option => option.value === rate)?.label || ''
+  const rate = effectivePlaybackRate.value
+  return ttsPlaybackRateOptions.value.find(option => option.value === rate)?.label || `${rate}x`
 })
 
 const { t: $t } = useI18n()

--- a/composables/use-text-to-speech.ts
+++ b/composables/use-text-to-speech.ts
@@ -78,6 +78,9 @@ export function useTextToSpeech(options: TTSOptions = {}) {
   })))
 
   const ttsPlaybackRate = useStorage(getTTSConfigKeyWithSuffix(ttsConfigCacheKey.value, 'playback-rate'), DEFAULT_PLAYBACK_RATE)
+  // Effective rate tracks what the player is actually using (may differ from user preference
+  // when Safari forces a downgrade on stall). Used for UI display and Media Session.
+  const effectivePlaybackRate = ref(ttsPlaybackRate.value)
   const isShowTextToSpeechOptions = ref(false)
   const isTextToSpeechOn = ref(false)
   const isTextToSpeechPlaying = ref(false)
@@ -227,7 +230,7 @@ export function useTextToSpeech(options: TTSOptions = {}) {
       try {
         navigator.mediaSession.setPositionState({
           duration: pos.duration,
-          playbackRate: ttsPlaybackRate.value,
+          playbackRate: effectivePlaybackRate.value,
           position: pos.position,
         })
       }
@@ -238,6 +241,11 @@ export function useTextToSpeech(options: TTSOptions = {}) {
   }
 
   player.on('positionState', () => {
+    updatePositionState()
+  })
+
+  player.on('rateForced', (rate) => {
+    effectivePlaybackRate.value = rate
     updatePositionState()
   })
 
@@ -325,6 +333,7 @@ export function useTextToSpeech(options: TTSOptions = {}) {
   })
 
   watch(ttsPlaybackRate, (newRate) => {
+    effectivePlaybackRate.value = newRate
     player.setRate(newRate)
     useLogEvent('tts_playback_rate_change', {
       nft_class_id: nftClassId,
@@ -530,6 +539,7 @@ export function useTextToSpeech(options: TTSOptions = {}) {
     isTextToSpeechPlaying.value = false
     isTextToSpeechLoading.value = false
     isShowTextToSpeechOptions.value = false
+    effectivePlaybackRate.value = ttsPlaybackRate.value
 
     if (!isNativeBridge.value && 'mediaSession' in navigator) {
       navigator.mediaSession.playbackState = 'none'
@@ -553,6 +563,7 @@ export function useTextToSpeech(options: TTSOptions = {}) {
     ttsLanguageVoiceOptionsWithAvatars,
     ttsPlaybackRateOptions,
     ttsPlaybackRate,
+    effectivePlaybackRate,
     setTTSLanguageVoice,
     // Player-related properties
     isShowTextToSpeechOptions,

--- a/composables/use-web-audio-player.ts
+++ b/composables/use-web-audio-player.ts
@@ -21,6 +21,7 @@ export function useWebAudioPlayer(): TTSAudioPlayer {
   let errored = false
   let stuckTimer: ReturnType<typeof setTimeout> | null = null
   let stuckRetried = false
+  let rateWasForced = false
 
   const handlers: Partial<{ [K in keyof TTSAudioPlayerEvents]: TTSAudioPlayerEvents[K] }> = {}
 
@@ -108,7 +109,10 @@ export function useWebAudioPlayer(): TTSAudioPlayer {
       console.warn(`Audio playback stalled at ${currentRate}x`)
       if (audio.currentTime < 0.00001) {
         // Safari on iOS sometimes gets stuck at 0.000001 for rate > 1.0
+        rateWasForced = true
         audio.playbackRate = 1.0
+        audio.defaultPlaybackRate = 1.0
+        handlers.rateForced?.(1.0)
         if (active && !errored) {
           audio.play()?.catch(() => {})
         }
@@ -226,6 +230,12 @@ export function useWebAudioPlayer(): TTSAudioPlayer {
     audible = false
     clearStuckTimer()
     clearAutoResumeTimer()
+
+    if (rateWasForced) {
+      rateWasForced = false
+      handlers.rateForced?.(currentRate)
+    }
+
     ensureAudioPool()
 
     const element = segments[index]
@@ -365,6 +375,7 @@ export function useWebAudioPlayer(): TTSAudioPlayer {
 
   function stop() {
     active = false
+    rateWasForced = false
     clearStuckTimer()
     clearAutoResumeTimer()
     resetAudio()
@@ -375,6 +386,7 @@ export function useWebAudioPlayer(): TTSAudioPlayer {
   }
 
   function setRate(rate: number) {
+    rateWasForced = false
     currentRate = rate
     const act = getActiveAudio()
     if (act) {

--- a/types/tts-audio-player.d.ts
+++ b/types/tts-audio-player.d.ts
@@ -6,6 +6,7 @@ declare interface TTSAudioPlayerEvents {
   allEnded: () => void
   error: (error: string | Event | MediaError) => void
   positionState: (state: { position: number, duration: number }) => void
+  rateForced: (rate: number) => void
 }
 
 declare interface TTSAudioPlayer {


### PR DESCRIPTION
When Safari iOS stalls at playback rates > 1.0, the audio rate is temporarily forced to 1.0x. The UI now reflects this downgrade and auto-restores the user's chosen rate on the next segment.