### PR TITLE
[TAS-5425] 🐛 Fix CMS tag items not sorted by staking amount

### DIFF
--- a/pages/store/index.vue
+++ b/pages/store/index.vue
@@ -901,18 +901,17 @@ async function fetchTags() {
 
 async function fetchTagItems({ isRefresh = false } = {}) {
   const apiSortValue = mapTagIdToAPIStakingSortValue(isStakingTagId.value ? tagId.value : STAKING_TAG_DEFAULT)
-  const fetchPromises = [
-    // NOTE: Fetch staking books for sorting CMS tag items by staking
-    bookstoreStore.fetchStakingBooks(apiSortValue, { isRefresh, limit: 100 }).catch((error) => {
-      if (isStakingTagId.value) {
-        throw error
-      }
-    }),
-  ]
-  if (!isStakingTagId.value) {
-    fetchPromises.push(bookstoreStore.fetchCMSProductsByTagId(tagId.value, { isRefresh }))
+
+  if (isStakingTagId.value) {
+    await bookstoreStore.fetchStakingBooks(apiSortValue, { isRefresh, limit: 100 })
+    return
   }
-  await Promise.all(fetchPromises)
+
+  // Fetch staking books first so CMS tag items can be sorted by staking
+  await bookstoreStore.fetchStakingBooks(apiSortValue, { isRefresh, limit: 100 }).catch((error) => {
+    console.warn('[store] Failed to fetch staking data for CMS tag sorting:', error)
+  })
+  await bookstoreStore.fetchCMSProductsByTagId(tagId.value, { isRefresh })
 }
 
 async function fetchItems({ lazy = false, isRefresh = false } = {}) {

--- a/stores/bookstore.ts
+++ b/stores/bookstore.ts
@@ -370,7 +370,7 @@ export const useBookstoreStore = defineStore('bookstore', () => {
         stakingBooksMap.value[sortBy].items.push(...bookNFTs)
       }
 
-      stakingBooksMap.value[sortBy].offset = result.data.length <= limit ? undefined : result.pagination?.next_key?.toString()
+      stakingBooksMap.value[sortBy].offset = result.data.length < limit ? undefined : result.pagination?.next_key?.toString()
       stakingBooksMap.value[sortBy].hasFetched = true
     }
     finally {


### PR DESCRIPTION
Staking fetch errors were silently swallowed for CMS tags, causing all items to get 0 totalStaked and preserving Airtable view order. Also fix staking pagination off-by-one that could miss the last page.