### PR TITLE
[TAS-5409] 🚀 Add dual-TTL server cache for Airtable CMS store APIs

### DIFF
--- a/pages/store/index.vue
+++ b/pages/store/index.vue
@@ -743,7 +743,7 @@ const products = computed<BookstoreItemList>(() => {
 })
 
 const itemsCount = computed(() => products.value.items.length)
-const hasMoreItems = computed(() => !!products.value.nextItemsKey || !products.value.hasFetchedItems)
+const hasMoreItems = computed(() => !!products.value.nextItemsKey || !!products.value.mayHaveMore || !products.value.hasFetchedItems)
 
 const itemsForStructuredData = computed(() => products.value.items.slice(0, Math.min(20, itemsCount.value)))
 const structuredData = useStorePageStructuredData({

--- a/server/api/store/genre.get.ts
+++ b/server/api/store/genre.get.ts
@@ -9,11 +9,16 @@ export default defineEventHandler(async (event) => {
     const pageSize = Number((Array.isArray(query.limit) ? query.limit[0] : query.limit)) || 100
     const offset = (Array.isArray(query.offset) ? query.offset[0] : query.offset) || undefined
 
-    const result = await fetchAirtableCMSPublicationsByGenre(genre, {
-      pageSize,
-      offset,
-    })
-    setHeader(event, 'cache-control', 'public, max-age=60, stale-while-revalidate=600')
+    if (offset) {
+      setHeader(event, 'cache-control', 'no-store')
+      return await fetchAirtableCMSPublicationsByGenre(genre, { pageSize, offset })
+    }
+
+    const result = await fetchWithAirtableCache(
+      `genre:${genre}:${pageSize}`,
+      () => fetchAirtableCMSPublicationsByGenre(genre, { pageSize }),
+    )
+    setHeader(event, 'cache-control', 'public, max-age=60')
     return result
   }
   catch (error) {

--- a/server/api/store/genre.get.ts
+++ b/server/api/store/genre.get.ts
@@ -6,7 +6,7 @@ export default defineEventHandler(async (event) => {
   try {
     const query = await getValidatedQuery(event, createValidator(StoreGenreQuerySchema))
     const genre = (Array.isArray(query.q) ? query.q[0] : query.q)!
-    const pageSize = Number((Array.isArray(query.limit) ? query.limit[0] : query.limit)) || 100
+    const pageSize = Math.min(Math.max(1, Number((Array.isArray(query.limit) ? query.limit[0] : query.limit)) || 100), 100)
     const offset = (Array.isArray(query.offset) ? query.offset[0] : query.offset) || undefined
 
     if (offset) {

--- a/server/api/store/products.get.ts
+++ b/server/api/store/products.get.ts
@@ -8,11 +8,18 @@ export default defineEventHandler(async (event) => {
     const tagId = (Array.isArray(query.tag) ? query.tag[0] : query.tag) || 'latest'
     const pageSize = Number((Array.isArray(query.limit) ? query.limit[0] : query.limit)) || 100
     const offset = (Array.isArray(query.offset) ? query.offset[0] : query.offset) || undefined
-    const result = await fetchAirtableCMSProductsByTagId(tagId, {
-      pageSize,
-      offset,
-    })
-    setHeader(event, 'cache-control', 'public, max-age=60, stale-while-revalidate=600')
+
+    // Paginated requests always go live
+    if (offset) {
+      setHeader(event, 'cache-control', 'no-store')
+      return await fetchAirtableCMSProductsByTagId(tagId, { pageSize, offset })
+    }
+
+    const result = await fetchWithAirtableCache(
+      `products:${tagId}:${pageSize}`,
+      () => fetchAirtableCMSProductsByTagId(tagId, { pageSize }),
+    )
+    setHeader(event, 'cache-control', 'public, max-age=60')
     return result
   }
   catch (error) {

--- a/server/api/store/products.get.ts
+++ b/server/api/store/products.get.ts
@@ -6,7 +6,7 @@ export default defineEventHandler(async (event) => {
   try {
     const query = await getValidatedQuery(event, createValidator(StoreProductsQuerySchema))
     const tagId = (Array.isArray(query.tag) ? query.tag[0] : query.tag) || 'latest'
-    const pageSize = Number((Array.isArray(query.limit) ? query.limit[0] : query.limit)) || 100
+    const pageSize = Math.min(Math.max(1, Number((Array.isArray(query.limit) ? query.limit[0] : query.limit)) || 100), 100)
     const offset = (Array.isArray(query.offset) ? query.offset[0] : query.offset) || undefined
 
     // Paginated requests always go live

--- a/server/api/store/search.get.ts
+++ b/server/api/store/search.get.ts
@@ -6,7 +6,7 @@ export default defineEventHandler(async (event) => {
   try {
     const query = await getValidatedQuery(event, createValidator(StoreSearchQuerySchema))
     const searchTerm = (Array.isArray(query.q) ? query.q[0] : query.q)!
-    const pageSize = Number((Array.isArray(query.limit) ? query.limit[0] : query.limit)) || 100
+    const pageSize = Math.min(Math.max(1, Number((Array.isArray(query.limit) ? query.limit[0] : query.limit)) || 100), 100)
     const offset = (Array.isArray(query.offset) ? query.offset[0] : query.offset) || undefined
 
     const result = await fetchAirtableCMSPublicationsBySearchTerm(searchTerm, {

--- a/server/api/store/tags/index.get.ts
+++ b/server/api/store/tags/index.get.ts
@@ -7,11 +7,17 @@ export default defineEventHandler(async (event) => {
     const query = await getValidatedQuery(event, createValidator(StoreTagsQuerySchema))
     const pageSize = Number((Array.isArray(query.limit) ? query.limit[0] : query.limit)) || 100
     const offset = (Array.isArray(query.offset) ? query.offset[0] : query.offset) || undefined
-    const result = await fetchAirtableCMSTagsForAll({
-      pageSize,
-      offset,
-    })
-    setHeader(event, 'cache-control', 'public, max-age=3600, stale-while-revalidate=86400')
+
+    if (offset) {
+      setHeader(event, 'cache-control', 'no-store')
+      return await fetchAirtableCMSTagsForAll({ pageSize, offset })
+    }
+
+    const result = await fetchWithAirtableCache(
+      `tags:${pageSize}`,
+      () => fetchAirtableCMSTagsForAll({ pageSize }),
+    )
+    setHeader(event, 'cache-control', 'public, max-age=3600')
     return result
   }
   catch (error) {

--- a/server/api/store/tags/index.get.ts
+++ b/server/api/store/tags/index.get.ts
@@ -5,7 +5,7 @@ import { StoreTagsQuerySchema } from '~/server/schemas/store'
 export default defineEventHandler(async (event) => {
   try {
     const query = await getValidatedQuery(event, createValidator(StoreTagsQuerySchema))
-    const pageSize = Number((Array.isArray(query.limit) ? query.limit[0] : query.limit)) || 100
+    const pageSize = Math.min(Math.max(1, Number((Array.isArray(query.limit) ? query.limit[0] : query.limit)) || 100), 100)
     const offset = (Array.isArray(query.offset) ? query.offset[0] : query.offset) || undefined
 
     if (offset) {

--- a/server/utils/airtable.ts
+++ b/server/utils/airtable.ts
@@ -1,3 +1,49 @@
+const AIRTABLE_RECORDS_TTL = 86400 // 1 day
+const AIRTABLE_OFFSET_TTL = 120 // 2 minutes (Airtable offsets expire ~5 min)
+
+/**
+ * Dual-TTL cache for Airtable paginated responses.
+ * Records are cached with a long TTL; offset cursor and hasMore flag are cached separately.
+ * When offset expires, cached records are still served with hasMore to signal the client
+ * should refresh page 1 for a new cursor.
+ */
+export async function fetchWithAirtableCache<T>(
+  cacheKey: string,
+  fetcher: () => Promise<{ records: T[], offset?: string }>,
+): Promise<{ records: T[], offset?: string, hasMore: boolean }> {
+  const storage = useStorage('airtable')
+  const recordsKey = `${cacheKey}:records`
+  const offsetKey = `${cacheKey}:offset`
+  const hasMoreKey = `${cacheKey}:hasMore`
+
+  const [cachedRecords, cachedOffset, cachedHasMore] = await Promise.all([
+    storage.getItem<T[]>(recordsKey),
+    storage.getItem<string>(offsetKey),
+    storage.getItem<boolean>(hasMoreKey),
+  ])
+
+  if (cachedRecords) {
+    return {
+      records: cachedRecords,
+      offset: cachedOffset ?? undefined,
+      hasMore: cachedHasMore ?? !!cachedOffset,
+    }
+  }
+
+  const result = await fetcher()
+  const hasMore = !!result.offset
+
+  // Fire-and-forget cache writes
+  const logCacheError = (key: string) => (err: unknown) => console.error(`[airtable-cache] failed to write ${key}:`, err)
+  storage.setItem(recordsKey, result.records, { ttl: AIRTABLE_RECORDS_TTL }).catch(logCacheError(recordsKey))
+  storage.setItem(hasMoreKey, hasMore, { ttl: AIRTABLE_RECORDS_TTL }).catch(logCacheError(hasMoreKey))
+  if (result.offset) {
+    storage.setItem(offsetKey, result.offset, { ttl: AIRTABLE_OFFSET_TTL }).catch(logCacheError(offsetKey))
+  }
+
+  return { ...result, hasMore }
+}
+
 export function getAirtableCMSFetch() {
   const config = useRuntimeConfig()
   return $fetch.create({

--- a/shared/types/bookstore.d.ts
+++ b/shared/types/bookstore.d.ts
@@ -19,6 +19,7 @@ export interface BookstoreCMSProduct {
 export interface FetchBookstoreCMSProductsResponseData {
   records: Array<BookstoreCMSProduct>
   offset?: string
+  hasMore?: boolean
 }
 
 export interface BookstoreCMSTag {

--- a/stores/bookstore.ts
+++ b/stores/bookstore.ts
@@ -70,14 +70,14 @@ export const useBookstoreStore = defineStore('bookstore', () => {
 
     // If offset expired but more pages likely exist, re-fetch page 1 to get fresh offset
     const state = bookstoreCMSProductsByTagIdMap.value[tagId]
-    const needsOffsetRefresh = !isRefresh && state?.hasFetched && !state?.offset && state?.mayHaveMore
+    const shouldRefreshOffset = !isRefresh && state?.hasFetched && !state?.offset && state?.mayHaveMore
 
     // Bump ts so the retry bypasses the browser HTTP cache (same URL otherwise)
-    if (needsOffsetRefresh && state) {
+    if (shouldRefreshOffset && state) {
       state.ts = Date.now()
     }
 
-    if (!bookstoreCMSProductsByTagIdMap.value[tagId] || (isRefresh && !needsOffsetRefresh)) {
+    if (!bookstoreCMSProductsByTagIdMap.value[tagId] || (isRefresh && !shouldRefreshOffset)) {
       bookstoreCMSProductsByTagIdMap.value[tagId] = {
         items: [],
         isFetching: false,
@@ -88,13 +88,13 @@ export const useBookstoreStore = defineStore('bookstore', () => {
     }
     try {
       bookstoreCMSProductsByTagIdMap.value[tagId].isFetching = true
-      const fetchOffset = (isRefresh || needsOffsetRefresh) ? undefined : bookstoreCMSProductsByTagIdMap.value[tagId]?.offset
+      const fetchOffset = (isRefresh || shouldRefreshOffset) ? undefined : bookstoreCMSProductsByTagIdMap.value[tagId]?.offset
       const result = await fetchBookstoreCMSProductsByTagId(tagId, {
         offset: fetchOffset,
         ts: bookstoreCMSProductsByTagIdMap.value[tagId].ts,
       })
 
-      if (isRefresh || needsOffsetRefresh) {
+      if (isRefresh || shouldRefreshOffset) {
         bookstoreCMSProductsByTagIdMap.value[tagId].items = result.records
       }
       else {
@@ -102,7 +102,7 @@ export const useBookstoreStore = defineStore('bookstore', () => {
       }
       bookstoreCMSProductsByTagIdMap.value[tagId].offset = result.offset
       // After an offset-refresh attempt that still returns no offset, stop retrying
-      if (needsOffsetRefresh && !result.offset) {
+      if (shouldRefreshOffset && !result.offset) {
         bookstoreCMSProductsByTagIdMap.value[tagId].mayHaveMore = false
       }
       else {

--- a/stores/bookstore.ts
+++ b/stores/bookstore.ts
@@ -5,6 +5,7 @@ interface BookstoreCMSTagProducts {
   isFetching: boolean
   hasFetched: boolean
   offset?: string
+  mayHaveMore?: boolean
   ts?: number
 }
 
@@ -46,13 +47,17 @@ export const useBookstoreStore = defineStore('bookstore', () => {
 
   const bookstoreCMSProductsByTagIdMap = ref<Record<string, BookstoreCMSTagProducts>>({})
   const getBookstoreCMSProductsByTagId = computed(() => (tagId: string) => {
+    const state = bookstoreCMSProductsByTagIdMap.value[tagId]
     return {
-      items: bookstoreCMSProductsByTagIdMap.value[tagId]?.items || [],
-      isFetchingItems: bookstoreCMSProductsByTagIdMap.value[tagId]?.isFetching || false,
-      hasFetchedItems: bookstoreCMSProductsByTagIdMap.value[tagId]?.hasFetched || false,
-      nextItemsKey: bookstoreCMSProductsByTagIdMap.value[tagId]?.offset || undefined,
+      items: state?.items || [],
+      isFetchingItems: state?.isFetching || false,
+      hasFetchedItems: state?.hasFetched || false,
+      nextItemsKey: state?.offset || undefined,
+      mayHaveMore: state?.mayHaveMore || false,
     }
   })
+
+  const DEFAULT_PAGE_SIZE = 100
 
   async function fetchCMSProductsByTagId(tagId: string, {
     isRefresh = false,
@@ -62,7 +67,17 @@ export const useBookstoreStore = defineStore('bookstore', () => {
     if (bookstoreCMSProductsByTagIdMap.value[tagId]?.isFetching) {
       return
     }
-    if (!bookstoreCMSProductsByTagIdMap.value[tagId] || isRefresh) {
+
+    // If offset expired but more pages likely exist, re-fetch page 1 to get fresh offset
+    const state = bookstoreCMSProductsByTagIdMap.value[tagId]
+    const needsOffsetRefresh = !isRefresh && state?.hasFetched && !state?.offset && state?.mayHaveMore
+
+    // Bump ts so the retry bypasses the browser HTTP cache (same URL otherwise)
+    if (needsOffsetRefresh && state) {
+      state.ts = Date.now()
+    }
+
+    if (!bookstoreCMSProductsByTagIdMap.value[tagId] || (isRefresh && !needsOffsetRefresh)) {
       bookstoreCMSProductsByTagIdMap.value[tagId] = {
         items: [],
         isFetching: false,
@@ -73,18 +88,26 @@ export const useBookstoreStore = defineStore('bookstore', () => {
     }
     try {
       bookstoreCMSProductsByTagIdMap.value[tagId].isFetching = true
+      const fetchOffset = (isRefresh || needsOffsetRefresh) ? undefined : bookstoreCMSProductsByTagIdMap.value[tagId]?.offset
       const result = await fetchBookstoreCMSProductsByTagId(tagId, {
-        offset: isRefresh ? undefined : bookstoreCMSProductsByTagIdMap.value[tagId]?.offset,
+        offset: fetchOffset,
         ts: bookstoreCMSProductsByTagIdMap.value[tagId].ts,
       })
 
-      if (isRefresh) {
+      if (isRefresh || needsOffsetRefresh) {
         bookstoreCMSProductsByTagIdMap.value[tagId].items = result.records
       }
       else {
         bookstoreCMSProductsByTagIdMap.value[tagId].items.push(...result.records)
       }
       bookstoreCMSProductsByTagIdMap.value[tagId].offset = result.offset
+      // After an offset-refresh attempt that still returns no offset, stop retrying
+      if (needsOffsetRefresh && !result.offset) {
+        bookstoreCMSProductsByTagIdMap.value[tagId].mayHaveMore = false
+      }
+      else {
+        bookstoreCMSProductsByTagIdMap.value[tagId].mayHaveMore = result.hasMore ?? (!result.offset && result.records.length >= DEFAULT_PAGE_SIZE)
+      }
       bookstoreCMSProductsByTagIdMap.value[tagId].hasFetched = true
     }
     catch (error) {

--- a/types/bookstore.d.ts
+++ b/types/bookstore.d.ts
@@ -21,6 +21,7 @@ declare interface BookstoreItemList {
   isFetchingItems: boolean
   hasFetchedItems: boolean
   nextItemsKey: number | string | undefined
+  mayHaveMore?: boolean
 }
 
 declare interface BookstorePrice {


### PR DESCRIPTION
Cache first-page records (1 day) and offset cursors (2 min) separately to avoid Airtable rate limits while handling cursor expiry gracefully. Paginated requests always bypass cache. Client detects missing offset on full pages and re-fetches page 1 for a fresh cursor without flash.