### PR TITLE
📈 Add pageIndex tracking and parallelize session writes

### DIFF
--- a/composables/use-reading-session.ts
+++ b/composables/use-reading-session.ts
@@ -138,6 +138,7 @@ export function useReadingSession(options: ReadingSessionOptions) {
       endProgress: progress.value,
       readerType,
       chapterIndex: chapterIndex?.value,
+      pageIndex: pageIndex?.value,
     }
   }
 

--- a/pages/reader/pdf.vue
+++ b/pages/reader/pdf.vue
@@ -66,12 +66,14 @@ function updatePDFProgress(page: number) {
   const totalPages = loadedPDFDocument.value?.numPages || 1
   pdfProgress.value = Math.round((page / totalPages) * 100)
 }
+const currentPageIndex = ref(1)
 const { isTTSPlaying } = useTTSPlayingState()
 useReadingSession({
   nftClassId,
   readerType: 'pdf',
   progress: pdfProgress,
   isTextToSpeechPlaying: isTTSPlaying,
+  pageIndex: currentPageIndex,
 })
 
 const fileBuffer = ref<ArrayBuffer | null>(null)
@@ -79,7 +81,6 @@ const isPDFReady = ref(false)
 const loadedPDFDocument = shallowRef<PDFDocumentProxy>()
 const isTTSExtracting = ref(false)
 const activeTTSElementIndex = ref<number | undefined>()
-const currentPageIndex = ref(1)
 const pdfReaderRef = ref()
 
 const { setTTSSegments, setChapterTitles, openPlayer } = useTTSPlayerModal({

--- a/server/api/analytics/session.post.ts
+++ b/server/api/analytics/session.post.ts
@@ -18,17 +18,14 @@ export default defineEventHandler(async (event) => {
     endProgress,
     readerType,
     chapterIndex,
+    pageIndex,
   } = body
 
   const hasActivity = activeReadingTimeMs > 0 || ttsActiveTimeMs > 0
 
-  if (hasActivity) {
-    // Run batch write first to avoid Firestore transaction contention on user doc
-    await incrementBookReadingTime(wallet, nftClassId, activeReadingTimeMsDelta, ttsActiveTimeMsDelta, { countSession: true })
-  }
-
   const tasks: Promise<unknown>[] = []
   if (hasActivity) {
+    tasks.push(incrementBookReadingTime(wallet, nftClassId, activeReadingTimeMsDelta, ttsActiveTimeMsDelta, { countSession: true }))
     tasks.push(updateReadingStreak(wallet))
   }
 
@@ -53,6 +50,7 @@ export default defineEventHandler(async (event) => {
       endProgress,
       readerType,
       chapterIndex,
+      pageIndex,
     })
 
     if (isNewCompletion) {

--- a/server/schemas/analytics.ts
+++ b/server/schemas/analytics.ts
@@ -49,6 +49,11 @@ export const ReadingSessionSchema = v.object({
     v.minValue(0, 'INVALID_CHAPTER_INDEX'),
     v.integer('INVALID_CHAPTER_INDEX'),
   )),
+  pageIndex: v.optional(v.pipe(
+    v.number('INVALID_PAGE_INDEX'),
+    v.minValue(0, 'INVALID_PAGE_INDEX'),
+    v.integer('INVALID_PAGE_INDEX'),
+  )),
 })
 
 export const HeartbeatSchema = v.object({


### PR DESCRIPTION
Wire pageIndex through client payload, server schema, and PubSub event so PDF readers report discrete page positions. Move incrementBookReadingTime into Promise.all to run concurrently with streak and completion updates.