### PR TITLE
💬 Use app_description for About page OG and closing statement

### DIFF
--- a/pages/about.vue
+++ b/pages/about.vue
@@ -717,6 +717,12 @@
           />
         </form>
       </section>
+
+      <USeparator />
+      <p
+        class="text-sm text-muted text-center leading-relaxed max-w-2xl mx-auto"
+        v-text="$t('app_description')"
+      />
     </div>
   </NuxtLayout>
 </template>
@@ -943,7 +949,7 @@ function onSubmitNewsletter() {
 }
 
 const pageTitle = computed(() => $t('about_page_title'))
-const pageDescription = computed(() => $t('about_page_hero_subtitle'))
+const pageDescription = computed(() => $t('app_description'))
 const canonicalURL = computed(() => `${baseURL}/about`)
 
 useHead({


### PR DESCRIPTION
Swap OG/meta description from hero subtitle to app_description for broader ecosystem positioning in search and social previews. Add the same mission statement as a quiet closing paragraph at the page bottom.