### PR TITLE
🚸 Improve mobile product page CTA and upsell modal clarity

### DIFF
--- a/components/UpsellPlusModal.vue
+++ b/components/UpsellPlusModal.vue
@@ -45,8 +45,9 @@
     <template #footer>
       <UButton
         :label="$t('plus_subscribe_cta_upsell_skip')"
-        variant="outline"
-        size="xl"
+        variant="ghost"
+        color="neutral"
+        size="lg"
         block
         :ui="{ base: 'cursor-pointer' }"
         @click="handleClose"
@@ -101,15 +102,19 @@ const isAllowYearlyTrial = computed(() => !props.nftClassId)
 const isPaidTrial = computed(() => props.trialPeriodDays && props.trialPeriodDays >= PAID_TRIAL_PERIOD_DAYS_THRESHOLD)
 
 const canGiftBook = computed(() => !!props.bookPrice && !!props.nftClassId)
-const isFreeBook = computed(() => !props.bookPrice)
+const isFreeBook = computed(() => props.bookPrice === 0)
 
 const yearlyDescription = computed(() => {
-  if (canGiftBook.value) return $t('upsell_plus_plan_yearly_gift_book')
+  if (canGiftBook.value) {
+    return $t('upsell_plus_plan_yearly_gift_book')
+  }
   return undefined
 })
 
 const monthlyDescription = computed(() => {
-  if (!isFreeBook.value) return $t('upsell_plus_plan_monthly_discount_book')
+  if (!isFreeBook.value) {
+    return $t('upsell_plus_plan_monthly_discount_book')
+  }
   return undefined
 })
 

--- a/components/UpsellPlusModal.vue
+++ b/components/UpsellPlusModal.vue
@@ -45,9 +45,8 @@
     <template #footer>
       <UButton
         :label="$t('plus_subscribe_cta_upsell_skip')"
-        variant="ghost"
-        color="neutral"
-        size="lg"
+        variant="soft"
+        size="xl"
         block
         :ui="{ base: 'cursor-pointer' }"
         @click="handleClose"

--- a/composables/use-subscription-modal.ts
+++ b/composables/use-subscription-modal.ts
@@ -98,8 +98,8 @@ export function useSubscriptionModal() {
     if (props.nftClassId) {
       if (shownUpsellClassIds.value.includes(props.nftClassId)) return
     }
-    else {
-      if (hasShownGenericUpsell.value) return
+    else if (hasShownGenericUpsell.value) {
+      return
     }
     if (upsellPlusModal.isOpen) {
       upsellPlusModal.close()

--- a/composables/use-subscription-modal.ts
+++ b/composables/use-subscription-modal.ts
@@ -89,10 +89,18 @@ export function useSubscriptionModal() {
     paywallModal.close()
   }
 
-  const hasShownUpsellThisSession = useSessionStorage('3ook_upsell_plus_shown', false)
+  const shownUpsellClassIds = useSessionStorage<string[]>('3ook_upsell_plus_shown_ids', [])
+  const hasShownGenericUpsell = useSessionStorage('3ook_upsell_plus_shown', false)
 
   async function openUpsellPlusModalIfEligible(props: UpsellPlusModalProps = {}) {
-    if (hasShownUpsellThisSession.value) return
+    // Per-book dedup: allow showing upsell for different books in the same session
+    // For non-book contexts (no nftClassId), fall back to once-per-session
+    if (props.nftClassId) {
+      if (shownUpsellClassIds.value.includes(props.nftClassId)) return
+    }
+    else {
+      if (hasShownGenericUpsell.value) return
+    }
     if (upsellPlusModal.isOpen) {
       upsellPlusModal.close()
     }
@@ -111,7 +119,12 @@ export function useSubscriptionModal() {
         ...getUpsellPlusModalProps(),
         nftClassId,
       }
-      hasShownUpsellThisSession.value = true
+      if (props.nftClassId) {
+        shownUpsellClassIds.value = [...shownUpsellClassIds.value, props.nftClassId]
+      }
+      else {
+        hasShownGenericUpsell.value = true
+      }
       useLogEvent('upsell_plus_modal_open')
       return upsellPlusModal.open(upsellModalProps).result
     }

--- a/doc/plan/plus-conversion-improvement.md
+++ b/doc/plan/plus-conversion-improvement.md
@@ -1,0 +1,153 @@
+# UI/UX Improvement Plan for Plus Conversion
+
+## Progress
+
+| Phase | Status | Date |
+|-------|--------|------|
+| Phase 1: Mobile Product Page CTA | ✅ Done | 2026-03-17 |
+| Phase 2: Upsell Modal Clarity | ✅ Done | 2026-03-17 |
+| Phase 3: TTS Paywall Softening | 🔲 Not started | — |
+| Phase 4: Trial Engagement & Retention | 🔲 Not started | — |
+| Phase 5: About Page Optimization | 🔲 Not started (data-dependent) | — |
+
+### Phase 1 & 2 Changes
+- Pricing card rendered above tabs on mobile via `order-first tablet:order-none`
+- Sticky bottom bar enhanced with edition pills, gift/wishlist icon buttons
+- Upsell modal copy clarified: concrete savings amounts, loss-framing skip button
+- Skip button de-emphasized (ghost variant, smaller)
+- Upsell dedup changed from once-per-session to per-book (with generic fallback)
+- Note: Intercom already syncs all analytics events and can trigger automations on `start_trial`, `upsell_plus_modal_open`, etc. Phase 4.2 in-app nudge should coordinate with existing Intercom Series to avoid duplicate messaging.
+
+---
+
+## Context
+
+PostHog data (90 days) reveals critical conversion gaps:
+- **Mobile view→cart: 4.0%** vs Desktop 9.4% (84% of traffic is mobile)
+- **Upsell modal: 92.5% skip rate** (704 shown → 51 clicked)
+- **Trial→paid: 1.7%** (FB Ads) / 0% (organic) — nearly all trialists churn
+- **End-to-end Plus: 0.17%** — 1,153 sign-ups → 2 paid subscribers
+
+The upsell modal during book purchase offers three paths:
+- **Yearly (no trial):** Get this book **free** + Plus subscription
+- **Trial (7-day free):** Get **20% off** this book + try Plus features
+- **Skip:** Buy the book at full price
+
+---
+
+## Phase 1: Mobile Product Page CTA (~1-2 days)
+
+**Files to modify:**
+- `pages/store/[nftClassId]/index.vue` (template restructuring)
+
+### 1.1 Move pricing card above tabs on mobile
+The pricing sidebar (line ~331) sits after all book info on mobile due to `flex-col` layout. Add responsive ordering so it renders first on mobile:
+- Add `order-first tablet:order-none` to the pricing sidebar container
+- Keeps desktop layout unchanged (sidebar right)
+
+### 1.2 Enhance sticky bottom bar with edition selector
+The fixed bottom bar (lines ~601-660) currently shows only price + buy button. Users must scroll up to change editions.
+- Add compact edition pills/dropdown to the `<aside>` sticky bar
+- Use existing `pricingItems` computed and `selectedPricingItemIndex` ref
+- Reuse existing `PricingItemSelector` component or create inline pills
+
+### 1.3 Add gift/wishlist to sticky bar
+Gift + wishlist buttons (lines ~516-543) are in the sidebar, invisible on mobile. Add icon-only versions to the sticky bar.
+
+**Verify:** Check mobile `view_item` → `add_to_cart` rate improvement over 2 weeks.
+
+---
+
+## Phase 2: Upsell Modal Clarity (~2-3 days)
+
+**Files to modify:**
+- `components/UpsellPlusModal.vue` (copy + layout)
+- `composables/use-subscription-modal.ts` (session logic)
+- `i18n/locales/en.json`, `i18n/locales/zh-Hant.json` (translations)
+
+### 2.1 Clarify yearly value prop
+Current button text "Gift this book + Plus" is confusing — "gift" implies giving to someone else.
+- Change to clearly communicate: "Get this book free with yearly Plus" or similar
+- Update i18n keys for both locales
+- Make yearly the visually emphasized/default option since it has the strongest incentive
+
+### 2.2 Clarify trial value prop
+The 20% book discount is the main trial hook during purchase, but it's buried in button text.
+- Show the discount amount explicitly: "Save $X on this book" with the actual dollar savings
+- Show trial benefits list: 20% off this book, AI narration, dark mode, custom voices
+- Clarify what trial doesn't include vs yearly (no free book)
+
+### 2.3 Relax once-per-session limit
+`hasShownUpsellThisSession` (line 92 of `use-subscription-modal.ts`) blocks re-triggering. Users who skip on one book never see the offer for different books.
+- Change from `useSessionStorage` to track per-book: `useSessionStorage('3ook_upsell_shown_${nftClassId}')`
+- Or use a cooldown (e.g., 10 minutes) instead of permanent session block
+
+**Verify:** Check `upsell_plus_modal_open` → `subscription_button_click` (store page) rate.
+
+---
+
+## Phase 3: TTS Paywall Softening (~1-2 days)
+
+**Files to modify:**
+- `composables/use-text-to-speech.ts` (pre-warning logic)
+- `components/TTSPlayerModal.vue` (lines ~317-342, paywall trigger)
+
+### 3.1 Add pre-limit warning
+Before the `NotSupportedError` fires, show a toast warning:
+- Track segments played, show toast at N-2 before limit
+- Requires understanding how the free limit is enforced (likely server-side when fetching audio)
+
+### 3.2 Replace abrupt paywall with explainer
+Current flow: audio stops → PaywallModal opens immediately (web). Change to:
+- Pause audio gracefully
+- Show inline message in the TTS player: "You've used your free AI narration allowance"
+- Show 20% discount incentive: "Subscribe to continue + get 20% off books"
+- Button: "Start free trial" / "See plans"
+- Don't auto-open PaywallModal — let user choose
+
+### 3.3 Align app and web experience
+Lines 330-335 (app) vs 337-341 (web) have different behavior. Both should use the same friendly flow.
+
+**Verify:** `tts_start` → `subscription_button_click` (reader page) rate.
+
+---
+
+## Phase 4: Trial Engagement & Retention (~3-5 days)
+
+**Files to modify:**
+- PostHog insights (no code)
+- New component for trial onboarding nudge
+- `likecoin-api-public` Stripe webhook (trial_will_end)
+
+### 4.1 Analyze trial engagement (PostHog only, no code)
+Create insight: for users with `start_trial`, count `tts_start`, `reading_session_start`, `shelf_open_book` within 7 days. Determine if trialists actually use Plus features.
+
+### 4.2 Trial onboarding nudge
+After `start_trial`, show a one-time card on shelf/account highlighting Plus features to try. Conditional on `user.isLikerPlus && likerPlus.currentType === 'trial'`.
+
+### 4.3 Trial ending awareness
+Add `customer.subscription.trial_will_end` Stripe webhook handler (in `likecoin-api-public`). Fire `trial_ending_soon` PostHog event. Display in-app banner 3 days before trial ends.
+
+**Verify:** `start_trial` → `subscribe` rate by channel.
+
+---
+
+## Phase 5: About Page Optimization (~1-2 days, data-dependent)
+
+Wait for 2+ weeks of About Page Analysis dashboard data, then:
+- Reorder sections by engagement (move highest-clicked features up)
+- Add trial CTA near high-engagement feature sections (especially AI narration if it leads)
+- A/B test hero CTA copy
+
+**Verify:** About Page CTA → Conversion Funnel insight.
+
+---
+
+## Execution Order
+
+Ship each phase independently, measure 1-2 weeks before next:
+1. **Phase 1** (mobile CTA) — highest ROI, lowest risk
+2. **Phase 2** (upsell modal) — second highest impact
+3. **Phase 3** (TTS paywall) — improves trial acquisition
+4. **Phase 4** (trial retention) — fixes trial→paid churn
+5. **Phase 5** (about page) — data-driven, last

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -538,9 +538,9 @@
   "plus_subscribe_cta_start_free_trial": "Start {days}-day free trial",
   "plus_subscribe_cta_trial_for_free": "Get {days} Days Free",
   "plus_subscribe_cta_trial_for_price": "Get {days} Days for {currency} ${price}",
-  "plus_subscribe_cta_upsell_skip": "Skip and continue to pay",
+  "plus_subscribe_cta_upsell_skip": "No thanks, pay full price",
   "plus_subscribe_cta_yearly": "Become an annual member",
-  "plus_subscribe_cta_yearly_gift": "Subscribe & get the book free",
+  "plus_subscribe_cta_yearly_gift": "Subscribe yearly — this book is free",
   "price_free": "Free",
   "pricing_page_description": "3ook.com — Read, Listen, Own. The 3rd-gen bookstore ecosystem. Become Plus member to listen to books with a custom voice, receive a free book of your choice and get 20% off on all titles.",
   "pricing_page_feature_1": "Custom voice narration — or create your own private voice actor",
@@ -802,6 +802,6 @@
   "upsell_plus_benefits_title": "Subscription Benefits",
   "upsell_plus_modal_title": "Become a Plus Member",
   "upsell_plus_plan_monthly_discount_book": "20% off this book",
-  "upsell_plus_plan_yearly_gift_book": "Get this book free",
+  "upsell_plus_plan_yearly_gift_book": "This book is included for free",
   "work_in_progress": "Work in progress"
 }

--- a/i18n/locales/zh-Hant.json
+++ b/i18n/locales/zh-Hant.json
@@ -538,9 +538,9 @@
   "plus_subscribe_cta_start_free_trial": "開始 {days} 日免費試用",
   "plus_subscribe_cta_trial_for_free": "取得 {days} 日免費",
   "plus_subscribe_cta_trial_for_price": "以 {currency} ${price} 體驗 {days} 天",
-  "plus_subscribe_cta_upsell_skip": "略過，繼續付款",
+  "plus_subscribe_cta_upsell_skip": "不用了，按原價購買",
   "plus_subscribe_cta_yearly": "成為年費會員",
-  "plus_subscribe_cta_yearly_gift": "訂閱兼得贈書",
+  "plus_subscribe_cta_yearly_gift": "年費訂閱，免費獲得本書",
   "price_free": "免費",
   "pricing_page_description": "3ook.com 第３代電子書店，可讀、可聽、可擁有。成為 Plus 會員，定制聲線，以粵語或國語聽書，獲贈自選電子書，享受八折購書等福利。",
   "pricing_page_feature_1": "定制聲線朗讀書籍，更可打造私人專屬聲優",
@@ -802,6 +802,6 @@
   "upsell_plus_benefits_title": "訂閱福利",
   "upsell_plus_modal_title": "成為 Plus 會員",
   "upsell_plus_plan_monthly_discount_book": "本書即享八折",
-  "upsell_plus_plan_yearly_gift_book": "即時獲贈本書",
+  "upsell_plus_plan_yearly_gift_book": "免費獲得本書",
   "work_in_progress": "即將推出"
 }

--- a/pages/store/[nftClassId]/index.vue
+++ b/pages/store/[nftClassId]/index.vue
@@ -95,7 +95,7 @@
         </div>
       </div>
 
-      <div class="order-last tablet:order-none">
+      <div :class="[!isStakingTabActive && 'order-last', 'tablet:order-none']">
         <UTabs
           v-if="infoTabItems.length"
           v-model="activeTabValue"
@@ -635,27 +635,27 @@
 
       <template v-else-if="pricingItems.length">
         <div class="flex flex-col gap-2 w-full">
-          <div
+          <UButtonGroup
             v-if="pricingItems.length > 1"
-            class="flex gap-1.5 overflow-x-auto"
+            size="xs"
           >
-            <button
-              v-for="(item, index) in pricingItems"
-              :key="item.name"
-              :class="[
-                'px-2.5 py-1 rounded-full text-xs font-medium whitespace-nowrap border transition-colors',
-                item.isSelected
-                  ? 'border-neutral-900 dark:border-neutral-300 bg-neutral-900 dark:bg-neutral-300 text-white dark:text-neutral-900'
-                  : 'border-neutral-300 dark:border-neutral-600 text-dimmed',
-                item.isSoldOut ? 'opacity-50' : 'cursor-pointer',
-              ]"
-              :aria-pressed="item.isSelected"
-              :disabled="item.isSoldOut"
-              @click="handlePricingItemClick(index)"
+            <UButton
+              :label="selectedPricingItem?.label"
+              color="neutral"
+              variant="outline"
+              :ui="{ base: 'cursor-default' }"
+            />
+            <UDropdownMenu
+              :items="stickyEditionDropdownItems"
             >
-              {{ item.label }}
-            </button>
-          </div>
+              <UButton
+                icon="i-material-symbols-arrow-drop-down"
+                color="neutral"
+                variant="outline"
+                class="cursor-pointer"
+              />
+            </UDropdownMenu>
+          </UButtonGroup>
           <div class="flex items-center justify-between">
             <span class="text-theme-cyan shrink-0">
               <span
@@ -1100,6 +1100,14 @@ const selectedPricingItem = computed(() => {
   return pricingItems.value[selectedPricingItemIndex.value]
 })
 const priceIndex = computed(() => selectedPricingItem.value?.index || 0)
+
+const stickyEditionDropdownItems = computed(() => {
+  return pricingItems.value.map((item, index) => ({
+    label: item.label,
+    disabled: item.isSoldOut,
+    onSelect: () => handlePricingItemClick(index),
+  }))
+})
 
 const bookName = computed(() => bookInfo.name.value)
 

--- a/pages/store/[nftClassId]/index.vue
+++ b/pages/store/[nftClassId]/index.vue
@@ -29,8 +29,8 @@
         </template>
       </UButton>
     </div>
-    <section class="flex flex-col tablet:flex-row gap-[32px] tablet:gap-[44px] w-full max-w-[1200px]">
-      <div class="grow pt-5">
+    <section class="grid grid-cols-1 tablet:grid-cols-[1fr_300px] laptop:grid-cols-[1fr_380px] gap-x-[44px] gap-y-0 w-full max-w-[1200px]">
+      <div class="pt-5">
         <AffiliateAlert class="mb-6" />
 
         <div class="flex flex-col laptop:flex-row gap-6 laptop:gap-8">
@@ -93,7 +93,9 @@
             </ul>
           </div>
         </div>
+      </div>
 
+      <div class="order-last tablet:order-none">
         <UTabs
           v-if="infoTabItems.length"
           v-model="activeTabValue"
@@ -328,7 +330,7 @@
         </UTabs>
       </div>
 
-      <div class="relative w-full tablet:max-w-[300px] laptop:max-w-[380px] shrink-0">
+      <div class="relative w-full tablet:row-span-2 tablet:col-start-2 tablet:row-start-1">
         <div class="sticky top-0 flex flex-col gap-4 tablet:pt-5">
           <template v-if="isStakingTabActive">
             <StakingControl
@@ -371,6 +373,8 @@
                       'ease-in-out',
                       { 'cursor-pointer': !item.isSoldOut },
                     ]"
+                    :aria-pressed="item.isSelected"
+                    :disabled="item.isSoldOut"
                     @click="handlePricingItemClick(index)"
                   >
                     <div class="relative shrink-0 w-[24px] h-[24px] flex items-center justify-center">
@@ -404,7 +408,7 @@
                       >
                         <span
                           class="font-semibold text-left"
-                          v-text="item.isAutoDeliver ? item.name : $t('product_page_edition_title', { name: item.name })"
+                          v-text="item.label"
                         />
                         <span
                           v-if="item.isSoldOut"
@@ -630,32 +634,81 @@
       </template>
 
       <template v-else-if="pricingItems.length">
-        <span class="text-theme-cyan">
-          <span
-            v-if="selectedPricingItem?.discountedPrice"
-            class="text-2xl font-semibold"
-            v-text="selectedPricingItem?.discountedPrice"
+        <div class="flex flex-col gap-2 w-full">
+          <div
+            v-if="pricingItems.length > 1"
+            class="flex gap-1.5 overflow-x-auto"
+          >
+            <button
+              v-for="(item, index) in pricingItems"
+              :key="item.name"
+              :class="[
+                'px-2.5 py-1 rounded-full text-xs font-medium whitespace-nowrap border transition-colors',
+                item.isSelected
+                  ? 'border-neutral-900 dark:border-neutral-300 bg-neutral-900 dark:bg-neutral-300 text-white dark:text-neutral-900'
+                  : 'border-neutral-300 dark:border-neutral-600 text-dimmed',
+                item.isSoldOut ? 'opacity-50' : 'cursor-pointer',
+              ]"
+              :aria-pressed="item.isSelected"
+              :disabled="item.isSoldOut"
+              @click="handlePricingItemClick(index)"
+            >
+              {{ item.label }}
+            </button>
+          </div>
+          <div class="flex items-center justify-between">
+            <span class="text-theme-cyan shrink-0">
+              <span
+                v-if="selectedPricingItem?.discountedPrice"
+                class="text-2xl font-semibold"
+                v-text="selectedPricingItem?.discountedPrice"
+              />
+              <PlusBadge
+                v-if="selectedPricingItem?.discountedPrice"
+                class="ml-1"
+              />
+              <span
+                v-else
+                class="text-2xl font-semibold"
+                v-text="selectedPricingItem?.originalPrice"
+              />
+            </span>
+            <div class="flex items-center gap-2">
+              <UButton
+                v-if="canBePurchased"
+                icon="i-material-symbols-featured-seasonal-and-gifts-rounded"
+                color="primary"
+                variant="outline"
+                size="sm"
+                :ui="{ base: 'cursor-pointer rounded-full p-1.5' }"
+                :aria-label="$t('product_page_gift_button_label')"
+                :title="$t('product_page_gift_button_label')"
+                @click="handleGiftButtonClick"
+              />
+              <UButton
+                :icon="isInBookList ? 'i-material-symbols-favorite-rounded' : 'i-material-symbols-favorite-outline-rounded'"
+                color="primary"
+                variant="outline"
+                size="sm"
+                :ui="{ base: 'cursor-pointer rounded-full p-1.5' }"
+                :loading="isCheckingBookList || isUpdatingBookList"
+                :aria-label="$t(isInBookList ? 'product_page_remove_from_book_list_button_label' : 'product_page_add_to_book_list_button_label')"
+                :title="$t(isInBookList ? 'product_page_remove_from_book_list_button_label' : 'product_page_add_to_book_list_button_label')"
+                @click="handleBookListButtonClickDebounced"
+              />
+            </div>
+          </div>
+          <UButton
+            v-bind="checkoutButtonProps"
+            class="cursor-pointer"
+            color="primary"
+            size="xl"
+            :loading="isPurchasing"
+            :disabled="!canBePurchased"
+            block
+            @click="handleStickyPurchaseButtonClick"
           />
-          <PlusBadge
-            v-if="selectedPricingItem?.discountedPrice"
-            class="ml-1"
-          />
-          <span
-            v-else
-            class="text-2xl font-semibold"
-            v-text="selectedPricingItem?.originalPrice"
-          />
-        </span>
-        <UButton
-          v-bind="checkoutButtonProps"
-          class="cursor-pointer max-w-[248px]"
-          color="primary"
-          size="xl"
-          :loading="isPurchasing"
-          :disabled="!canBePurchased"
-          block
-          @click="handleStickyPurchaseButtonClick"
-        />
+        </div>
       </template>
     </aside>
 
@@ -1034,6 +1087,7 @@ const pricingItems = computed(() => {
       const shouldShowDiscount = !from.value && isLikerPlus.value && item.price > 0
       return {
         ...item,
+        label: item.isAutoDeliver ? item.name : $t('product_page_edition_title', { name: item.name }),
         originalPrice: formatPrice(item.price),
         discountedPrice: shouldShowDiscount ? formatDiscountedPrice(item.price, PLUS_BOOK_PURCHASE_DISCOUNT) : null,
         isSelected: index === selectedPricingItemIndex.value,

--- a/pages/store/[nftClassId]/index.vue
+++ b/pages/store/[nftClassId]/index.vue
@@ -330,7 +330,7 @@
         </UTabs>
       </div>
 
-      <div class="relative w-full tablet:row-span-2 tablet:col-start-2 tablet:row-start-1">
+      <div class="relative w-full mt-6 tablet:mt-0 tablet:row-span-2 tablet:col-start-2 tablet:row-start-1">
         <div class="sticky top-0 flex flex-col gap-4 tablet:pt-5">
           <template v-if="isStakingTabActive">
             <StakingControl

--- a/pages/store/[nftClassId]/index.vue
+++ b/pages/store/[nftClassId]/index.vue
@@ -1,5 +1,11 @@
 <template>
-  <main class="items-center px-4 laptop:px-12 pb-[100px]">
+  <main
+    :class="[
+      'items-center',
+      'px-4 laptop:px-12',
+      pricingItems.length > 1 ? 'pb-[152px]' : 'pb-[120px]',
+    ]"
+  >
     <div
       :class="[
         'z-10',
@@ -29,7 +35,10 @@
         </template>
       </UButton>
     </div>
-    <section class="grid grid-cols-1 tablet:grid-cols-[1fr_300px] laptop:grid-cols-[1fr_380px] gap-x-[44px] gap-y-0 w-full max-w-[1200px]">
+
+    <!-- Main content -->
+    <section class="grid tablet:grid-cols-[1fr_300px] laptop:grid-cols-[1fr_380px] gap-x-[44px] w-full max-w-[1200px]">
+      <!-- Primary content column -->
       <div class="pt-5">
         <AffiliateAlert class="mb-6" />
 
@@ -95,260 +104,278 @@
         </div>
       </div>
 
-      <div :class="[!isStakingTabActive && 'order-last', 'tablet:order-none']">
-        <UTabs
-          v-if="infoTabItems.length"
-          v-model="activeTabValue"
-          :items="infoTabItems"
-          variant="link"
-          class="gap-6 w-full mt-[52px] tablet:mt-[80px]"
-          :unmount-on-hide="false"
-          :ui="{ list: 'gap-6 border-0', trigger: 'text-lg font-bold pb-0 px-0', indicator: 'border-1 dark:border-theme-cyan' }"
-        >
-          <template #description>
-            <ExpandableContent>
-              <div
-                class="markdown"
-                v-html="bookInfoDescriptionHTML"
-              />
-            </ExpandableContent>
-            <template v-if="bookInfo.descriptionSummary?.value">
-              <h3 class="text-lg font-semibold mt-8 mb-4">
-                {{ $t('product_page_description_summary_label') }}
-              </h3>
-              <ExpandableContent>
-                <div
-                  class="markdown"
-                  v-html="bookInfoDescriptionSummaryHTML"
-                />
-              </ExpandableContent>
-            </template>
-            <template v-if="bookInfo.bookReviewInfo.value?.url">
-              <h3 class="text-lg font-semibold mt-8 mb-4">
-                {{ $t('product_page_review_info_label') }}
-              </h3>
-              <NuxtLink
-                :to="bookReviewURLWithUTM"
-                target="_blank"
-                rel="noopener noreferrer"
-                class="inline-flex items-center text-sm text-primary hover:underline"
-                @click="handleBookReviewClick"
-              >
-                <UIcon
-                  name="i-material-symbols-book-outline-rounded"
-                  size="16"
-                />
-                <span class="mx-2">{{ bookInfo.bookReviewInfo.value?.title || $t('product_page_book_review_link_label') }}</span>
-                <UIcon
-                  name="i-material-symbols-open-in-new-rounded"
-                  size="14"
-                />
-              </NuxtLink>
-            </template>
-            <ul
-              v-if="bookInfo.genre.value || descriptionTags.length"
-              :class="[
-                'flex',
-                'flex-wrap',
-                'gap-x-2',
-                'gap-y-4',
-                'mt-[48px]',
-                { 'max-tablet:hidden': isStakingTabActive },
-              ]"
-            >
-              <li v-if="bookInfo.genre.value">
-                <UButton
-                  :label="bookInfo.localizedGenre.value"
-                  :to="localeRoute({
-                    name: 'store',
-                    query: {
-                      genre: bookInfo.genre.value,
-                      ll_medium: 'genre',
-                      ll_source: 'product-page',
-                    },
-                  })"
-                  variant="soft"
-                  :ui="{ base: 'rounded-full' }"
-                  @click="handleGenreClick"
-                />
-              </li>
-              <li
-                v-for="tag in descriptionTags"
-                :key="tag"
-              >
-                <UButton
-                  :label="tag"
-                  :to="localeRoute({
-                    name: 'store',
-                    query: {
-                      q: tag,
-                      ll_medium: `keyword-${tag}`,
-                      ll_source: 'product-page',
-                    },
-                  })"
-                  variant="soft"
-                  :ui="{ base: 'rounded-full' }"
-                  @click="handleKeywordClick(tag)"
-                />
-              </li>
-            </ul>
-          </template>
-
-          <template #author>
-            <ExpandableContent>
-              <div
-                class="markdown"
-                v-html="authorDescriptionHTML"
-              />
-            </ExpandableContent>
-          </template>
-
-          <template #table-of-contents>
-            <ExpandableContent>
-              <div
-                class="markdown"
-                v-html="tableOfContentsHTML"
-              />
-            </ExpandableContent>
-          </template>
-
-          <template #staking-info>
-            <div class="max-tablet:hidden space-y-4 text-highlighted">
-              <div class="grid grid-cols-1 tablet:grid-cols-3 gap-4">
-                <UCard :ui="{ body: 'p-4' }">
-                  <div class="text-center">
-                    <BalanceLabel
-                      class="text-2xl"
-                      :value="formattedTotalStake"
-                      :is-compact="true"
-                    />
-                    <div
-                      class="mt-1 text-sm text-muted"
-                      v-text="$t('staking_total_staked')"
-                    />
-                  </div>
-                </UCard>
-                <UCard :ui="{ body: 'p-4' }">
-                  <div class="text-center">
-                    <div
-                      class="text-2xl font-semibold"
-                      v-text="numberOfStakers.toLocaleString()"
-                    />
-                    <div
-                      class="mt-1 text-sm text-muted"
-                      v-text="$t('staking_total_stakers')"
-                    />
-                  </div>
-                </UCard>
-                <UCard
-                  v-if="hasLoggedIn"
-                  :ui="{ body: 'p-4' }"
-                >
-                  <div class="text-center">
-                    <BalanceLabel
-                      class="text-2xl"
-                      :value="formattedUserStake"
-                      :is-compact="true"
-                    />
-
-                    <div
-                      class="mt-1 text-sm text-muted"
-                      v-text="$t('staking_your_stake')"
-                    />
-                  </div>
-                </UCard>
-              </div>
-
-              <div
-                v-if="hasLoggedIn && pendingRewards > 0n"
-                class="mt-4"
-              >
-                <UCard :ui="{ body: 'p-4' }">
-                  <div class="flex justify-between items-center">
-                    <div>
-                      <BalanceLabel
-                        class="text-2xl"
-                        :value="formattedPendingRewards"
-                      />
-                      <div
-                        class="mt-1 text-sm text-muted"
-                        v-text="$t('staking_pending_rewards')"
-                      />
-                    </div>
-                    <UButton
-                      v-if="!isApp"
-                      :label="$t('staking_claim_rewards')"
-                      color="primary"
-                      variant="outline"
-                      :loading="isClaimingRewards"
-                      @click="handleClaimRewards"
-                    />
-                  </div>
-                </UCard>
-              </div>
-
-              <div class="mt-6">
-                <NuxtLink
-                  :to="localeRoute({ name: 'about', hash: '#curate-to-earn' })"
-                  class="inline-flex items-center gap-1 text-sm hover:underline"
-                >
-                  <UIcon
-                    name="i-material-symbols-help-outline-rounded"
-                    size="16"
-                  />
-                  <span>{{ $t('staking_learn_more') }}</span>
-                </NuxtLink>
-              </div>
-            </div>
-          </template>
-
-          <template #buyer-messages>
+      <UAccordion
+        v-if="infoTabItems.length"
+        v-model="activeTabValue"
+        class="col-start-1 max-laptop:col-span-full gap-6 w-full mt-[52px] tablet:mt-[80px]"
+        :items="infoTabItems"
+        :unmount-on-hide="false"
+        :ui="{
+          trigger: 'text-lg font-bold',
+          content: '[&>*:last-child]:pb-10',
+        }"
+      >
+        <template #description>
+          <ExpandableContent>
             <div
-              v-for="buyer in buyerMessages"
-              :key="buyer.txHash"
-              class="p-4"
+              class="markdown"
+              v-html="bookInfoDescriptionHTML"
+            />
+          </ExpandableContent>
+          <template v-if="bookInfo.descriptionSummary?.value">
+            <h3 class="text-lg font-semibold mt-8 mb-4">
+              {{ $t('product_page_description_summary_label') }}
+            </h3>
+            <ExpandableContent>
+              <div
+                class="markdown"
+                v-html="bookInfoDescriptionSummaryHTML"
+              />
+            </ExpandableContent>
+          </template>
+          <template v-if="bookInfo.bookReviewInfo.value?.url">
+            <h3 class="text-lg font-semibold mt-8 mb-4">
+              {{ $t('product_page_review_info_label') }}
+            </h3>
+            <NuxtLink
+              :to="bookReviewURLWithUTM"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="inline-flex items-center text-sm text-primary hover:underline"
+              @click="handleBookReviewClick"
             >
-              <div class="flex flex-col items-start gap-3">
-                <div class="flex items-center gap-2">
-                  <EntityItem
-                    :name="buyer.wallet"
-                    :wallet-address="buyer.wallet"
-                    :is-link-disabled="true"
+              <UIcon
+                name="i-material-symbols-book-outline-rounded"
+                size="16"
+              />
+              <span class="mx-2">{{ bookInfo.bookReviewInfo.value?.title || $t('product_page_book_review_link_label') }}</span>
+              <UIcon
+                name="i-material-symbols-open-in-new-rounded"
+                size="14"
+              />
+            </NuxtLink>
+          </template>
+          <ul
+            v-if="bookInfo.genre.value || descriptionTags.length"
+            :class="[
+              'flex',
+              'flex-wrap',
+              'gap-x-2',
+              'gap-y-4',
+              'mt-[48px]',
+              { 'max-tablet:hidden': isStakingTabActive },
+            ]"
+          >
+            <li v-if="bookInfo.genre.value">
+              <UButton
+                :label="bookInfo.localizedGenre.value"
+                :to="localeRoute({
+                  name: 'store',
+                  query: {
+                    genre: bookInfo.genre.value,
+                    ll_medium: 'genre',
+                    ll_source: 'product-page',
+                  },
+                })"
+                variant="soft"
+                :ui="{ base: 'rounded-full' }"
+                @click="handleGenreClick"
+              />
+            </li>
+            <li
+              v-for="tag in descriptionTags"
+              :key="tag"
+            >
+              <UButton
+                :label="tag"
+                :to="localeRoute({
+                  name: 'store',
+                  query: {
+                    q: tag,
+                    ll_medium: `keyword-${tag}`,
+                    ll_source: 'product-page',
+                  },
+                })"
+                variant="soft"
+                :ui="{ base: 'rounded-full' }"
+                @click="handleKeywordClick(tag)"
+              />
+            </li>
+          </ul>
+        </template>
+
+        <template #author>
+          <ExpandableContent>
+            <div
+              class="markdown"
+              v-html="authorDescriptionHTML"
+            />
+          </ExpandableContent>
+        </template>
+
+        <template #table-of-contents>
+          <ExpandableContent>
+            <div
+              class="markdown"
+              v-html="tableOfContentsHTML"
+            />
+          </ExpandableContent>
+        </template>
+
+        <template #staking-info>
+          <StakingControl
+            class="tablet:hidden"
+            :nft-class-id="nftClassId"
+            :is-control-hidden="isApp"
+          />
+          <div class="max-tablet:hidden space-y-4 text-highlighted">
+            <div class="grid grid-cols-1 tablet:grid-cols-3 gap-4">
+              <UCard :ui="{ body: 'p-4' }">
+                <div class="text-center">
+                  <BalanceLabel
+                    class="text-2xl"
+                    :value="formattedTotalStake"
+                    :is-compact="true"
                   />
-                  <p
-                    class="text-dimmed text-xs"
-                    v-text="new Date(buyer.timestamp).toLocaleString()"
+                  <div
+                    class="mt-1 text-sm text-muted"
+                    v-text="$t('staking_total_staked')"
                   />
                 </div>
+              </UCard>
+              <UCard :ui="{ body: 'p-4' }">
+                <div class="text-center">
+                  <div
+                    class="text-2xl font-semibold"
+                    v-text="numberOfStakers.toLocaleString()"
+                  />
+                  <div
+                    class="mt-1 text-sm text-muted"
+                    v-text="$t('staking_total_stakers')"
+                  />
+                </div>
+              </UCard>
+              <UCard
+                v-if="hasLoggedIn"
+                :ui="{ body: 'p-4' }"
+              >
+                <div class="text-center">
+                  <BalanceLabel
+                    class="text-2xl"
+                    :value="formattedUserStake"
+                    :is-compact="true"
+                  />
+
+                  <div
+                    class="mt-1 text-sm text-muted"
+                    v-text="$t('staking_your_stake')"
+                  />
+                </div>
+              </UCard>
+            </div>
+
+            <div
+              v-if="hasLoggedIn && pendingRewards > 0n"
+              class="mt-4"
+            >
+              <UCard :ui="{ body: 'p-4' }">
+                <div class="flex justify-between items-center">
+                  <div>
+                    <BalanceLabel
+                      class="text-2xl"
+                      :value="formattedPendingRewards"
+                    />
+                    <div
+                      class="mt-1 text-sm text-muted"
+                      v-text="$t('staking_pending_rewards')"
+                    />
+                  </div>
+                  <UButton
+                    v-if="!isApp"
+                    :label="$t('staking_claim_rewards')"
+                    color="primary"
+                    variant="outline"
+                    :loading="isClaimingRewards"
+                    @click="handleClaimRewards"
+                  />
+                </div>
+              </UCard>
+            </div>
+
+            <div class="mt-6">
+              <NuxtLink
+                :to="localeRoute({ name: 'about', hash: '#curate-to-earn' })"
+                class="inline-flex items-center gap-1 text-sm hover:underline"
+              >
+                <UIcon
+                  name="i-material-symbols-help-outline-rounded"
+                  size="16"
+                />
+                <span>{{ $t('staking_learn_more') }}</span>
+              </NuxtLink>
+            </div>
+          </div>
+        </template>
+
+        <template #buyer-messages>
+          <div
+            v-for="buyer in buyerMessages"
+            :key="buyer.txHash"
+            class="py-4"
+          >
+            <div class="flex flex-col items-start gap-3">
+              <div class="flex items-center gap-2">
+                <EntityItem
+                  :name="buyer.wallet"
+                  :wallet-address="buyer.wallet"
+                  :is-link-disabled="true"
+                />
                 <p
-                  class="text-highlighted whitespace-pre-wrap break-words"
-                  v-text="buyer.message"
+                  class="text-dimmed text-xs"
+                  v-text="new Date(buyer.timestamp).toLocaleString()"
                 />
               </div>
+              <p
+                class="text-highlighted whitespace-pre-wrap break-words"
+                v-text="buyer.message"
+              />
             </div>
-          </template>
-        </UTabs>
-      </div>
+          </div>
+        </template>
+      </UAccordion>
 
-      <div class="relative w-full mt-6 tablet:mt-0 tablet:row-span-2 tablet:col-start-2 tablet:row-start-1">
+      <!-- Sticky side panel -->
+      <div
+        :class="[
+          'relative',
+          'w-full',
+          'max-tablet:mt-6',
+          'row-start-2 tablet:row-start-1',
+          'tablet:row-span-2',
+          'tablet:col-start-2',
+        ]"
+      >
         <div class="sticky top-0 flex flex-col gap-4 tablet:pt-5">
-          <template v-if="isStakingTabActive">
-            <StakingControl
-              class="max-tablet:-mt-8"
-              :nft-class-id="nftClassId"
-              :is-control-hidden="isApp"
-            />
-          </template>
+          <StakingControl
+            v-if="isStakingTabActive"
+            class="max-tablet:hidden"
+            :nft-class-id="nftClassId"
+            :is-control-hidden="isApp"
+          />
 
-          <template v-else>
+          <div
+            :class="[
+              'flex',
+              { 'tablet:hidden': isStakingTabActive },
+              'flex-col',
+              'gap-4',
+            ]"
+          >
             <div
               v-if="pricingItems.length"
               class="bg-white dark:bg-neutral-900 space-y-6 p-4 pt-6 pb-8 rounded-lg shadow-[0px_10px_20px_0px_rgba(0,0,0,0.04)]"
             >
-              <ul
-                ref="pricing"
-                class="space-y-2"
-              >
+              <ul class="space-y-2">
                 <li
                   v-for="(item, index) in pricingItems"
                   :key="item.name"
@@ -528,7 +555,7 @@
                   :label="$t('product_page_gift_button_label')"
                   variant="outline"
                   color="primary"
-                  size="xl"
+                  size="lg"
                   leading-icon="i-material-symbols-featured-seasonal-and-gifts-rounded"
                   @click="handleGiftButtonClick"
                 />
@@ -538,14 +565,14 @@
                   :label="isInBookList ? $t('product_page_remove_from_book_list_button_label') : $t('product_page_add_to_book_list_button_label')"
                   variant="outline"
                   color="primary"
-                  size="xl"
+                  size="lg"
                   :leading-icon="isInBookList ? 'i-material-symbols-favorite-rounded' : 'i-material-symbols-favorite-outline-rounded'"
                   :loading="isCheckingBookList || isUpdatingBookList"
                   @click="handleBookListButtonClickDebounced"
                 />
               </div>
             </div>
-          </template>
+          </div>
 
           <ul class="flex justify-center items-center gap-2">
             <li
@@ -576,7 +603,7 @@
       class="w-full max-w-[1200px] mx-auto mt-16 laptop:mt-20"
     >
       <h2
-        class="text-theme-cyan text-lg font-bold"
+        class="text-lg font-bold"
         v-text="$t('product_page_related_books_title')"
       />
 
@@ -602,16 +629,16 @@
       </ul>
     </section>
 
+    <!-- Mobile sticky bottom bar -->
     <aside
+      v-if="isUserBookOwner || pricingItems.length"
       :class="[
         'fixed',
         'bottom-[56px]',
         'inset-x-0',
-        isPricingItemsVisible && !isUserBookOwner ? 'hidden' : 'flex',
-        'tablet:hidden',
-        'gap-4',
-        'justify-between',
-        'items-center',
+        'flex tablet:hidden',
+        'flex-col',
+        'gap-2',
         'mb-safe',
         'px-4',
         'py-3',
@@ -621,94 +648,98 @@
         'z-10',
       ]"
     >
-      <template v-if="isUserBookOwner">
+      <UButton
+        v-if="isUserBookOwner"
+        :label="$t('product_page_read_button_label')"
+        icon="i-material-symbols-auto-stories-outline-rounded"
+        class="cursor-pointer"
+        color="primary"
+        size="xl"
+        block
+        @click="handleReadButtonClick"
+      />
+
+      <template v-else-if="pricingItems.length">
+        <UButtonGroup
+          v-if="pricingItems.length > 1"
+          size="xs"
+        >
+          <UButton
+            :label="selectedPricingItem?.label"
+            color="neutral"
+            variant="outline"
+            :ui="{ base: 'cursor-default' }"
+          />
+          <UDropdownMenu
+            :items="stickyEditionDropdownItems"
+          >
+            <UButton
+              icon="i-material-symbols-arrow-drop-down"
+              color="neutral"
+              variant="outline"
+              class="cursor-pointer"
+            />
+          </UDropdownMenu>
+        </UButtonGroup>
+
+        <div class="flex items-center justify-between">
+          <span class="flex items-center gap-1 shrink-0">
+            <span
+              v-if="selectedPricingItem?.discountedPrice"
+              :class="[
+                { 'text-theme-cyan': selectedPricingItem?.discountedPrice },
+                'text-2xl',
+                'font-semibold',
+                'leading-none',
+              ]"
+              v-text="selectedPricingItem?.discountedPrice"
+            />
+            <span
+              :class="[
+                selectedPricingItem?.discountedPrice
+                  ? 'text-xs text-dimmed line-through'
+                  : 'text-2xl font-semibold',
+                'leading-none',
+              ]"
+              v-text="selectedPricingItem?.originalPrice"
+            />
+            <PlusBadge v-if="isLikerPlus && selectedPricingItem?.discountedPrice" />
+          </span>
+          <div class="flex items-center gap-2">
+            <UButton
+              v-if="canBePurchased"
+              icon="i-material-symbols-featured-seasonal-and-gifts-rounded"
+              color="primary"
+              variant="outline"
+              size="sm"
+              :ui="{ base: 'cursor-pointer rounded-full p-1.5' }"
+              :aria-label="$t('product_page_gift_button_label')"
+              :title="$t('product_page_gift_button_label')"
+              @click="handleGiftButtonClick"
+            />
+            <UButton
+              :icon="isInBookList ? 'i-material-symbols-favorite-rounded' : 'i-material-symbols-favorite-outline-rounded'"
+              color="primary"
+              variant="outline"
+              size="sm"
+              :ui="{ base: 'cursor-pointer rounded-full p-1.5' }"
+              :loading="isCheckingBookList || isUpdatingBookList"
+              :aria-label="$t(isInBookList ? 'product_page_remove_from_book_list_button_label' : 'product_page_add_to_book_list_button_label')"
+              :title="$t(isInBookList ? 'product_page_remove_from_book_list_button_label' : 'product_page_add_to_book_list_button_label')"
+              @click="handleBookListButtonClickDebounced"
+            />
+          </div>
+        </div>
         <UButton
-          :label="$t('product_page_read_button_label')"
-          icon="i-material-symbols-auto-stories-outline-rounded"
+          v-bind="checkoutButtonProps"
           class="cursor-pointer"
           color="primary"
           size="xl"
+          :loading="isPurchasing"
+          :disabled="!canBePurchased"
           block
-          @click="handleReadButtonClick"
+          @click="handleStickyPurchaseButtonClick"
         />
-      </template>
-
-      <template v-else-if="pricingItems.length">
-        <div class="flex flex-col gap-2 w-full">
-          <UButtonGroup
-            v-if="pricingItems.length > 1"
-            size="xs"
-          >
-            <UButton
-              :label="selectedPricingItem?.label"
-              color="neutral"
-              variant="outline"
-              :ui="{ base: 'cursor-default' }"
-            />
-            <UDropdownMenu
-              :items="stickyEditionDropdownItems"
-            >
-              <UButton
-                icon="i-material-symbols-arrow-drop-down"
-                color="neutral"
-                variant="outline"
-                class="cursor-pointer"
-              />
-            </UDropdownMenu>
-          </UButtonGroup>
-          <div class="flex items-center justify-between">
-            <span class="text-theme-cyan shrink-0">
-              <span
-                v-if="selectedPricingItem?.discountedPrice"
-                class="text-2xl font-semibold"
-                v-text="selectedPricingItem?.discountedPrice"
-              />
-              <PlusBadge
-                v-if="selectedPricingItem?.discountedPrice"
-                class="ml-1"
-              />
-              <span
-                v-else
-                class="text-2xl font-semibold"
-                v-text="selectedPricingItem?.originalPrice"
-              />
-            </span>
-            <div class="flex items-center gap-2">
-              <UButton
-                v-if="canBePurchased"
-                icon="i-material-symbols-featured-seasonal-and-gifts-rounded"
-                color="primary"
-                variant="outline"
-                size="sm"
-                :ui="{ base: 'cursor-pointer rounded-full p-1.5' }"
-                :aria-label="$t('product_page_gift_button_label')"
-                :title="$t('product_page_gift_button_label')"
-                @click="handleGiftButtonClick"
-              />
-              <UButton
-                :icon="isInBookList ? 'i-material-symbols-favorite-rounded' : 'i-material-symbols-favorite-outline-rounded'"
-                color="primary"
-                variant="outline"
-                size="sm"
-                :ui="{ base: 'cursor-pointer rounded-full p-1.5' }"
-                :loading="isCheckingBookList || isUpdatingBookList"
-                :aria-label="$t(isInBookList ? 'product_page_remove_from_book_list_button_label' : 'product_page_add_to_book_list_button_label')"
-                :title="$t(isInBookList ? 'product_page_remove_from_book_list_button_label' : 'product_page_add_to_book_list_button_label')"
-                @click="handleBookListButtonClickDebounced"
-              />
-            </div>
-          </div>
-          <UButton
-            v-bind="checkoutButtonProps"
-            class="cursor-pointer"
-            color="primary"
-            size="xl"
-            :loading="isPurchasing"
-            :disabled="!canBePurchased"
-            block
-            @click="handleStickyPurchaseButtonClick"
-          />
-        </div>
       </template>
     </aside>
 
@@ -761,7 +792,7 @@
 </template>
 
 <script setup lang="ts">
-import type { TabsItem } from '@nuxt/ui'
+import type { AccordionItem } from '@nuxt/ui'
 import MarkdownIt from 'markdown-it'
 
 const likeCoinSessionAPI = useLikeCoinSessionAPI()
@@ -1008,7 +1039,7 @@ const buyerMessages = computed(() => {
 })
 
 const infoTabItems = computed(() => {
-  const items: TabsItem[] = []
+  const items: AccordionItem[] = []
 
   if (bookInfo.description.value) {
     items.push({
@@ -1076,9 +1107,6 @@ function initializeTabFromHash() {
     }
   }
 }
-
-const pricingItemsElement = useTemplateRef<HTMLLIElement>('pricing')
-const isPricingItemsVisible = useElementVisibility(pricingItemsElement)
 
 const pricingItems = computed(() => {
   return bookInfo.pricingItems.value


### PR DESCRIPTION
<img width="365" height="685" alt="image" src="https://github.com/user-attachments/assets/e99d0b70-59e6-46a6-b5e0-88108bc4c5f9" />
<img width="348" height="189" alt="image" src="https://github.com/user-attachments/assets/1b3ef106-d6a6-4aad-bc75-3435e72bfea9" />

Moves purchase UI directly below title/tags, before description

- Move pricing card above tabs on mobile (order-first)
- Add edition pills, gift and wishlist icons to sticky bottom bar
- Show concrete savings amounts in upsell modal (not just percentages)
- Clarify yearly/skip button copy to reduce confusion
- De-emphasize skip button to reduce upsell skip rate
- Track upsell per-book instead of once-per-session