### PR TITLE
[TAS-4121] 🐛 Validate Magic session before contract writes and private key reveal

### DIFF
--- a/composables/use-contract-write.ts
+++ b/composables/use-contract-write.ts
@@ -1,0 +1,14 @@
+import { useWriteContract } from '@wagmi/vue'
+import type { Hash } from 'viem'
+
+export function useContractWrite() {
+  const { writeContractAsync: wagmiWriteContract } = useWriteContract()
+  const { ensureMagicSession } = useMagicSession()
+
+  async function writeContractAsync(params: Parameters<typeof wagmiWriteContract>[0]): Promise<Hash> {
+    await ensureMagicSession()
+    return wagmiWriteContract(params)
+  }
+
+  return { writeContractAsync }
+}

--- a/composables/use-like-collective-contract.ts
+++ b/composables/use-like-collective-contract.ts
@@ -1,5 +1,4 @@
 import { readContract } from '@wagmi/core'
-import { useWriteContract } from '@wagmi/vue'
 import type { Hash } from 'viem'
 
 import likeCollectiveABI from '~/contracts/like-collective.json'
@@ -7,7 +6,7 @@ import likeCollectiveABI from '~/contracts/like-collective.json'
 export const likeCollectiveAddress = '0x4506ac2dd1e9a470d92a3d1656e1a99c676e1c8e'
 
 export function useLikeCollectiveContract() {
-  const { writeContractAsync } = useWriteContract()
+  const { writeContractAsync } = useContractWrite()
   const { $wagmiConfig } = useNuxtApp()
   // TODO: Update address when deployed
 

--- a/composables/use-like-nft-class-contract.ts
+++ b/composables/use-like-nft-class-contract.ts
@@ -1,12 +1,11 @@
 import { readContract } from '@wagmi/core'
-import { useWriteContract } from '@wagmi/vue'
 import type { Hash } from 'viem'
 
 import likeCoinNFTClassABI from '~/contracts/like-nft-class.json'
 
 export function useLikeNFTClassContract() {
   const { $wagmiConfig } = useNuxtApp()
-  const { writeContractAsync } = useWriteContract()
+  const { writeContractAsync } = useContractWrite()
 
   async function fetchNFTClassMetadataById(nftClassId: string) {
     const nftClassMetadataURI = await readContract($wagmiConfig, {

--- a/composables/use-likecoin-contract.ts
+++ b/composables/use-likecoin-contract.ts
@@ -1,5 +1,4 @@
 import { readContract } from '@wagmi/core'
-import { useWriteContract } from '@wagmi/vue'
 import type { Hash } from 'viem'
 
 import likeCoinABI from '~/contracts/likecoin.json'
@@ -7,7 +6,7 @@ import likeCoinABI from '~/contracts/likecoin.json'
 export function useLikeCoinContract() {
   const config = useRuntimeConfig()
   const likeCoinAddress = config.public.likeCoinTokenAddress as `0x${string}`
-  const { writeContractAsync } = useWriteContract()
+  const { writeContractAsync } = useContractWrite()
   const { $wagmiConfig } = useNuxtApp()
 
   // Read functions

--- a/composables/use-magic-session.ts
+++ b/composables/use-magic-session.ts
@@ -1,0 +1,44 @@
+import { useConnect, useDisconnect } from '@wagmi/vue'
+import type { Magic } from 'magic-sdk'
+
+let pendingSessionCheck: Promise<void> | null = null
+
+export function useMagicSession() {
+  const { $wagmiConfig } = useNuxtApp()
+  const { connectAsync } = useConnect()
+  const { disconnectAsync } = useDisconnect()
+
+  async function doEnsureMagicSession() {
+    const currentKey = $wagmiConfig.state.current
+    const connector = currentKey
+      ? $wagmiConfig.state.connections.get(currentKey)?.connector
+      : undefined
+    if (!connector || connector.id !== 'magic' || !('getMagic' in connector)) return
+
+    let needsReauth = false
+    try {
+      const magic = await (connector as unknown as { getMagic: () => Promise<Magic> }).getMagic()
+      needsReauth = !(await magic.user.isLoggedIn())
+    }
+    catch {
+      needsReauth = true
+    }
+
+    if (needsReauth) {
+      await disconnectAsync()
+      await connectAsync({ connector, chainId: $wagmiConfig.chains[0].id })
+    }
+  }
+
+  async function ensureMagicSession() {
+    if (pendingSessionCheck) {
+      return pendingSessionCheck
+    }
+    pendingSessionCheck = doEnsureMagicSession().finally(() => {
+      pendingSessionCheck = null
+    })
+    return pendingSessionCheck
+  }
+
+  return { ensureMagicSession }
+}

--- a/composables/use-ve-like-contract.ts
+++ b/composables/use-ve-like-contract.ts
@@ -1,5 +1,4 @@
 import { readContract } from '@wagmi/core'
-import { useWriteContract } from '@wagmi/vue'
 import type { Hash } from 'viem'
 
 import veLikeABI from '~/contracts/ve-like.json'
@@ -8,7 +7,7 @@ import veLikeABI from '~/contracts/ve-like.json'
 export const veLikeAddress = '0xE55C2b91E688BE70e5BbcEdE3792d723b4766e2B'
 
 export function useVeLikeContract() {
-  const { writeContractAsync } = useWriteContract()
+  const { writeContractAsync } = useContractWrite()
   const { $wagmiConfig } = useNuxtApp()
 
   // Read functions

--- a/composables/use-ve-like-reward-contract.ts
+++ b/composables/use-ve-like-reward-contract.ts
@@ -1,11 +1,10 @@
 import { readContract } from '@wagmi/core'
-import { useWriteContract } from '@wagmi/vue'
 import type { Hash } from 'viem'
 
 import veLikeRewardABI from '~/contracts/ve-like-reward.json'
 
 export function useVeLikeRewardContract(contractAddress: Ref<string | null> | string) {
-  const { writeContractAsync } = useWriteContract()
+  const { writeContractAsync } = useContractWrite()
   const { $wagmiConfig } = useNuxtApp()
 
   // Read functions

--- a/stores/account.ts
+++ b/stores/account.ts
@@ -55,6 +55,7 @@ export const useAccountStore = defineStore('account', () => {
   const { getLikeCoinV3BookMigrationSiteURL } = useLikeCoinV3MigrationSite()
   const likeCoinSessionAPI = useLikeCoinSessionAPI()
 
+  const { ensureMagicSession } = useMagicSession()
   const loginModal = overlay.create(LoginModal)
   const registrationFormModal = overlay.create(RegistrationModal)
 
@@ -608,6 +609,7 @@ export const useAccountStore = defineStore('account', () => {
     }
 
     try {
+      await ensureMagicSession()
       const connector = connectors.find((c: { id: string }) => c.id === 'magic')
       if (!connector || !('getMagic' in connector)) {
         throw createError({


### PR DESCRIPTION
Add useMagicSession composable to check magic.user.isLoggedIn() and trigger re-auth when session expires. Centralize write contract calls through useContractWrite wrapper so all on-chain transactions are protected by session validation.