### PR TITLE
🐛 Handle expired Airtable offset cursors in store pagination

### DIFF
--- a/server/api/store/genre.get.ts
+++ b/server/api/store/genre.get.ts
@@ -31,6 +31,12 @@ export default defineEventHandler(async (event) => {
           message: 'INVALID_API_SECRET',
         })
       }
+      if (code === 422) {
+        throw createError({
+          status: 422,
+          message: 'OFFSET_EXPIRED',
+        })
+      }
     }
     console.error(error)
     throw createError({

--- a/server/api/store/products.get.ts
+++ b/server/api/store/products.get.ts
@@ -38,6 +38,12 @@ export default defineEventHandler(async (event) => {
           message: 'TAG_NOT_FOUND',
         })
       }
+      if (code === 422) {
+        throw createError({
+          status: 422,
+          message: 'OFFSET_EXPIRED',
+        })
+      }
     }
     console.error(error)
     throw createError({

--- a/server/api/store/search.get.ts
+++ b/server/api/store/search.get.ts
@@ -26,6 +26,12 @@ export default defineEventHandler(async (event) => {
           message: 'INVALID_API_SECRET',
         })
       }
+      if (code === 422) {
+        throw createError({
+          status: 422,
+          message: 'OFFSET_EXPIRED',
+        })
+      }
     }
     console.error(error)
     throw createError({

--- a/server/api/store/tags/index.get.ts
+++ b/server/api/store/tags/index.get.ts
@@ -36,6 +36,12 @@ export default defineEventHandler(async (event) => {
           message: type,
         })
       }
+      if (code === 422) {
+        throw createError({
+          status: 422,
+          message: 'OFFSET_EXPIRED',
+        })
+      }
     }
     console.error(error)
     throw createError({

--- a/stores/bookstore.ts
+++ b/stores/bookstore.ts
@@ -86,9 +86,9 @@ export const useBookstoreStore = defineStore('bookstore', () => {
         ts: getTimestampRoundedToMinute(),
       }
     }
+    const fetchOffset = (isRefresh || shouldRefreshOffset) ? undefined : bookstoreCMSProductsByTagIdMap.value[tagId]?.offset
     try {
       bookstoreCMSProductsByTagIdMap.value[tagId].isFetching = true
-      const fetchOffset = (isRefresh || shouldRefreshOffset) ? undefined : bookstoreCMSProductsByTagIdMap.value[tagId]?.offset
       const result = await fetchBookstoreCMSProductsByTagId(tagId, {
         offset: fetchOffset,
         ts: bookstoreCMSProductsByTagIdMap.value[tagId].ts,
@@ -111,6 +111,14 @@ export const useBookstoreStore = defineStore('bookstore', () => {
       bookstoreCMSProductsByTagIdMap.value[tagId].hasFetched = true
     }
     catch (error) {
+      // If a paginated request failed with expired offset, clear it and retry from page 1
+      if (fetchOffset && getErrorStatusCode(error) === 422) {
+        bookstoreCMSProductsByTagIdMap.value[tagId].offset = undefined
+        bookstoreCMSProductsByTagIdMap.value[tagId].mayHaveMore = true
+        bookstoreCMSProductsByTagIdMap.value[tagId].isFetching = false
+        // Must await so the finally block doesn't clobber isFetching mid-retry
+        return await fetchCMSProductsByTagId(tagId)
+      }
       // HACK: When `hasFetched` is placed inside the finally block, it will execute before `items` are updated.
       bookstoreCMSProductsByTagIdMap.value[tagId].hasFetched = true
       throw error


### PR DESCRIPTION
Server endpoints now return OFFSET_EXPIRED (422) instead of a generic 500 when Airtable rejects a stale cursor. Client auto-retries by clearing the offset and re-fetching page 1 for a fresh cursor.