### PR TITLE
🐛 Filter out Chinese "未知" placeholder in EPUB chapter titles

### DIFF
--- a/pages/reader/epub.vue
+++ b/pages/reader/epub.vue
@@ -952,7 +952,7 @@ async function extractTTSSegments(book: Book) {
       }
 
       const titleText = chapter.querySelector('title')?.textContent?.trim() || ''
-      const chapterTitle = (titleText && titleText.toLowerCase() !== 'unknown')
+      const chapterTitle = (titleText && titleText.toLowerCase() !== 'unknown' && titleText !== '未知')
         ? titleText
         : chapter.querySelector('h1, h2, h3')?.textContent?.trim() || ''
       chapterTitles[section.index ?? 0] = chapterTitle


### PR DESCRIPTION
Some EPUB files use "未知" (unknown) as the chapter title element text. Exclude it alongside the existing "unknown" check so TTS falls back to the first heading instead.