### PR TITLE
🚸 Add TTS buffering indicator and completion tracking

### DIFF
--- a/composables/use-native-audio-player.ts
+++ b/composables/use-native-audio-player.ts
@@ -34,9 +34,15 @@ export function useNativeAudioPlayer(isActive: Ref<boolean | undefined>): TTSAud
         if (detail.state === 'playing') {
           handlers.play?.()
         }
+        else if (detail.state === 'buffering') {
+          handlers.buffering?.()
+        }
         else if (detail.state === 'paused' || detail.state === 'stopped') {
           handlers.pause?.()
         }
+        break
+      case 'ended':
+        handlers.ended?.()
         break
       case 'trackChanged':
         if (typeof detail.index === 'number') {

--- a/composables/use-text-to-speech.ts
+++ b/composables/use-text-to-speech.ts
@@ -108,6 +108,10 @@ export function useTextToSpeech(options: TTSOptions = {}) {
     isTextToSpeechLoading.value = false
   })
 
+  player.on('buffering', () => {
+    isTextToSpeechLoading.value = true
+  })
+
   player.on('pause', () => {
     isTextToSpeechPlaying.value = false
   })
@@ -132,6 +136,7 @@ export function useTextToSpeech(options: TTSOptions = {}) {
 
   player.on('allEnded', () => {
     isTextToSpeechPlaying.value = false
+    isTextToSpeechLoading.value = false
     useLogEvent('tts_completed', { nft_class_id: nftClassId })
     options.onAllSegmentsPlayed?.()
   })
@@ -410,7 +415,6 @@ export function useTextToSpeech(options: TTSOptions = {}) {
   function playNextElement() {
     cancelPendingSkip()
     if (currentTTSSegmentIndex.value + 1 >= ttsSegments.value.length) {
-      options.onAllSegmentsPlayed?.()
       return
     }
     isTextToSpeechLoading.value = true

--- a/composables/use-web-audio-player.ts
+++ b/composables/use-web-audio-player.ts
@@ -68,6 +68,11 @@ export function useWebAudioPlayer(): TTSAudioPlayer {
       handlers.play?.()
     }
 
+    audio.onwaiting = () => {
+      if (audio !== getActiveAudio() || swapping) return
+      handlers.buffering?.()
+    }
+
     audio.onpause = () => {
       if (audio !== getActiveAudio() || swapping) return
       audible = false
@@ -160,6 +165,7 @@ export function useWebAudioPlayer(): TTSAudioPlayer {
     audio.load()
     audio.onplay = null
     audio.onplaying = null
+    audio.onwaiting = null
     audio.onpause = null
     audio.onended = null
     audio.onerror = null

--- a/types/tts-audio-player.d.ts
+++ b/types/tts-audio-player.d.ts
@@ -1,6 +1,7 @@
 declare interface TTSAudioPlayerEvents {
   play: () => void
   pause: () => void
+  buffering: () => void
   ended: () => void
   trackChanged: (index: number) => void
   allEnded: () => void


### PR DESCRIPTION
Show loading state when audio is buffering mid-playback, handle the ended event in native player, and log tts_completed analytics when all segments finish.