### PR TITLE
🔒 Add text signature verification to TTS endpoint

### DIFF
--- a/components/CustomVoiceUploadModal.vue
+++ b/components/CustomVoiceUploadModal.vue
@@ -416,6 +416,7 @@
 
 <script setup lang="ts">
 import type { CustomVoiceData } from '~/shared/types/custom-voice'
+import { computeTTSTextSig, TTS_PREVIEW_NFT_CLASS_ID } from '~/shared/utils/tts-sig'
 import customDefaultAvatar from '@/assets/images/voice-avatars/custom-default.jpg'
 
 const props = defineProps<{
@@ -429,6 +430,7 @@ const emit = defineEmits<{
 }>()
 
 const { t: $t, locale } = useI18n()
+const { user: sessionUser } = useUserSession()
 const { customVoice, isLoading, uploadCustomVoice, updateCustomVoiceInfo, removeCustomVoice } = useCustomVoice()
 
 const voiceName = ref(props.existingVoice?.voiceName || '')
@@ -686,10 +688,13 @@ async function confirmDelete() {
 
 function getTTSPreviewUrl(language: string): string {
   const text = PREVIEW_TEXT[language] || PREVIEW_TEXT['zh-HK'] || ''
+  const ttsKey = sessionUser.value?.ttsKey || sessionUser.value?.evmWallet || ''
   const params = new URLSearchParams({
     text,
     language,
     voice_id: 'custom',
+    nft_class_id: TTS_PREVIEW_NFT_CLASS_ID,
+    sig: computeTTSTextSig(ttsKey, TTS_PREVIEW_NFT_CLASS_ID, text),
     _t: previewCacheBuster.value.toString(),
   })
   return `/api/reader/tts?${params.toString()}`

--- a/composables/use-text-to-speech.ts
+++ b/composables/use-text-to-speech.ts
@@ -1,5 +1,6 @@
 import { useEventListener, useStorage } from '@vueuse/core'
 import type { CustomVoiceData } from '~/shared/types/custom-voice'
+import { computeTTSTextSig } from '~/shared/utils/tts-sig'
 
 export const TTS_ERROR_NOT_ALLOWED = 'NotAllowedError'
 
@@ -25,6 +26,8 @@ export function useTextToSpeech(options: TTSOptions = {}) {
   } = options || {}
 
   const nftClassId = options.nftClassId
+
+  const { user: sessionUser } = useUserSession()
 
   const config = useRuntimeConfig()
 
@@ -361,40 +364,44 @@ export function useTextToSpeech(options: TTSOptions = {}) {
     })
   })
 
+  function appendCommonParams(params: URLSearchParams, text: string) {
+    if (nftClassId) {
+      params.set('nft_class_id', nftClassId)
+      const ttsKey = sessionUser.value?.ttsKey || sessionUser.value?.evmWallet || ''
+      params.set('sig', computeTTSTextSig(ttsKey, nftClassId, text))
+    }
+    if (isNativeBridge.value) {
+      params.set('blocking', '1')
+    }
+  }
+
+
   function getAudioSrc(element: TTSSegment): string {
     if (element.audioSrc) return element.audioSrc
+
+    const sanitizedText = sanitizeTTSText(element.text)
 
     if (ttsLanguageVoice.value === 'custom') {
       const language = resolveCustomVoiceLanguage()
       const params = new URLSearchParams({
-        text: sanitizeTTSText(element.text),
+        text: sanitizedText,
         language,
         voice_id: 'custom',
       })
-      if (nftClassId) {
-        params.set('nft_class_id', nftClassId)
-      }
+      appendCommonParams(params, sanitizedText)
       if (options.customVoice?.value?.updatedAt) {
         params.set('_t', options.customVoice.value.updatedAt.toString())
-      }
-      if (isNativeBridge.value) {
-        params.set('blocking', '1')
       }
       return `/api/reader/tts?${params.toString()}`
     }
 
     const [language, ...voiceIdParts] = ttsLanguageVoice.value.split('_')
     const params = new URLSearchParams({
-      text: sanitizeTTSText(element.text),
+      text: sanitizedText,
       language: language || 'zh-HK',
       voice_id: voiceIdParts.join('_'),
     })
-    if (nftClassId) {
-      params.set('nft_class_id', nftClassId)
-    }
-    if (isNativeBridge.value) {
-      params.set('blocking', '1')
-    }
+    appendCommonParams(params, sanitizedText)
     return `/api/reader/tts?${params.toString()}`
   }
 

--- a/composables/use-text-to-speech.ts
+++ b/composables/use-text-to-speech.ts
@@ -5,7 +5,7 @@ import { computeTTSTextSig } from '~/shared/utils/tts-sig'
 export const TTS_ERROR_NOT_ALLOWED = 'NotAllowedError'
 
 interface TTSOptions {
-  nftClassId?: string
+  nftClassId: string
   onError?: (error: string | Event | MediaError) => void
   onAllSegmentsPlayed?: () => void
   bookName?: string | Ref<string> | ComputedRef<string>
@@ -16,7 +16,7 @@ interface TTSOptions {
   customVoice?: Ref<CustomVoiceData | null>
 }
 
-export function useTextToSpeech(options: TTSOptions = {}) {
+export function useTextToSpeech(options: TTSOptions) {
   const {
     bookName,
     bookChapterName,
@@ -365,11 +365,9 @@ export function useTextToSpeech(options: TTSOptions = {}) {
   })
 
   function appendCommonParams(params: URLSearchParams, text: string) {
-    if (nftClassId) {
-      params.set('nft_class_id', nftClassId)
-      const ttsKey = sessionUser.value?.ttsKey || sessionUser.value?.evmWallet || ''
-      params.set('sig', computeTTSTextSig(ttsKey, nftClassId, text))
-    }
+    params.set('nft_class_id', nftClassId)
+    const ttsKey = sessionUser.value?.ttsKey || sessionUser.value?.evmWallet || ''
+    params.set('sig', computeTTSTextSig(ttsKey, nftClassId, text))
     if (isNativeBridge.value) {
       params.set('blocking', '1')
     }

--- a/composables/use-text-to-speech.ts
+++ b/composables/use-text-to-speech.ts
@@ -375,7 +375,6 @@ export function useTextToSpeech(options: TTSOptions = {}) {
     }
   }
 
-
   function getAudioSrc(element: TTSSegment): string {
     if (element.audioSrc) return element.audioSrc
 

--- a/server/api/login.post.ts
+++ b/server/api/login.post.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from 'node:crypto'
 import { jwtDecode } from 'jwt-decode'
 import { FieldValue } from 'firebase-admin/firestore'
 
@@ -71,6 +72,7 @@ export default defineEventHandler(async (event) => {
     isLikerPlus: userInfoRes.isLikerPlus || false,
     isExpiredLikerPlus: userInfoRes.isExpiredLikerPlus || false,
     likerPlusPeriod: userInfoRes.likerPlusPeriod,
+    ttsKey: randomBytes(16).toString('hex'),
   }
   await setUserSession(event, { user: userInfo })
 

--- a/server/api/reader/tts.get.ts
+++ b/server/api/reader/tts.get.ts
@@ -2,6 +2,7 @@ import { createHash } from 'node:crypto'
 import type { Writable } from 'node:stream'
 import type { H3Event } from 'h3'
 import { TTSQuerySchema } from '~/server/schemas/tts'
+import { computeTTSTextSig } from '~/shared/utils/tts-sig'
 
 // Coalesces concurrent identical TTS requests (e.g. browser range probes)
 const inFlightWrites = new Map<string, Promise<void>>()
@@ -98,7 +99,14 @@ export default defineEventHandler(async (event) => {
     voice_id: voiceId,
     blocking,
     nft_class_id: nftClassId,
+    sig,
   } = await getValidatedQuery(event, createValidator(TTSQuerySchema))
+
+  // Verify text signature — binds request to user + book + exact text content
+  const ttsKey = session.user.ttsKey || session.user.evmWallet
+  if (sig !== computeTTSTextSig(ttsKey, nftClassId, text)) {
+    throw createError({ status: 403, message: 'INVALID_TTS_SIG' })
+  }
 
   const isCustomVoice = voiceId === 'custom'
   let customMiniMaxVoiceId: string | undefined

--- a/server/api/register.post.ts
+++ b/server/api/register.post.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from 'node:crypto'
 import { FetchError } from 'ofetch'
 import { FieldValue } from 'firebase-admin/firestore'
 
@@ -70,6 +71,7 @@ export default defineEventHandler(async (event) => {
     loginMethod: body.loginMethod,
     isLikerPlus: userInfoRes.isLikerPlus || false,
     isExpiredLikerPlus: userInfoRes.isExpiredLikerPlus || false,
+    ttsKey: randomBytes(16).toString('hex'),
   }
   await setUserSession(event, { user: userInfo })
 

--- a/server/schemas/tts.ts
+++ b/server/schemas/tts.ts
@@ -1,10 +1,13 @@
 import * as v from 'valibot'
 import { nftClassIdField } from '~/server/schemas/params'
 
+export const TTS_MAX_TEXT_LENGTH = 2000
+
 export const TTSQuerySchema = v.object({
   text: v.pipe(
     v.string('MISSING_TEXT'),
     v.nonEmpty('MISSING_TEXT'),
+    v.maxLength(TTS_MAX_TEXT_LENGTH, 'TEXT_TOO_LONG'),
   ),
   language: v.picklist(['en-US', 'zh-TW', 'zh-HK'], 'INVALID_LANGUAGE'),
   voice_id: v.pipe(
@@ -12,5 +15,9 @@ export const TTSQuerySchema = v.object({
     v.nonEmpty('INVALID_VOICE_ID'),
   ),
   blocking: v.optional(v.string()),
-  nft_class_id: v.optional(nftClassIdField),
+  nft_class_id: nftClassIdField,
+  sig: v.pipe(
+    v.string('MISSING_SIG'),
+    v.nonEmpty('MISSING_SIG'),
+  ),
 })

--- a/server/schemas/tts.ts
+++ b/server/schemas/tts.ts
@@ -1,5 +1,6 @@
 import * as v from 'valibot'
 import { nftClassIdField } from '~/server/schemas/params'
+import { TTS_PREVIEW_NFT_CLASS_ID } from '~/shared/utils/tts-sig'
 
 export const TTS_MAX_TEXT_LENGTH = 2000
 
@@ -15,7 +16,7 @@ export const TTSQuerySchema = v.object({
     v.nonEmpty('INVALID_VOICE_ID'),
   ),
   blocking: v.optional(v.string()),
-  nft_class_id: nftClassIdField,
+  nft_class_id: v.union([nftClassIdField, v.literal(TTS_PREVIEW_NFT_CLASS_ID)]),
   sig: v.pipe(
     v.string('MISSING_SIG'),
     v.nonEmpty('MISSING_SIG'),

--- a/shared/utils/tts-sig.ts
+++ b/shared/utils/tts-sig.ts
@@ -1,3 +1,5 @@
+export const TTS_PREVIEW_NFT_CLASS_ID = 'custom_voice_preview'
+
 export function computeTTSTextSig(token: string, nftClassId: string, text: string): string {
   return cyrb53(`${token}:${nftClassId.toLowerCase()}:${text}`)
 }

--- a/shared/utils/tts-sig.ts
+++ b/shared/utils/tts-sig.ts
@@ -1,0 +1,16 @@
+export function computeTTSTextSig(token: string, nftClassId: string, text: string): string {
+  return cyrb53(`${token}:${nftClassId.toLowerCase()}:${text}`)
+}
+
+function cyrb53(str: string): string {
+  let h1 = 0x300CDEED
+  let h2 = 0xDEF1B00C
+  for (let i = 0; i < str.length; i++) {
+    const ch = str.charCodeAt(i)
+    h1 = Math.imul(h1 ^ ch, 2654435761)
+    h2 = Math.imul(h2 ^ ch, 1597334677)
+  }
+  h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507)
+  h2 = Math.imul(h2 ^ (h2 >>> 16), 3266489909)
+  return (4294967296 * (2097151 & h2) + (h1 >>> 0)).toString(36)
+}

--- a/types/nuxt-auth-utils.d.ts
+++ b/types/nuxt-auth-utils.d.ts
@@ -14,6 +14,7 @@ declare module '#auth-utils' {
     isLikerPlus?: boolean
     isExpiredLikerPlus?: boolean
     likerPlusPeriod?: LikerPlusStatus
+    ttsKey?: string
   }
 }
 


### PR DESCRIPTION
Protect the TTS API from arbitrary text synthesis by requiring a per-request signature (sig) derived from the user's session ttsKey, nft_class_id, and text content. Also enforces nft_class_id as required and caps text at 2000 characters.