### PR TITLE
✅ Add unit tests for TTS text utilities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Run tests
+        run: npm run test:run
+
       - name: Run linter
         run: npm run lint
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,10 +56,15 @@
         "@iconify-json/material-symbols": "^1.2.17",
         "@iconify-json/simple-icons": "^1.2.29",
         "@nuxt/eslint": "^1.2.0",
+        "@nuxt/test-utils": "^4.0.0",
         "@types/markdown-it": "^14.1.2",
         "@vite-pwa/assets-generator": "^1.0.1",
+        "@vue/test-utils": "^2.4.6",
         "eslint": "^9.22.0",
+        "happy-dom": "^20.8.8",
+        "playwright-core": "^1.58.2",
         "typescript": "^5.8.3",
+        "vitest": "^4.1.1",
         "vue-tsc": "^2.2.10"
       },
       "engines": {
@@ -665,12 +670,12 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
-      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.5"
+        "@babel/types": "^7.29.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1822,9 +1827,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
-      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -6835,6 +6840,235 @@
       "integrity": "sha512-uBj69dVlYe/+wxj8JOpr97XfsxH/eumMt6HqjNTmJDf/6NO9s+0uxeOneIz3AsPt2m6y9PqzDzd3ATcU17MNfw==",
       "license": "MIT"
     },
+    "node_modules/@nuxt/test-utils": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@nuxt/test-utils/-/test-utils-4.0.0.tgz",
+      "integrity": "sha512-QJfyCiqYxflUKA5xlEGuXdDApTBhJxoPXxYePIDtA90hkmKbhYs/mrMM+Bi9LiUrI/cCJOPRyIx9jOzhMvTIgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@clack/prompts": "1.0.0",
+        "@nuxt/devtools-kit": "^2.7.0",
+        "@nuxt/kit": "^3.21.0",
+        "c12": "^3.3.3",
+        "consola": "^3.4.2",
+        "defu": "^6.1.4",
+        "destr": "^2.0.5",
+        "estree-walker": "^3.0.3",
+        "exsolve": "^1.0.8",
+        "fake-indexeddb": "^6.2.5",
+        "get-port-please": "^3.2.0",
+        "h3": "^1.15.5",
+        "h3-next": "npm:h3@2.0.1-rc.11",
+        "local-pkg": "^1.1.2",
+        "magic-string": "^0.30.21",
+        "node-fetch-native": "^1.6.7",
+        "node-mock-http": "^1.0.4",
+        "nypm": "^0.6.4",
+        "ofetch": "^1.5.1",
+        "pathe": "^2.0.3",
+        "perfect-debounce": "^2.1.0",
+        "radix3": "^1.1.2",
+        "scule": "^1.3.0",
+        "std-env": "^3.10.0",
+        "tinyexec": "^1.0.2",
+        "ufo": "^1.6.3",
+        "unplugin": "^3.0.0",
+        "vitest-environment-nuxt": "^1.0.1",
+        "vue": "^3.5.27"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@cucumber/cucumber": ">=11.0.0",
+        "@jest/globals": ">=30.0.0",
+        "@playwright/test": "^1.43.1",
+        "@testing-library/vue": "^8.0.1",
+        "@vue/test-utils": "^2.4.2",
+        "happy-dom": ">=20.0.11",
+        "jsdom": ">=27.4.0",
+        "playwright-core": "^1.43.1",
+        "vitest": "^4.0.2"
+      },
+      "peerDependenciesMeta": {
+        "@cucumber/cucumber": {
+          "optional": true
+        },
+        "@jest/globals": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "@testing-library/vue": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "@vue/test-utils": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "playwright-core": {
+          "optional": true
+        },
+        "vitest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nuxt/test-utils/node_modules/@clack/core": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.0.0.tgz",
+      "integrity": "sha512-Orf9Ltr5NeiEuVJS8Rk2XTw3IxNC2Bic3ash7GgYeA8LJ/zmSNpSQ/m5UAhe03lA6KFgklzZ5KTHs4OAMA/SAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picocolors": "^1.0.0",
+        "sisteransi": "^1.0.5"
+      }
+    },
+    "node_modules/@nuxt/test-utils/node_modules/@clack/prompts": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.0.0.tgz",
+      "integrity": "sha512-rWPXg9UaCFqErJVQ+MecOaWsozjaxol4yjnmYcGNipAWzdaWa2x+VJmKfGq7L0APwBohQOYdHC+9RO4qRXej+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@clack/core": "1.0.0",
+        "picocolors": "^1.0.0",
+        "sisteransi": "^1.0.5"
+      }
+    },
+    "node_modules/@nuxt/test-utils/node_modules/@nuxt/kit": {
+      "version": "3.21.2",
+      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.21.2.tgz",
+      "integrity": "sha512-Bd6m6mrDrqpBEbX+g0rc66/ALd1sxlgdx5nfK9MAYO0yKLTOSK7McSYz1KcOYn3LQFCXOWfvXwaqih/b+REI1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "c12": "^3.3.3",
+        "consola": "^3.4.2",
+        "defu": "^6.1.4",
+        "destr": "^2.0.5",
+        "errx": "^0.1.0",
+        "exsolve": "^1.0.8",
+        "ignore": "^7.0.5",
+        "jiti": "^2.6.1",
+        "klona": "^2.0.6",
+        "knitwork": "^1.3.0",
+        "mlly": "^1.8.1",
+        "ohash": "^2.0.11",
+        "pathe": "^2.0.3",
+        "pkg-types": "^2.3.0",
+        "rc9": "^3.0.0",
+        "scule": "^1.3.0",
+        "semver": "^7.7.4",
+        "tinyglobby": "^0.2.15",
+        "ufo": "^1.6.3",
+        "unctx": "^2.5.0",
+        "untyped": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      }
+    },
+    "node_modules/@nuxt/test-utils/node_modules/crossws": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.4.4.tgz",
+      "integrity": "sha512-w6c4OdpRNnudVmcgr7brb/+/HmYjMQvYToO/oTrprTwxRUiom3LYWU1PMWuD006okbUWpII1Ea9/+kwpUfmyRg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "peerDependencies": {
+        "srvx": ">=0.7.1"
+      },
+      "peerDependenciesMeta": {
+        "srvx": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nuxt/test-utils/node_modules/h3-next": {
+      "name": "h3",
+      "version": "2.0.1-rc.11",
+      "resolved": "https://registry.npmjs.org/h3/-/h3-2.0.1-rc.11.tgz",
+      "integrity": "sha512-2myzjCqy32c1As9TjZW9fNZXtLqNedjFSrdFy2AjFBQQ3LzrnGoDdFDYfC0tV2e4vcyfJ2Sfo/F6NQhO2Ly/Mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rou3": "^0.7.12",
+        "srvx": "^0.10.1"
+      },
+      "engines": {
+        "node": ">=20.11.1"
+      },
+      "peerDependencies": {
+        "crossws": "^0.4.1"
+      },
+      "peerDependenciesMeta": {
+        "crossws": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nuxt/test-utils/node_modules/rc9": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rc9/-/rc9-3.0.0.tgz",
+      "integrity": "sha512-MGOue0VqscKWQ104udASX/3GYDcKyPI4j4F8gu/jHHzglpmy9a/anZK3PNe8ug6aZFl+9GxLtdhe3kVZuMaQbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defu": "^6.1.4",
+        "destr": "^2.0.5"
+      }
+    },
+    "node_modules/@nuxt/test-utils/node_modules/srvx": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/srvx/-/srvx-0.10.1.tgz",
+      "integrity": "sha512-A//xtfak4eESMWWydSRFUVvCTQbSwivnGCEf8YGPe2eHU0+Z6znfUTCPF0a7oV3sObSOcrXHlL6Bs9vVctfXdg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "srvx": "bin/srvx.mjs"
+      },
+      "engines": {
+        "node": ">=20.16.0"
+      }
+    },
+    "node_modules/@nuxt/test-utils/node_modules/tinyexec": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
+      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nuxt/test-utils/node_modules/unplugin": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-3.0.0.tgz",
+      "integrity": "sha512-0Mqk3AT2TZCXWKdcoaufeXNukv2mTrEZExeXlHIOZXdqYoHHr4n51pymnwV8x2BOVxwXbK2HLlI7usrqMpycdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "picomatch": "^4.0.3",
+        "webpack-virtual-modules": "^0.6.2"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
     "node_modules/@nuxt/ui": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@nuxt/ui/-/ui-3.2.0.tgz",
@@ -7340,6 +7574,13 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
+    },
+    "node_modules/@one-ini/wasm": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.1.1.tgz",
+      "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.0",
@@ -14419,9 +14660,10 @@
       }
     },
     "node_modules/@standard-schema/spec": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
-      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
     },
     "node_modules/@stylistic/eslint-plugin": {
       "version": "4.2.0",
@@ -14931,6 +15173,17 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -14948,6 +15201,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/deep-freeze-strict": {
       "version": "1.1.2",
@@ -15213,6 +15473,13 @@
       "version": "0.0.21",
       "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
       "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/ws": {
@@ -15710,6 +15977,119 @@
       "integrity": "sha512-HLlu3Qn3ePmNCbfehwKWXQMzX/2rzcL6Jmpo+Dl3xnq46TGMyJAgO+IsS8ka7IDLeD3wcoOhjJwxTdIdbrFhGw==",
       "license": "MIT"
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.1.tgz",
+      "integrity": "sha512-xAV0fqBTk44Rn6SjJReEQkHP3RrqbJo6JQ4zZ7/uVOiJZRarBtblzrOfFIZeYUrukp2YD6snZG6IBqhOoHTm+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.1",
+        "@vitest/utils": "4.1.1",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.1.tgz",
+      "integrity": "sha512-h3BOylsfsCLPeceuCPAAJ+BvNwSENgJa4hXoXu4im0bs9Lyp4URc4JYK4pWLZ4pG/UQn7AT92K6IByi6rE6g3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.1",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.1.tgz",
+      "integrity": "sha512-GM+TEQN5WhOygr1lp7skeVjdLPqqWMHsfzXrcHAqZJi/lIVh63H0kaRCY8MDhNWikx19zBUK8ceaLB7X5AH9NQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.1.tgz",
+      "integrity": "sha512-f7+FPy75vN91QGWsITueq0gedwUZy1fLtHOCMeQpjs8jTekAHeKP80zfDEnhrleviLHzVSDXIWuCIOFn3D3f8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.1",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.1.tgz",
+      "integrity": "sha512-kMVSgcegWV2FibXEx9p9WIKgje58lcTbXgnJixfcg15iK8nzCXhmalL0ZLtTWLW9PH1+1NEDShiFFedB3tEgWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.1",
+        "@vitest/utils": "4.1.1",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.1.tgz",
+      "integrity": "sha512-6Ti/KT5OVaiupdIZEuZN7l3CZcR0cxnxt70Z0//3CtwgObwA6jZhmVBA3yrXSVN3gmwjgd7oDNLlsXz526gpRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.1.tgz",
+      "integrity": "sha512-cNxAlaB3sHoCdL6pj6yyUXv9Gry1NHNg0kFTXdvSIZXLHsqKH7chiWOkwJ5s5+d/oMwcoG9T0bKU38JZWKusrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.1",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@volar/language-core": {
       "version": "2.4.13",
       "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.13.tgz",
@@ -15815,16 +16195,28 @@
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.5.24",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.24.tgz",
-      "integrity": "sha512-eDl5H57AOpNakGNAkFDH+y7kTqrQpJkZFXhWZQGyx/5Wh7B1uQYvcWkvZi11BDhscPgj8N7XV3oRwiPnx1Vrig==",
+      "version": "3.5.31",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.31.tgz",
+      "integrity": "sha512-k/ueL14aNIEy5Onf0OVzR8kiqF/WThgLdFhxwa4e/KF/0qe38IwIdofoSWBTvvxQOesaz6riAFAUaYjoF9fLLQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.5",
-        "@vue/shared": "3.5.24",
-        "entities": "^4.5.0",
+        "@babel/parser": "^7.29.2",
+        "@vue/shared": "3.5.31",
+        "entities": "^7.0.1",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-core/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/@vue/compiler-core/node_modules/estree-walker": {
@@ -15834,29 +16226,29 @@
       "license": "MIT"
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.5.24",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.24.tgz",
-      "integrity": "sha512-1QHGAvs53gXkWdd3ZMGYuvQFXHW4ksKWPG8HP8/2BscrbZ0brw183q2oNWjMrSWImYLHxHrx1ItBQr50I/q2zw==",
+      "version": "3.5.31",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.31.tgz",
+      "integrity": "sha512-BMY/ozS/xxjYqRFL+tKdRpATJYDTTgWSo0+AJvJNg4ig+Hgb0dOsHPXvloHQ5hmlivUqw1Yt2pPIqp4e0v1GUw==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-core": "3.5.24",
-        "@vue/shared": "3.5.24"
+        "@vue/compiler-core": "3.5.31",
+        "@vue/shared": "3.5.31"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.5.24",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.24.tgz",
-      "integrity": "sha512-8EG5YPRgmTB+YxYBM3VXy8zHD9SWHUJLIGPhDovo3Z8VOgvP+O7UP5vl0J4BBPWYD9vxtBabzW1EuEZ+Cqs14g==",
+      "version": "3.5.31",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.31.tgz",
+      "integrity": "sha512-M8wpPgR9UJ8MiRGjppvx9uWJfLV7A/T+/rL8s/y3QG3u0c2/YZgff3d6SuimKRIhcYnWg5fTfDMlz2E6seUW8Q==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.5",
-        "@vue/compiler-core": "3.5.24",
-        "@vue/compiler-dom": "3.5.24",
-        "@vue/compiler-ssr": "3.5.24",
-        "@vue/shared": "3.5.24",
+        "@babel/parser": "^7.29.2",
+        "@vue/compiler-core": "3.5.31",
+        "@vue/compiler-dom": "3.5.31",
+        "@vue/compiler-ssr": "3.5.31",
+        "@vue/shared": "3.5.31",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.30.21",
-        "postcss": "^8.5.6",
+        "postcss": "^8.5.8",
         "source-map-js": "^1.2.1"
       }
     },
@@ -15867,13 +16259,13 @@
       "license": "MIT"
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.5.24",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.24.tgz",
-      "integrity": "sha512-trOvMWNBMQ/odMRHW7Ae1CdfYx+7MuiQu62Jtu36gMLXcaoqKvAyh+P73sYG9ll+6jLB6QPovqoKGGZROzkFFg==",
+      "version": "3.5.31",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.31.tgz",
+      "integrity": "sha512-h0xIMxrt/LHOvJKMri+vdYT92BrK3HFLtDqq9Pr/lVVfE4IyKZKvWf0vJFW10Yr6nX02OR4MkJwI0c1HDa1hog==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.24",
-        "@vue/shared": "3.5.24"
+        "@vue/compiler-dom": "3.5.31",
+        "@vue/shared": "3.5.31"
       }
     },
     "node_modules/@vue/compiler-vue2": {
@@ -15990,54 +16382,65 @@
       }
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.5.24",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.24.tgz",
-      "integrity": "sha512-BM8kBhtlkkbnyl4q+HiF5R5BL0ycDPfihowulm02q3WYp2vxgPcJuZO866qa/0u3idbMntKEtVNuAUp5bw4teg==",
+      "version": "3.5.31",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.31.tgz",
+      "integrity": "sha512-DtKXxk9E/KuVvt8VxWu+6Luc9I9ETNcqR1T1oW1gf02nXaZ1kuAx58oVu7uX9XxJR0iJCro6fqBLw9oSBELo5g==",
       "license": "MIT",
       "dependencies": {
-        "@vue/shared": "3.5.24"
+        "@vue/shared": "3.5.31"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.5.24",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.24.tgz",
-      "integrity": "sha512-RYP/byyKDgNIqfX/gNb2PB55dJmM97jc9wyF3jK7QUInYKypK2exmZMNwnjueWwGceEkP6NChd3D2ZVEp9undQ==",
+      "version": "3.5.31",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.31.tgz",
+      "integrity": "sha512-AZPmIHXEAyhpkmN7aWlqjSfYynmkWlluDNPHMCZKFHH+lLtxP/30UJmoVhXmbDoP1Ng0jG0fyY2zCj1PnSSA6Q==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.5.24",
-        "@vue/shared": "3.5.24"
+        "@vue/reactivity": "3.5.31",
+        "@vue/shared": "3.5.31"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.5.24",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.24.tgz",
-      "integrity": "sha512-Z8ANhr/i0XIluonHVjbUkjvn+CyrxbXRIxR7wn7+X7xlcb7dJsfITZbkVOeJZdP8VZwfrWRsWdShH6pngMxRjw==",
+      "version": "3.5.31",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.31.tgz",
+      "integrity": "sha512-xQJsNRmGPeDCJq/u813tyonNgWBFjzfVkBwDREdEWndBnGdHLHgkwNBQxLtg4zDrzKTEcnikUy1UUNecb3lJ6g==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.5.24",
-        "@vue/runtime-core": "3.5.24",
-        "@vue/shared": "3.5.24",
-        "csstype": "^3.1.3"
+        "@vue/reactivity": "3.5.31",
+        "@vue/runtime-core": "3.5.31",
+        "@vue/shared": "3.5.31",
+        "csstype": "^3.2.3"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.5.24",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.24.tgz",
-      "integrity": "sha512-Yh2j2Y4G/0/4z/xJ1Bad4mxaAk++C2v4kaa8oSYTMJBJ00/ndPuxCnWeot0/7/qafQFLh5pr6xeV6SdMcE/G1w==",
+      "version": "3.5.31",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.31.tgz",
+      "integrity": "sha512-GJuwRvMcdZX/CriUnyIIOGkx3rMV3H6sOu0JhdKbduaeCji6zb60iOGMY7tFoN24NfsUYoFBhshZtGxGpxO4iA==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-ssr": "3.5.24",
-        "@vue/shared": "3.5.24"
+        "@vue/compiler-ssr": "3.5.31",
+        "@vue/shared": "3.5.31"
       },
       "peerDependencies": {
-        "vue": "3.5.24"
+        "vue": "3.5.31"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.5.24",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.24.tgz",
-      "integrity": "sha512-9cwHL2EsJBdi8NY22pngYYWzkTDhld6fAD6jlaeloNGciNSJL6bLpbxVgXl96X00Jtc6YWQv96YA/0sxex/k1A==",
+      "version": "3.5.31",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.31.tgz",
+      "integrity": "sha512-nBxuiuS9Lj5bPkPbWogPUnjxxWpkRniX7e5UBQDWl6Fsf4roq9wwV+cR7ezQ4zXswNvPIlsdj1slcLB7XCsRAw==",
       "license": "MIT"
+    },
+    "node_modules/@vue/test-utils": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-2.4.6.tgz",
+      "integrity": "sha512-FMxEjOpYNYiFe0GkaHsnJPXFHxQ6m4t8vI/ElPGpMWxZKpmRvQ33OIrvRXemy6yha03RxhOlQuy+gZMC3CQSow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-beautify": "^1.14.9",
+        "vue-component-type-helpers": "^2.0.0"
+      }
     },
     "node_modules/@vueuse/core": {
       "version": "13.0.0",
@@ -16894,9 +17297,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -17211,6 +17614,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ast-kit": {
@@ -17878,12 +18291,12 @@
       }
     },
     "node_modules/c12": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/c12/-/c12-3.3.2.tgz",
-      "integrity": "sha512-QkikB2X5voO1okL3QsES0N690Sn/K9WokXqUsDQsWy5SnYb+psYQFGA10iy1bZHj3fjISKsI67Q90gruvWWM3A==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/c12/-/c12-3.3.3.tgz",
+      "integrity": "sha512-750hTRvgBy5kcMNPdh95Qo+XUBeGo8C7nsKSmedDmaQI+E0r82DwHeM6vBewDe4rGFbnxoa4V9pw+sPh5+Iz8Q==",
       "license": "MIT",
       "dependencies": {
-        "chokidar": "^4.0.3",
+        "chokidar": "^5.0.0",
         "confbox": "^0.2.2",
         "defu": "^6.1.4",
         "dotenv": "^17.2.3",
@@ -17905,6 +18318,21 @@
         }
       }
     },
+    "node_modules/c12/node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/c12/node_modules/confbox": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.2.tgz",
@@ -17921,6 +18349,19 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/c12/node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/cac": {
@@ -18049,6 +18490,16 @@
       "dependencies": {
         "events": "^3.3.0",
         "protobufjs": "^7.2.5"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -18399,6 +18850,24 @@
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
       "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
       "license": "MIT"
+    },
+    "node_modules/config-chain": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+      "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
+    },
+    "node_modules/config-chain/node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/consola": {
       "version": "3.4.2",
@@ -19376,6 +19845,35 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/editorconfig": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-1.0.7.tgz",
+      "integrity": "sha512-e0GOtq/aTQhVdNyDU9e02+wz9oDDM+SIOQxWME2QRjzRX5yyLAuHDE+0aE8vHb9XRC8XD37eO2u57+F09JqFhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@one-ini/wasm": "0.1.1",
+        "commander": "^10.0.0",
+        "minimatch": "^9.0.1",
+        "semver": "^7.5.3"
+      },
+      "bin": {
+        "editorconfig": "bin/editorconfig"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/editorconfig/node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/ee-first": {
@@ -20630,6 +21128,16 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/exsolve": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
@@ -20676,6 +21184,16 @@
       "integrity": "sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==",
       "engines": {
         "node": "> 0.1.90"
+      }
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/farmhash-modern": {
@@ -21708,9 +22226,9 @@
       }
     },
     "node_modules/h3": {
-      "version": "1.15.4",
-      "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.4.tgz",
-      "integrity": "sha512-z5cFQWDffyOe4vQ9xIqNfCZdV4p//vy6fBnr8Q1AWnVZ0teurKMG66rLj++TKwKPUP3u7iMUvrvKaEUiQw2QWQ==",
+      "version": "1.15.10",
+      "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.10.tgz",
+      "integrity": "sha512-YzJeWSkDZxAhvmp8dexjRK5hxziRO7I9m0N53WhvYL5NiWfkUkzssVzY9jvGu0HBoLFW6+duYmNSn6MaZBCCtg==",
       "license": "MIT",
       "dependencies": {
         "cookie-es": "^1.2.2",
@@ -21718,9 +22236,9 @@
         "defu": "^6.1.4",
         "destr": "^2.0.5",
         "iron-webcrypto": "^1.2.1",
-        "node-mock-http": "^1.0.2",
+        "node-mock-http": "^1.0.4",
         "radix3": "^1.1.2",
-        "ufo": "^1.6.1",
+        "ufo": "^1.6.3",
         "uncrypto": "^0.1.3"
       }
     },
@@ -21741,6 +22259,47 @@
       "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.2.tgz",
       "integrity": "sha512-+W7VmiVINB+ywl1HGXJXmrqkOhpKrIiVZV6tQuV54ZyQC7MMuBt81Vc336GMLoHBq5hV/F9eXgt5Mnx0Rha5Fg==",
       "license": "MIT"
+    },
+    "node_modules/happy-dom": {
+      "version": "20.8.8",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.8.8.tgz",
+      "integrity": "sha512-5/F8wxkNxYtsN0bXfMwIyNLZ9WYsoOYPbmoluqVJqv8KBUbcyKZawJ7uYK4WTX8IHBLYv+VXIwfeNDPy1oKMwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.18.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/happy-dom/node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/happy-dom/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
@@ -23050,6 +23609,86 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/js-beautify": {
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.15.4.tgz",
+      "integrity": "sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "config-chain": "^1.1.13",
+        "editorconfig": "^1.0.4",
+        "glob": "^10.4.2",
+        "js-cookie": "^3.0.5",
+        "nopt": "^7.2.1"
+      },
+      "bin": {
+        "css-beautify": "js/bin/css-beautify.js",
+        "html-beautify": "js/bin/html-beautify.js",
+        "js-beautify": "js/bin/js-beautify.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/js-beautify/node_modules/abbrev": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
+      "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/js-beautify/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/js-beautify/node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/js-beautify/node_modules/nopt": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
+      "integrity": "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^2.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/js-cookie": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.1.tgz",
@@ -23432,9 +24071,9 @@
       }
     },
     "node_modules/knitwork": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/knitwork/-/knitwork-1.2.0.tgz",
-      "integrity": "sha512-xYSH7AvuQ6nXkq42x0v5S8/Iry+cfulBz/DJQzhIyESdLD7425jXsPy4vn5cCXU+HhRN2kVw51Vd1K6/By4BQg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/knitwork/-/knitwork-1.3.0.tgz",
+      "integrity": "sha512-4LqMNoONzR43B1W0ek0fhXMsDNW/zxa1NdFAVMY+k28pgZLovR4G3PB5MrpTxCy1QaZCqNoiaKPr5w5qZHfSNw==",
       "license": "MIT"
     },
     "node_modules/kolorist": {
@@ -24371,15 +25010,15 @@
       "license": "MIT"
     },
     "node_modules/mlly": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz",
-      "integrity": "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
       "license": "MIT",
       "dependencies": {
-        "acorn": "^8.15.0",
+        "acorn": "^8.16.0",
         "pathe": "^2.0.3",
         "pkg-types": "^1.3.1",
-        "ufo": "^1.6.1"
+        "ufo": "^1.6.3"
       }
     },
     "node_modules/mlly/node_modules/pkg-types": {
@@ -24737,9 +25376,9 @@
       }
     },
     "node_modules/node-mock-http": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/node-mock-http/-/node-mock-http-1.0.3.tgz",
-      "integrity": "sha512-jN8dK25fsfnMrVsEhluUTPkBFY+6ybu7jSB1n+ri/vOGjJxU8J9CZhpSGkHXSkFjtUhbmoncG/YG9ta5Ludqog==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/node-mock-http/-/node-mock-http-1.0.4.tgz",
+      "integrity": "sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==",
       "license": "MIT"
     },
     "node_modules/node-releases": {
@@ -25300,23 +25939,27 @@
       }
     },
     "node_modules/nypm": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.2.tgz",
-      "integrity": "sha512-7eM+hpOtrKrBDCh7Ypu2lJ9Z7PNZBdi/8AT3AX8xoCj43BBVHD0hPSTEvMtkMpfs8FCqBGhxB+uToIQimA111g==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.5.tgz",
+      "integrity": "sha512-K6AJy1GMVyfyMXRVB88700BJqNUkByijGJM8kEHpLdcAt+vSQAVfkWWHYzuRXHSY6xA2sNc5RjTj0p9rE2izVQ==",
       "license": "MIT",
       "dependencies": {
-        "citty": "^0.1.6",
-        "consola": "^3.4.2",
+        "citty": "^0.2.0",
         "pathe": "^2.0.3",
-        "pkg-types": "^2.3.0",
-        "tinyexec": "^1.0.1"
+        "tinyexec": "^1.0.2"
       },
       "bin": {
         "nypm": "dist/cli.mjs"
       },
       "engines": {
-        "node": "^14.16.0 || >=16.10.0"
+        "node": ">=18"
       }
+    },
+    "node_modules/nypm/node_modules/citty": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.1.tgz",
+      "integrity": "sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg==",
+      "license": "MIT"
     },
     "node_modules/nypm/node_modules/tinyexec": {
       "version": "1.0.2",
@@ -25407,6 +26050,17 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
     },
     "node_modules/ofetch": {
       "version": "1.5.1",
@@ -26009,9 +26663,9 @@
       }
     },
     "node_modules/perfect-debounce": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.0.0.tgz",
-      "integrity": "sha512-fkEH/OBiKrqqI/yIgjR92lMfs2K8105zt/VT6+7eTjNwisrsh47CeIED9z58zI7DfKdH3uHAn25ziRZn3kgAow==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.1.0.tgz",
+      "integrity": "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==",
       "license": "MIT"
     },
     "node_modules/pg-int8": {
@@ -26147,6 +26801,19 @@
       "integrity": "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==",
       "license": "MIT"
     },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/pluralize": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
@@ -26184,9 +26851,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
       "funding": [
         {
           "type": "opencollective",
@@ -26822,6 +27489,13 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/proto3-json-serializer": {
       "version": "2.0.2",
@@ -27743,6 +28417,13 @@
         }
       }
     },
+    "node_modules/rou3": {
+      "version": "0.7.12",
+      "resolved": "https://registry.npmjs.org/rou3/-/rou3-0.7.12.tgz",
+      "integrity": "sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/rpc-websockets": {
       "version": "9.3.2",
       "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-9.3.2.tgz",
@@ -27983,9 +28664,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -28303,6 +28984,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -28549,6 +29237,13 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
     },
@@ -29369,6 +30064,13 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
@@ -29389,6 +30091,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-data-view": {
@@ -29612,9 +30324,9 @@
       "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="
     },
     "node_modules/ufo": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
-      "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
+      "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
       "license": "MIT"
     },
     "node_modules/uint8arrays": {
@@ -29679,15 +30391,15 @@
       "license": "MIT"
     },
     "node_modules/unctx": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/unctx/-/unctx-2.4.1.tgz",
-      "integrity": "sha512-AbaYw0Nm4mK4qjhns67C+kgxR2YWiwlDBPzxrN8h8C6VtAdCgditAY5Dezu3IJy4XVqAnbrXt9oQJvsn3fyozg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/unctx/-/unctx-2.5.0.tgz",
+      "integrity": "sha512-p+Rz9x0R7X+CYDkT+Xg8/GhpcShTlU8n+cf9OtOEf7zEQsNcCZO1dPKNRDqvUTaq+P32PMMkxWHwfrxkqfqAYg==",
       "license": "MIT",
       "dependencies": {
-        "acorn": "^8.14.0",
+        "acorn": "^8.15.0",
         "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.17",
-        "unplugin": "^2.1.0"
+        "magic-string": "^0.30.21",
+        "unplugin": "^2.3.11"
       }
     },
     "node_modules/undici-types": {
@@ -30913,6 +31625,122 @@
         "vue": "^3.5.0"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.1.tgz",
+      "integrity": "sha512-yF+o4POL41rpAzj5KVILUxm1GCjKnELvaqmU9TLLUbMfDzuN0UpUR9uaDs+mCtjPe+uYPksXDRLQGGPvj1cTmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.1",
+        "@vitest/mocker": "4.1.1",
+        "@vitest/pretty-format": "4.1.1",
+        "@vitest/runner": "4.1.1",
+        "@vitest/snapshot": "4.1.1",
+        "@vitest/spy": "4.1.1",
+        "@vitest/utils": "4.1.1",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.1",
+        "@vitest/browser-preview": "4.1.1",
+        "@vitest/browser-webdriverio": "4.1.1",
+        "@vitest/ui": "4.1.1",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest-environment-nuxt": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/vitest-environment-nuxt/-/vitest-environment-nuxt-1.0.1.tgz",
+      "integrity": "sha512-eBCwtIQriXW5/M49FjqNKfnlJYlG2LWMSNFsRVKomc8CaMqmhQPBS5LZ9DlgYL9T8xIVsiA6RZn2lk7vxov3Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nuxt/test-utils": ">=3.13.1"
+      }
+    },
+    "node_modules/vitest/node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/tinyexec": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
+      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/vscode-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
@@ -30920,16 +31748,16 @@
       "license": "MIT"
     },
     "node_modules/vue": {
-      "version": "3.5.24",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.24.tgz",
-      "integrity": "sha512-uTHDOpVQTMjcGgrqFPSb8iO2m1DUvo+WbGqoXQz8Y1CeBYQ0FXf2z1gLRaBtHjlRz7zZUBHxjVB5VTLzYkvftg==",
+      "version": "3.5.31",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.31.tgz",
+      "integrity": "sha512-iV/sU9SzOlmA/0tygSmjkEN6Jbs3nPoIPFhCMLD2STrjgOU8DX7ZtzMhg4ahVwf5Rp9KoFzcXeB1ZrVbLBp5/Q==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.24",
-        "@vue/compiler-sfc": "3.5.24",
-        "@vue/runtime-dom": "3.5.24",
-        "@vue/server-renderer": "3.5.24",
-        "@vue/shared": "3.5.24"
+        "@vue/compiler-dom": "3.5.31",
+        "@vue/compiler-sfc": "3.5.31",
+        "@vue/runtime-dom": "3.5.31",
+        "@vue/server-renderer": "3.5.31",
+        "@vue/shared": "3.5.31"
       },
       "peerDependencies": {
         "typescript": "*"
@@ -31147,6 +31975,16 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
@@ -31275,6 +32113,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "generate:pwa-assets": "pwa-assets-generator",
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare",
-    "typecheck": "nuxt typecheck"
+    "typecheck": "nuxt typecheck",
+    "test": "vitest",
+    "test:run": "vitest run"
   },
   "dependencies": {
     "@aa-sdk/core": "^4.86.0",
@@ -23,11 +25,11 @@
     "@account-kit/wallet-client": "^4.86.0",
     "@breezystack/lamejs": "^1.2.7",
     "@coinbase/wallet-sdk": "~4.3.7",
-    "@metamask/connect-evm": "~0.9.0",
     "@farcaster/miniapp-sdk": "^0.2.1",
     "@google-cloud/pubsub": "^5.3.0",
     "@likecoin/epub-ts": "^0.4.9",
     "@likecoin/wagmi-connector": "2.4.0-like.0",
+    "@metamask/connect-evm": "~0.9.0",
     "@nuxt/icon": "^1.11.0",
     "@nuxt/scripts": "^0.13.1",
     "@nuxt/ui": "^3.2.0",
@@ -65,10 +67,15 @@
     "@iconify-json/material-symbols": "^1.2.17",
     "@iconify-json/simple-icons": "^1.2.29",
     "@nuxt/eslint": "^1.2.0",
+    "@nuxt/test-utils": "^4.0.0",
     "@types/markdown-it": "^14.1.2",
     "@vite-pwa/assets-generator": "^1.0.1",
+    "@vue/test-utils": "^2.4.6",
     "eslint": "^9.22.0",
+    "happy-dom": "^20.8.8",
+    "playwright-core": "^1.58.2",
     "typescript": "^5.8.3",
+    "vitest": "^4.1.1",
     "vue-tsc": "^2.2.10"
   },
   "overrides": {

--- a/test/unit/tts.test.ts
+++ b/test/unit/tts.test.ts
@@ -1,0 +1,286 @@
+import { describe, expect, it } from 'vitest'
+import {
+  sanitizeTTSText,
+  isSpeakableText,
+  splitTextIntoSegments,
+  mergeShortTTSSegments,
+  getTTSConfigKeySuffixes,
+  getTTSConfigKeyWithSuffix,
+  TTS_CONFIG_KEY,
+} from '~/utils/tts'
+
+describe('sanitizeTTSText', () => {
+  it('returns empty string for falsy input', () => {
+    expect(sanitizeTTSText('')).toBe('')
+  })
+
+  // Regression: 343dea3d — fullwidth ASCII caused TTS mispronunciation
+  it('normalizes fullwidth ASCII to basic ASCII', () => {
+    expect(sanitizeTTSText('ＡＢＣ')).toBe('ABC')
+    expect(sanitizeTTSText('１２３')).toBe('123')
+    expect(sanitizeTTSText('（）')).toBe('()')
+    expect(sanitizeTTSText('＊')).toBe('')
+  })
+
+  it('removes asterisks including normalized fullwidth ones', () => {
+    expect(sanitizeTTSText('**bold**')).toBe('bold')
+    expect(sanitizeTTSText('＊重點＊')).toBe('重點')
+  })
+
+  // Regression: fbda87d9 — horizontal rules (---) caused TTS errors
+  it('removes horizontal rule lines', () => {
+    expect(sanitizeTTSText('---')).toBe('')
+    expect(sanitizeTTSText('  -----  ')).toBe('')
+    expect(sanitizeTTSText('text\n---\nmore')).toBe('text\n\nmore')
+  })
+
+  // Regression: fbda87d9 — dot-only lines like "..." on their own line
+  it('removes dot-only lines', () => {
+    expect(sanitizeTTSText('...')).toBe('')
+    expect(sanitizeTTSText('  ...  ')).toBe('')
+  })
+
+  it('does not remove dots inside normal text', () => {
+    expect(sanitizeTTSText('end. start')).toBe('end. start')
+  })
+
+  // Regression: 3c114fd2 — ellipsis (…) was not replaced, causing mispronunciation
+  it('replaces ellipsis-like characters with 。', () => {
+    expect(sanitizeTTSText('好⋯')).toBe('好。')
+    expect(sanitizeTTSText('好…')).toBe('好。')
+    expect(sanitizeTTSText('好︙')).toBe('好。')
+    expect(sanitizeTTSText('好……')).toBe('好。')
+    expect(sanitizeTTSText('好⋯⋯⋯')).toBe('好。')
+  })
+
+  // Regression: 3c114fd2 — em dashes had no pause, causing run-on speech
+  // Regression: 343dea3d — dashes now map to ASCII comma (not fullwidth ，)
+  it('replaces dash-like characters with comma', () => {
+    expect(sanitizeTTSText('好—壞')).toBe('好,壞')
+    expect(sanitizeTTSText('好──壞')).toBe('好,壞')
+    expect(sanitizeTTSText('好⸺壞')).toBe('好,壞')
+  })
+
+  // Regression: fbda87d9 — vertical quotation marks were only replaced once (no /g flag)
+  it('normalizes all vertical quotation marks globally', () => {
+    expect(sanitizeTTSText('﹁a﹂﹁b﹂')).toBe('「a」「b」')
+    expect(sanitizeTTSText('﹃a﹄﹃b﹄')).toBe('『a』『b』')
+  })
+
+  it('applies multiple sanitization rules together', () => {
+    const input = '﹁好＊﹂\n---\n好⋯⋯好—壞'
+    const result = sanitizeTTSText(input)
+    expect(result).toBe('「好」\n\n好。好,壞')
+  })
+})
+
+describe('isSpeakableText', () => {
+  // Regression: 99236427 — punctuation-only segments caused Minimax/Azure synthesis errors
+  it('returns false for punctuation-only text', () => {
+    expect(isSpeakableText('...')).toBe(false)
+    expect(isSpeakableText('---')).toBe(false)
+    expect(isSpeakableText('***')).toBe(false)
+    expect(isSpeakableText('。，、')).toBe(false)
+    expect(isSpeakableText('——')).toBe(false)
+  })
+
+  it('returns false for empty text', () => {
+    expect(isSpeakableText('')).toBe(false)
+  })
+
+  it('returns true for text containing letters', () => {
+    expect(isSpeakableText('hello')).toBe(true)
+    expect(isSpeakableText('你好')).toBe(true)
+  })
+
+  it('returns true for text containing digits', () => {
+    expect(isSpeakableText('123')).toBe(true)
+  })
+
+  it('returns false when text becomes non-speakable after sanitization', () => {
+    expect(isSpeakableText('⋯⋯')).toBe(false)
+  })
+
+  it('returns true when text has letters after sanitization', () => {
+    expect(isSpeakableText('＊hello＊')).toBe(true)
+  })
+})
+
+describe('splitTextIntoSegments', () => {
+  it('returns empty array for empty input', () => {
+    expect(splitTextIntoSegments('')).toEqual([])
+  })
+
+  it('returns single segment for short text', () => {
+    expect(splitTextIntoSegments('你好世界')).toEqual(['你好世界'])
+  })
+
+  // Regression: 33c20b20 — sentence boundaries are preferred over commas
+  it('splits at sentence-ending punctuation', () => {
+    const text = '這是第一句話不算短的文本。這是第二句話也不算短的文本。'
+    const result = splitTextIntoSegments(text)
+    expect(result.join('')).toBe(text)
+  })
+
+  // Regression: eebb08af — closing quotes must stay attached to sentence-ending punctuation
+  it('keeps closing quotes attached to sentence punctuation', () => {
+    const text = '他說：「我很好。」然後離開了。'
+    const result = splitTextIntoSegments(text)
+    const joined = result.join('')
+    expect(joined).toBe(text)
+    for (const seg of result) {
+      expect(seg).not.toMatch(/^[」』】》）)'\u2019\u201D]/)
+    }
+  })
+
+  it('splits long text at clause-level punctuation when sentences are too long', () => {
+    const clause = '這是一段包含了很多很多內容的測試文字用來驗證文本能被正確分段的子句'
+    const longText = `${clause}，${clause}，${clause}。`
+    const result = splitTextIntoSegments(longText)
+    expect(result.length).toBeGreaterThan(1)
+    for (const segment of result) {
+      expect(segment.length).toBeLessThanOrEqual(150)
+    }
+  })
+
+  // Regression: 99236427 — non-speakable segments must be filtered out
+  it('filters out non-speakable segments', () => {
+    const text = '你好。---。世界。'
+    const result = splitTextIntoSegments(text)
+    for (const segment of result) {
+      expect(isSpeakableText(segment)).toBe(true)
+    }
+  })
+
+  // Regression: 415e73d3 — short fragments should be merged
+  it('merges short adjacent parts instead of producing many tiny segments', () => {
+    const result = splitTextIntoSegments('好。嗎。你。我。他。她。')
+    expect(result.length).toBeLessThan(6)
+    expect(result.join('')).toBe('好。嗎。你。我。他。她。')
+  })
+
+  // Regression: 415e73d3 — short trailing text merges into previous segment
+  it('merges short trailing text into the previous segment', () => {
+    // "嗎。" is short trailing; should merge with the sentence before it
+    const sentence = '這是一段長度接近上限的句子讓結尾能夠被測試到。'
+    const result = splitTextIntoSegments(`${sentence}嗎。`)
+    const lastSegment = result[result.length - 1]!
+    expect(lastSegment).toContain('嗎。')
+  })
+
+  it('handles text with only whitespace and zero-width spaces', () => {
+    expect(splitTextIntoSegments('   \u200B  ')).toEqual([])
+  })
+
+  it('preserves text integrity — no characters lost', () => {
+    const text = '第一段。第二段！第三段？最後一段。'
+    const result = splitTextIntoSegments(text)
+    expect(result.join('')).toBe(text)
+  })
+})
+
+describe('mergeShortTTSSegments', () => {
+  function makeSegment(text: string, overrides?: Partial<TTSSegment>): TTSSegment {
+    return {
+      id: 'test',
+      text,
+      sectionIndex: 0,
+      elementIndex: 0,
+      cfi: '/test',
+      ...overrides,
+    }
+  }
+
+  it('returns same array for 0 or 1 segments', () => {
+    expect(mergeShortTTSSegments([])).toEqual([])
+    const single = [makeSegment('hello world test')]
+    expect(mergeShortTTSSegments(single)).toHaveLength(1)
+  })
+
+  // Regression: 415e73d3 — short fragments trigger extra TTS API calls
+  it('merges short adjacent segments in the same section/element/cfi', () => {
+    const segments = [
+      makeSegment('短文'),
+      makeSegment('也是短文'),
+    ]
+    const result = mergeShortTTSSegments(segments)
+    expect(result).toHaveLength(1)
+    expect(result[0]!.text).toBe('短文也是短文')
+  })
+
+  it('does not merge segments from different sections', () => {
+    const segments = [
+      makeSegment('短', { sectionIndex: 0 }),
+      makeSegment('文', { sectionIndex: 1 }),
+    ]
+    expect(mergeShortTTSSegments(segments)).toHaveLength(2)
+  })
+
+  it('does not merge segments with different cfi', () => {
+    const segments = [
+      makeSegment('短', { cfi: '/a' }),
+      makeSegment('文', { cfi: '/b' }),
+    ]
+    expect(mergeShortTTSSegments(segments)).toHaveLength(2)
+  })
+
+  it('does not merge segments with different elementIndex', () => {
+    const segments = [
+      makeSegment('短', { elementIndex: 0 }),
+      makeSegment('文', { elementIndex: 1 }),
+    ]
+    expect(mergeShortTTSSegments(segments)).toHaveLength(2)
+  })
+
+  it('does not merge when combined length exceeds MAX_SEGMENT_LENGTH (100)', () => {
+    const segments = [
+      makeSegment('a'.repeat(10)),
+      makeSegment('b'.repeat(95)),
+    ]
+    expect(mergeShortTTSSegments(segments)).toHaveLength(2)
+  })
+
+  it('only merges when at least one segment is below MIN_SEGMENT_LENGTH (15)', () => {
+    const segments = [
+      makeSegment('a'.repeat(20)),
+      makeSegment('b'.repeat(20)),
+    ]
+    expect(mergeShortTTSSegments(segments)).toHaveLength(2)
+  })
+
+  it('chains merges across multiple consecutive short segments', () => {
+    const segments = [
+      makeSegment('一'),
+      makeSegment('二'),
+      makeSegment('三'),
+    ]
+    const result = mergeShortTTSSegments(segments)
+    expect(result).toHaveLength(1)
+    expect(result[0]!.text).toBe('一二三')
+  })
+
+  it('mutates the text of the first segment when merging', () => {
+    const seg1 = makeSegment('短')
+    const segments = [seg1, makeSegment('文')]
+    const result = mergeShortTTSSegments(segments)
+    expect(result[0]).toBe(seg1)
+    expect(seg1.text).toBe('短文')
+  })
+})
+
+describe('TTS config helpers', () => {
+  it('TTS_CONFIG_KEY is tts-config', () => {
+    expect(TTS_CONFIG_KEY).toBe('tts-config')
+  })
+
+  it('getTTSConfigKeySuffixes returns the suffix list', () => {
+    const suffixes = getTTSConfigKeySuffixes()
+    expect(suffixes).toContain('voice')
+    expect(suffixes).toContain('playback-rate')
+  })
+
+  it('getTTSConfigKeyWithSuffix joins key and suffix', () => {
+    expect(getTTSConfigKeyWithSuffix('tts-config', 'voice')).toBe('tts-config-voice')
+    expect(getTTSConfigKeyWithSuffix('tts-config', 'playback-rate')).toBe('tts-config-playback-rate')
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineVitestConfig } from '@nuxt/test-utils/config'
+
+export default defineVitestConfig({
+  test: {
+    include: ['test/unit/**/*.{test,spec}.ts'],
+    environment: 'nuxt',
+  },
+})


### PR DESCRIPTION
Set up Vitest with @nuxt/test-utils and add 38 regression tests for sanitizeTTSText, isSpeakableText, splitTextIntoSegments, and mergeShortTTSSegments covering past bugs from git history.