### PR TITLE
[TAS-5415] ✨ Add preview content tab to product page

### DIFF
--- a/composables/use-book-info.ts
+++ b/composables/use-book-info.ts
@@ -205,6 +205,10 @@ export default function (
     return bookstoreInfo.value?.tableOfContents || ''
   })
 
+  const previewContent = computed(() => {
+    return bookstoreInfo.value?.previewContent || ''
+  })
+
   const genre = computed(() => {
     return bookstoreInfo.value?.genre
   })
@@ -335,6 +339,7 @@ export default function (
     formattedTTSSupportLabel,
     formattedReadingMethods,
     tableOfContents,
+    previewContent,
     genre,
     localizedGenre,
     keywords,

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -586,7 +586,6 @@
   "product_page_info_tab_preview_content": "Preview",
   "product_page_info_tab_table_of_contents": "Table of Contents",
   "product_page_not_found_error": "Book not found",
-  "product_page_preview_content_login_button": "Log in to read preview",
   "product_page_preview_content_login_prompt": "Log in to read the preview content",
   "product_page_pricing_title": "Versions",
   "product_page_publish_date_label": "Publish Date",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -586,6 +586,8 @@
   "product_page_info_tab_preview_content": "Preview",
   "product_page_info_tab_table_of_contents": "Table of Contents",
   "product_page_not_found_error": "Book not found",
+  "product_page_preview_content_login_button": "Log in to read preview",
+  "product_page_preview_content_login_prompt": "Log in to read the preview content",
   "product_page_pricing_title": "Versions",
   "product_page_publish_date_label": "Publish Date",
   "product_page_publisher_label": "Publisher",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -583,6 +583,7 @@
   "product_page_info_tab_author_description": "Author",
   "product_page_info_tab_description": "Description",
   "product_page_info_tab_file_info": "File Info",
+  "product_page_info_tab_preview_content": "Preview",
   "product_page_info_tab_table_of_contents": "Table of Contents",
   "product_page_not_found_error": "Book not found",
   "product_page_pricing_title": "Versions",

--- a/i18n/locales/zh-Hant.json
+++ b/i18n/locales/zh-Hant.json
@@ -586,6 +586,8 @@
   "product_page_info_tab_preview_content": "試閱",
   "product_page_info_tab_table_of_contents": "目錄",
   "product_page_not_found_error": "找不到書本",
+  "product_page_preview_content_login_button": "登入閱讀試閱內容",
+  "product_page_preview_content_login_prompt": "請先登入以閱讀試閱內容",
   "product_page_pricing_title": "購買版本",
   "product_page_publish_date_label": "上架日期",
   "product_page_publisher_label": "出版",

--- a/i18n/locales/zh-Hant.json
+++ b/i18n/locales/zh-Hant.json
@@ -583,6 +583,7 @@
   "product_page_info_tab_author_description": "作者簡介",
   "product_page_info_tab_description": "內容簡介",
   "product_page_info_tab_file_info": "檔案資訊",
+  "product_page_info_tab_preview_content": "試閱",
   "product_page_info_tab_table_of_contents": "目錄",
   "product_page_not_found_error": "找不到書本",
   "product_page_pricing_title": "購買版本",

--- a/i18n/locales/zh-Hant.json
+++ b/i18n/locales/zh-Hant.json
@@ -586,7 +586,6 @@
   "product_page_info_tab_preview_content": "試閱",
   "product_page_info_tab_table_of_contents": "目錄",
   "product_page_not_found_error": "找不到書本",
-  "product_page_preview_content_login_button": "登入閱讀試閱內容",
   "product_page_preview_content_login_prompt": "請先登入以閱讀試閱內容",
   "product_page_pricing_title": "購買版本",
   "product_page_publish_date_label": "上架日期",

--- a/pages/store/[nftClassId]/index.vue
+++ b/pages/store/[nftClassId]/index.vue
@@ -204,6 +204,15 @@
           </ul>
         </template>
 
+        <template #preview-content>
+          <ExpandableContent>
+            <div
+              class="markdown"
+              v-html="previewContentHTML"
+            />
+          </ExpandableContent>
+        </template>
+
         <template #author>
           <ExpandableContent>
             <div
@@ -1025,6 +1034,10 @@ const tableOfContentsHTML = computed(() => {
   return renderDescription(bookInfo.tableOfContents?.value || '')
 })
 
+const previewContentHTML = computed(() => {
+  return renderDescription(bookInfo.previewContent?.value || '')
+})
+
 const authorDescriptionHTML = computed(() => {
   return renderDescription(bookInfo.authorDescription?.value || '')
 })
@@ -1054,6 +1067,14 @@ const infoTabItems = computed(() => {
       label: $t('product_page_info_tab_table_of_contents'),
       slot: 'table-of-contents',
       value: 'table-of-contents',
+    })
+  }
+
+  if (bookInfo.previewContent.value) {
+    items.push({
+      label: $t('product_page_info_tab_preview_content'),
+      slot: 'preview-content',
+      value: 'preview-content',
     })
   }
 

--- a/pages/store/[nftClassId]/index.vue
+++ b/pages/store/[nftClassId]/index.vue
@@ -221,11 +221,7 @@
               class="text-muted"
               v-text="$t('product_page_preview_content_login_prompt')"
             />
-            <UButton
-              :label="$t('product_page_preview_content_login_button')"
-              color="primary"
-              @click="handlePreviewContentLoginClick"
-            />
+            <LoginButton @click="handlePreviewContentLoginClick" />
           </div>
         </template>
 
@@ -1123,6 +1119,7 @@ const infoTabItems = computed(() => {
 })
 
 const activeTabValue = ref(infoTabItems.value[0]?.value || 'description')
+const isTabInitialized = ref(false)
 
 const isStakingTabActive = computed(() => {
   return activeTabValue.value === 'staking-info'
@@ -1133,7 +1130,7 @@ watch(activeTabValue, (newTabValue) => {
   if (tabValue) {
     router.replace({ hash: `#${tabValue.slot}` })
   }
-  if (newTabValue === 'preview-content') {
+  if (isTabInitialized.value && newTabValue === 'preview-content') {
     useLogEvent('product_page_preview_content_tab_click', { nft_class_id: nftClassId.value })
   }
 })
@@ -1359,6 +1356,8 @@ onMounted(async () => {
   checkBookListStatus()
   await loadStakingData()
   initializeTabFromHash()
+  await nextTick()
+  isTabInitialized.value = true
 })
 
 const { copy: copyToClipboard } = useClipboard()
@@ -1695,8 +1694,7 @@ function handleBookReviewClick() {
   })
 }
 
-async function handlePreviewContentLoginClick() {
+function handlePreviewContentLoginClick() {
   useLogEvent('product_page_preview_content_login_click', { nft_class_id: nftClassId.value })
-  await accountStore.login()
 }
 </script>

--- a/pages/store/[nftClassId]/index.vue
+++ b/pages/store/[nftClassId]/index.vue
@@ -205,12 +205,28 @@
         </template>
 
         <template #preview-content>
-          <ExpandableContent>
-            <div
-              class="markdown"
-              v-html="previewContentHTML"
+          <template v-if="hasLoggedIn">
+            <ExpandableContent>
+              <div
+                class="markdown"
+                v-html="previewContentHTML"
+              />
+            </ExpandableContent>
+          </template>
+          <div
+            v-else
+            class="flex flex-col items-center gap-4 py-8"
+          >
+            <p
+              class="text-muted"
+              v-text="$t('product_page_preview_content_login_prompt')"
             />
-          </ExpandableContent>
+            <UButton
+              :label="$t('product_page_preview_content_login_button')"
+              color="primary"
+              @click="handlePreviewContentLoginClick"
+            />
+          </div>
         </template>
 
         <template #author>
@@ -1117,6 +1133,9 @@ watch(activeTabValue, (newTabValue) => {
   if (tabValue) {
     router.replace({ hash: `#${tabValue.slot}` })
   }
+  if (newTabValue === 'preview-content') {
+    useLogEvent('product_page_preview_content_tab_click', { nft_class_id: nftClassId.value })
+  }
 })
 
 function initializeTabFromHash() {
@@ -1674,5 +1693,10 @@ function handleBookReviewClick() {
   useLogEvent('book_review_link_click', {
     nft_class_id: nftClassId.value,
   })
+}
+
+async function handlePreviewContentLoginClick() {
+  useLogEvent('product_page_preview_content_login_click', { nft_class_id: nftClassId.value })
+  await accountStore.login()
 }
 </script>

--- a/types/bookstore.d.ts
+++ b/types/bookstore.d.ts
@@ -80,6 +80,7 @@ declare interface BookstoreInfo {
   thumbnailUrl: string
   usageInfo: string
   tableOfContents?: string
+  previewContent?: string
   recommendedClassIds?: string[]
   promotionalImages?: string[]
   promotionalVideos?: string[]


### PR DESCRIPTION
<img width="851" height="347" alt="image" src="https://github.com/user-attachments/assets/e5f8ca96-ef36-4a03-9ad5-83c9b9dda59d" />

Display previewContent from the API as a new accordion tab on the book product page, between table of contents and author description.