### PR TITLE
[TAS-5487] 🐛 Load all shelf books eagerly so read progress sorting works correctly

### DIFF
--- a/pages/shelf/[[walletAddress]].vue
+++ b/pages/shelf/[[walletAddress]].vue
@@ -138,8 +138,7 @@
         />
       </ul>
       <div
-        v-if="bookshelfStore.isFetching || hasMoreItems"
-        ref="infiniteScrollDetector"
+        v-if="bookshelfStore.isFetching"
         class="flex justify-center py-48"
       >
         <UIcon
@@ -179,8 +178,6 @@ const {
   claimFreeBook,
   reset: resetClaimableBooks,
 } = useClaimableBooks()
-const infiniteScrollDetectorElement = useTemplateRef<HTMLLIElement>('infiniteScrollDetector')
-const shouldLoadMore = useElementVisibility(infiniteScrollDetectorElement)
 
 const stakingData = computed(() => {
   return isMyBookshelf.value
@@ -262,7 +259,6 @@ const bookshelfItemsWithStaking = computed<BookshelfItemWithStaking[]>(() => {
 })
 
 const itemsCount = computed(() => bookshelfStore.items.length)
-const hasMoreItems = computed(() => !!bookshelfStore.nextKey)
 const paramWalletAddress = computed(() => getRouteParam('walletAddress'))
 
 if (paramWalletAddress.value && !checkIsEVMAddress(paramWalletAddress.value)) {
@@ -331,18 +327,24 @@ useHead(() => ({
 
 const { gridClasses, getGridItemClassesByIndex, columnMax } = usePaginatedGrid({
   itemsCount,
-  hasMore: hasMoreItems,
 })
+
+async function loadBookshelfData(addr: string, { isRefresh = false } = {}) {
+  const promises: Promise<unknown>[] = [
+    bookshelfStore.fetchAllItems({ walletAddress: addr, isRefresh }),
+  ]
+  if (isMyBookshelf.value) {
+    promises.push(
+      fetchClaimableFreeBooks(),
+      stakingStore.fetchUserStakingData(user.value!.evmWallet),
+    )
+  }
+  await Promise.all(promises)
+}
 
 onMounted(async () => {
   if (walletAddress.value) {
-    if (isMyBookshelf.value) {
-      await Promise.all([
-        fetchClaimableFreeBooks(),
-        stakingStore.fetchUserStakingData(user.value!.evmWallet),
-      ])
-    }
-    await bookshelfStore.fetchItems({ walletAddress: walletAddress.value })
+    await loadBookshelfData(walletAddress.value)
   }
 })
 
@@ -359,27 +361,7 @@ watch(
     bookshelfStore.reset()
     resetClaimableBooks()
     if (value) {
-      if (isMyBookshelf.value) {
-        await Promise.all([
-          fetchClaimableFreeBooks(),
-          stakingStore.fetchUserStakingData(user.value!.evmWallet),
-        ])
-      }
-      await bookshelfStore.fetchItems({ walletAddress: value, isRefresh: true })
-    }
-  },
-)
-
-watch(
-  shouldLoadMore,
-  async (loadMore) => {
-    if (walletAddress.value && loadMore) {
-      do {
-        // HACK: prevent scrollbar stuck at bottom, causing infinite loading
-        window.scrollBy(0, -1)
-        await bookshelfStore.fetchItems({ walletAddress: walletAddress.value })
-        await sleep(100)
-      } while (walletAddress.value && bookshelfStore.nextKey && shouldLoadMore.value)
+      await loadBookshelfData(value, { isRefresh: true })
     }
   },
 )
@@ -415,6 +397,6 @@ function handleBookshelfItemDownload({
 async function handleBookClaim(nftClassId: string) {
   useLogEvent('shelf_claim_free_book', { nft_class_id: nftClassId })
   await claimFreeBook(nftClassId)
-  await bookshelfStore.fetchItems({ walletAddress: walletAddress.value as string, isRefresh: true })
+  await bookshelfStore.fetchAllItems({ walletAddress: walletAddress.value as string, isRefresh: true })
 }
 </script>

--- a/stores/bookshelf.ts
+++ b/stores/bookshelf.ts
@@ -102,6 +102,7 @@ export const useBookshelfStore = defineStore('bookshelf', () => {
       const statusCode = getErrorStatusCode(error)
       if (statusCode === 404) {
         // NOTE: For a new wallet address, the API will return 404
+        nextKey.value = undefined
         return
       }
       throw createError({
@@ -113,6 +114,19 @@ export const useBookshelfStore = defineStore('bookshelf', () => {
     finally {
       isFetching.value = false
       hasFetched.value = true
+    }
+  }
+
+  async function fetchAllItems({
+    walletAddress,
+    isRefresh = false,
+  }: {
+    walletAddress: string
+    isRefresh?: boolean
+  }) {
+    await fetchItems({ walletAddress, isRefresh })
+    while (nextKey.value) {
+      await fetchItems({ walletAddress })
     }
   }
 
@@ -182,6 +196,7 @@ export const useBookshelfStore = defineStore('bookshelf', () => {
     items,
 
     fetchItems,
+    fetchAllItems,
     getTokenIdsByNFTClassId,
     getFirstTokenIdByNFTClassId,
     fetchNFTByNFTClassIdAndOwnerWalletAddressThroughContract,

--- a/stores/bookshelf.ts
+++ b/stores/bookshelf.ts
@@ -126,7 +126,11 @@ export const useBookshelfStore = defineStore('bookshelf', () => {
   }) {
     await fetchItems({ walletAddress, isRefresh })
     while (nextKey.value) {
+      const previousNextKey = nextKey.value
       await fetchItems({ walletAddress })
+      if (nextKey.value === previousNextKey) {
+        break
+      }
     }
   }
 


### PR DESCRIPTION
Infinite scroll only sorted within loaded pages, so books with recent read progress on later pages wouldn't appear at the top. Now fetches all pages before rendering. Also parallelizes bookshelf, claimable, and staking fetches, and fixes a potential infinite loop on 404.