### PR TITLE
👔 Hide all Plus subscription UI from non-subscribed app users

### DIFF
--- a/components/TTSPlayerModal.vue
+++ b/components/TTSPlayerModal.vue
@@ -322,7 +322,7 @@ const {
       if (isApp.value) {
         errorModal.open({
           title: $t('tts_free_trial_limit_error_title'),
-          description: $t('tts_free_trial_limit_error_description'),
+          description: $t('tts_free_trial_limit_error_description_app'),
         })
         return
       }

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -784,6 +784,7 @@
   "tts_custom_voice_upload_audio_button": "Choose audio file",
   "tts_custom_voice_upload_button": "Upload audio",
   "tts_free_trial_limit_error_description": "Please subscribe to Plus member to continue using this feature.",
+  "tts_free_trial_limit_error_description_app": "Today's text-to-speech limit has been reached. Please try again tomorrow.",
   "tts_free_trial_limit_error_title": "Text-to-speech usage limit reached",
   "tts_offline_modal_description": "TTS has been paused because the next track could not be loaded without an internet connection. Playback will resume automatically when your connection is restored.",
   "tts_offline_modal_resume_button": "Try Anyway",

--- a/i18n/locales/zh-Hant.json
+++ b/i18n/locales/zh-Hant.json
@@ -784,6 +784,7 @@
   "tts_custom_voice_upload_audio_button": "選擇音檔",
   "tts_custom_voice_upload_button": "上傳音檔",
   "tts_free_trial_limit_error_description": "請訂閱 Plus 會員以繼續享用服務。",
+  "tts_free_trial_limit_error_description_app": "今日朗讀次數已達上限，請明天再試。",
   "tts_free_trial_limit_error_title": "朗讀功能使用已達上限",
   "tts_offline_modal_description": "由於沒有網絡連接，無法載入下一個音軌，朗讀已暫停。網絡連接恢復後將自動繼續播放。",
   "tts_offline_modal_resume_button": "嘗試繼續",

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -145,7 +145,15 @@
                 size="24"
                 class="text-primary"
               />
-              <h3 class="text-xl font-semibold text-gray-900">
+              <h3
+                v-if="isApp"
+                class="text-xl font-semibold text-gray-900"
+                v-text="$t('about_page_feature_dual_format')"
+              />
+              <h3
+                v-else
+                class="text-xl font-semibold text-gray-900"
+              >
                 <NuxtLink
                   to="https://docs.3ook.com/zh-TW/articles/11905421-成為-3ook-plus-會員後-如何使用朗讀功能"
                   target="_blank"

--- a/pages/account/index.vue
+++ b/pages/account/index.vue
@@ -6,6 +6,7 @@
     >
       <UCard :ui="{ body: '!p-0 divide-y-1 divide-(--ui-border)' }">
         <AccountSettingsItem
+          v-if="isPlusFeatureVisible"
           icon="i-material-symbols-diamond-outline-rounded"
           :label="$t('account_page_subscription')"
         >
@@ -279,7 +280,7 @@
 
       <UCard :ui="{ body: '!p-0 divide-y-1 divide-(--ui-border)' }">
         <AccountSettingsItem
-          v-if="hasLoggedIn"
+          v-if="hasLoggedIn && isPlusFeatureVisible"
           icon="i-material-symbols-record-voice-over-outline"
           :label="$t('tts_custom_voice_section_title')"
         >
@@ -291,21 +292,10 @@
 
           <template #right>
             <UButton
-              v-if="isPlusFeatureVisible"
               :label="hasCustomVoice ? $t('tts_custom_voice_change_button') : $t('tts_custom_voice_upload_button')"
               :variant="hasCustomVoice ? 'outline' : 'solid'"
-              :icon="isPlusFeatureLocked ? LOCK_ICON : undefined"
               color="primary"
-              :disabled="isPlusFeatureLocked"
               @click="handleOpenCustomVoiceModal"
-            />
-            <UButton
-              v-else
-              :label="$t('account_page_upgrade_to_plus')"
-              :icon="LOCK_ICON"
-              variant="solid"
-              color="primary"
-              :to="localeRoute({ name: 'member', query: { ll_medium: 'custom-voice' } })"
             />
           </template>
         </AccountSettingsItem>
@@ -330,23 +320,12 @@
         </AccountSettingsItem>
 
         <AccountSettingsItem
+          v-if="isPlusFeatureVisible"
           icon="i-material-symbols-dark-mode-outline-rounded"
           :label="$t('account_page_color_mode')"
         >
           <template #right>
-            <ColorModeSwitcher
-              v-if="isPlusFeatureVisible"
-              :icon="isPlusFeatureLocked ? LOCK_ICON : undefined"
-              :disabled="isPlusFeatureLocked"
-            />
-            <UButton
-              v-else
-              :label="$t('account_page_upgrade_to_plus')"
-              :icon="LOCK_ICON"
-              variant="solid"
-              color="primary"
-              :to="localeRoute({ name: 'member', query: { ll_medium: 'color-mode' } })"
-            />
+            <ColorModeSwitcher />
           </template>
         </AccountSettingsItem>
 
@@ -527,8 +506,6 @@ import { useSignMessage } from '@wagmi/vue'
 import { CustomVoiceUploadModal } from '#components'
 import likeCoinTokenImage from '~/assets/images/likecoin-token.png'
 
-const LOCK_ICON = 'i-material-symbols-lock-outline'
-
 const config = useRuntimeConfig()
 const { $wagmiConfig } = useNuxtApp()
 const likeCoinSessionAPI = useLikeCoinSessionAPI()
@@ -547,8 +524,7 @@ const { isApp } = useAppDetection()
 const isAdultContentEnabled = useAdultContentSetting()
 const isAdultContentConfirmOpen = ref(false)
 
-const isPlusFeatureVisible = computed(() => isApp.value || !!user.value?.isLikerPlus)
-const isPlusFeatureLocked = computed(() => isApp.value && !user.value?.isLikerPlus)
+const isPlusFeatureVisible = computed(() => !isApp.value || !!user.value?.isLikerPlus)
 
 function handleAdultContentToggle(value: boolean) {
   if (value) {

--- a/pages/gift/plus/index.vue
+++ b/pages/gift/plus/index.vue
@@ -173,6 +173,7 @@
 <script setup lang="ts">
 const { t: $t } = useI18n()
 const localeRoute = useLocaleRoute()
+const { isApp } = useAppDetection()
 const { handleError } = useErrorHandler()
 const likeCoinSessionAPI = useLikeCoinSessionAPI()
 const { loggedIn: hasLoggedIn, user } = useUserSession()
@@ -269,7 +270,11 @@ function handleCancel() {
   navigateTo(localeRoute({ name: 'store' }))
 }
 
-onMounted(() => {
+onMounted(async () => {
+  if (isApp.value) {
+    await navigateTo(localeRoute({ name: 'store' }))
+    return
+  }
   // Prefill sender name if user is logged in
   if (hasLoggedIn.value && user.value?.displayName) {
     formData.fromName = user.value.displayName

--- a/pages/member.vue
+++ b/pages/member.vue
@@ -42,6 +42,7 @@ const { t: $t } = useI18n()
 const config = useRuntimeConfig()
 const baseURL = config.public.baseURL
 
+const { isApp } = useAppDetection()
 const selectedPlan = ref<SubscriptionPlan>('yearly')
 
 const { memberProgramData } = useMemberProgramStructuredData()
@@ -213,6 +214,10 @@ async function handleSubscribe(payload: {
 }
 
 onMounted(async () => {
+  if (isApp.value) {
+    await navigateTo(localeRoute({ name: 'store' }))
+    return
+  }
   await checkout.redirectIfSubscribed()
 })
 </script>


### PR DESCRIPTION
Ensure app users who are not Plus subscribers see no indication that a paid membership exists, to comply with App Store review guidelines.

- Redirect /member and /gift/plus to store when in app
- Hide subscription, custom voice, and dark mode settings on account page
- Use daily-limit error message instead of subscribe CTA for TTS quota
- Hide Plus docs link on about page for app users
- Remove dead isPlusFeatureLocked code and LOCK_ICON constant