### PR TITLE
[TAS-5579] 🚸 Make register CTA mobile-only and always show TTS samples on mobile

### DIFF
--- a/components/PricingPageContent.vue
+++ b/components/PricingPageContent.vue
@@ -119,37 +119,47 @@
           :description="campaignContent?.description"
           :is-compact="isShowTTSSamples"
         />
-        <TTSSamplesSection v-if="isShowTTSSamples" />
+        <TTSSamplesSection :class="{ 'laptop:hidden': !isShowTTSSamples }" />
 
         <div class="flex flex-col w-full mt-6 laptop:mt-8">
-          <PricingLimitedOfferAlert
-            v-if="!isApp"
-            :is-hidden="!isPaidTrial"
+          <div
+            v-if="$slots['pricing-mobile']"
+            class="laptop:hidden"
           >
-            <PricingPlanSelect
-              v-model="selectedPlan"
-              :trial-period-days="trialPeriodDays"
-            />
+            <slot name="pricing-mobile" />
+          </div>
+          <div :class="$slots['pricing-mobile'] ? 'hidden laptop:contents' : undefined">
+            <slot name="pricing">
+              <PricingLimitedOfferAlert
+                v-if="!isApp"
+                :is-hidden="!isPaidTrial"
+              >
+                <PricingPlanSelect
+                  v-model="selectedPlan"
+                  :trial-period-days="trialPeriodDays"
+                />
 
-            <UButton
-              class="mt-4"
-              :label="subscribeButtonLabel"
-              block
-              size="xl"
-              :loading="props.isProcessingSubscription"
-              :ui="{ base: 'py-2 laptop:py-3 cursor-pointer', label: 'font-bold' }"
-              @click="handleSubscribeButtonClick"
-            />
-          </PricingLimitedOfferAlert>
+                <UButton
+                  class="mt-4"
+                  :label="subscribeButtonLabel"
+                  block
+                  size="xl"
+                  :loading="props.isProcessingSubscription"
+                  :ui="{ base: 'py-2 laptop:py-3 cursor-pointer', label: 'font-bold' }"
+                  @click="handleSubscribeButtonClick"
+                />
+              </PricingLimitedOfferAlert>
 
-          <UButton
-            class="mt-2 self-center"
-            :label="$t('pricing_page_learn_more')"
-            :to="learnMoreRoute"
-            variant="link"
-            color="neutral"
-            size="sm"
-          />
+              <UButton
+                class="mt-2 self-center"
+                :label="$t('pricing_page_learn_more')"
+                :to="learnMoreRoute"
+                variant="link"
+                color="neutral"
+                size="sm"
+              />
+            </slot>
+          </div>
         </div>
       </div>
     </div>

--- a/components/PricingPageContent.vue
+++ b/components/PricingPageContent.vue
@@ -124,7 +124,7 @@
         <div class="flex flex-col w-full mt-6 laptop:mt-8">
           <div
             v-if="$slots['pricing-mobile']"
-            class="laptop:hidden"
+            class="contents laptop:hidden"
           >
             <slot name="pricing-mobile" />
           </div>

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -802,7 +802,7 @@
   "tts_sample_mandarin": "Mandarin",
   "tts_sample_mandarin_description": "Read by Aurora",
   "tts_samples_section_footer": "Subscribe to Plus and unlock more voices to enjoy.",
-  "tts_samples_section_title": "Try AI Text-to-Speech",
+  "tts_samples_section_title": "Try Text-to-Speech",
   "tts_try_modal_description": "On 3ook.com, books aren't just for reading — you can listen to them too.\nLet our voice actors read them for you.",
   "tts_try_modal_dismiss_button": "Don't ask again",
   "tts_try_modal_remind_me_later": "Remind me next time",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -555,6 +555,8 @@
   "pricing_page_feature_6_yearly": "Receive one free ebook of your choice",
   "pricing_page_intercom_prefill": "Hi, I'd like to learn more about 3ook.com Plus",
   "pricing_page_learn_more": "Learn more about 3ook.com",
+  "pricing_page_login_cta_button": "Register",
+  "pricing_page_login_cta_description": "One step away from 20% off books and AI reading",
   "pricing_page_liker_id_required": "Register Required",
   "pricing_page_liker_id_required_description": "You need to register in order to subscribe. Please contact support for assistance.",
   "pricing_page_monthly": "Monthly",

--- a/i18n/locales/zh-Hant.json
+++ b/i18n/locales/zh-Hant.json
@@ -555,6 +555,8 @@
   "pricing_page_feature_6_yearly": "每年獲贈自選電子書",
   "pricing_page_intercom_prefill": "你好，我想了解更多關於 3ook.com Plus 的資訊",
   "pricing_page_learn_more": "了解更多關於 3ook.com",
+  "pricing_page_login_cta_button": "註冊",
+  "pricing_page_login_cta_description": "一步之遙，即享八折購書與 AI 朗讀",
   "pricing_page_liker_id_required": "需要註冊帳戶",
   "pricing_page_liker_id_required_description": "你需要註冊帳戶才能訂閱。請聯絡客服獲取協助。",
   "pricing_page_monthly": "月費",

--- a/i18n/locales/zh-Hant.json
+++ b/i18n/locales/zh-Hant.json
@@ -802,7 +802,7 @@
   "tts_sample_mandarin": "國語",
   "tts_sample_mandarin_description": "由 Aurora 讀出",
   "tts_samples_section_footer": "訂閱 Plus 會員解鎖更多聲音，隨心體驗。",
-  "tts_samples_section_title": "體驗 AI 朗讀",
+  "tts_samples_section_title": "體驗朗讀",
   "tts_try_modal_description": "在 3ook.com，書除了用來看，還能用來聽。\n讓我們的聲優為你朗讀吧：",
   "tts_try_modal_dismiss_button": "不用再問了",
   "tts_try_modal_remind_me_later": "下次再提醒我",

--- a/pages/member.vue
+++ b/pages/member.vue
@@ -28,9 +28,10 @@
       #pricing-mobile
     >
       <div class="flex flex-col items-center gap-3">
-        <span class="text-sm text-theme-black/60 dark:text-theme-white/60">
-          {{ $t('pricing_page_login_cta_description') }}
-        </span>
+        <span
+          class="text-sm text-muted"
+          v-text="$t('pricing_page_login_cta_description')"
+        />
         <UButton
           :label="$t('pricing_page_login_cta_button')"
           icon="i-material-symbols-login-rounded"

--- a/pages/member.vue
+++ b/pages/member.vue
@@ -22,6 +22,26 @@
         size="md"
       />
     </template>
+
+    <template
+      v-if="!hasLoggedIn"
+      #pricing-mobile
+    >
+      <div class="flex flex-col items-center gap-3">
+        <span class="text-sm text-theme-black/60 dark:text-theme-white/60">
+          {{ $t('pricing_page_login_cta_description') }}
+        </span>
+        <UButton
+          :label="$t('pricing_page_login_cta_button')"
+          icon="i-material-symbols-login-rounded"
+          size="xl"
+          block
+          :loading="accountStore.isLoggingIn"
+          :ui="{ base: 'py-2 laptop:py-3 cursor-pointer', label: 'font-bold' }"
+          @click="handleRegisterClick"
+        />
+      </div>
+    </template>
   </PricingPageContent>
 </template>
 
@@ -43,6 +63,8 @@ const config = useRuntimeConfig()
 const baseURL = config.public.baseURL
 
 const { isApp } = useAppDetection()
+const { loggedIn: hasLoggedIn } = useUserSession()
+const accountStore = useAccountStore()
 const selectedPlan = ref<SubscriptionPlan>('yearly')
 
 const { memberProgramData } = useMemberProgramStructuredData()
@@ -197,6 +219,11 @@ function handleOpen() {
       quantity: 1,
     }],
   })
+}
+
+async function handleRegisterClick() {
+  useLogEvent('pricing_page_register_click')
+  await accountStore.login()
 }
 
 async function handleSubscribe(payload: {


### PR DESCRIPTION

<img width="224" height="220" alt="image" src="https://github.com/user-attachments/assets/aa0c2cbd-b30b-4c2d-b1f3-840c74f2dc84" />

Use CSS responsive classes instead of JS media queries to avoid SSR hydration mismatch. Add pricing-mobile slot for mobile-specific content override with display:contents fallback on desktop.