### PR TITLE
⚗️ Gate mobile register CTA and TTS samples behind A/B test

### DIFF
--- a/components/PricingPageContent.props.ts
+++ b/components/PricingPageContent.props.ts
@@ -7,5 +7,5 @@ export interface PricingPageContentProps {
   utmMedium?: string
   utmSource?: string
   coupon?: string
-  forceShowTTSOnMobile?: boolean
+  mustShowTtsOnMobile?: boolean
 }

--- a/components/PricingPageContent.props.ts
+++ b/components/PricingPageContent.props.ts
@@ -7,4 +7,5 @@ export interface PricingPageContentProps {
   utmMedium?: string
   utmSource?: string
   coupon?: string
+  forceShowTTSOnMobile?: boolean
 }

--- a/components/PricingPageContent.vue
+++ b/components/PricingPageContent.vue
@@ -120,7 +120,7 @@
           :is-compact="isShowTTSSamples"
         />
         <TTSSamplesSection
-          v-if="isShowTTSSamples || props.forceShowTTSOnMobile"
+          v-if="isShowTTSSamples || props.mustShowTtsOnMobile"
           :class="{ 'laptop:hidden': !isShowTTSSamples }"
         />
 

--- a/components/PricingPageContent.vue
+++ b/components/PricingPageContent.vue
@@ -119,10 +119,7 @@
           :description="campaignContent?.description"
           :is-compact="isShowTTSSamples"
         />
-        <TTSSamplesSection
-          v-if="isShowTTSSamples || props.mustShowTtsOnMobile"
-          :class="{ 'laptop:hidden': !isShowTTSSamples }"
-        />
+        <TTSSamplesSection v-if="isShowTTSSamples" />
 
         <div class="flex flex-col w-full mt-6 laptop:mt-8">
           <div
@@ -209,7 +206,7 @@ const abTest = shouldShowTTSSamples.value
       experimentKey: 'pricing-page-tts-sample',
     })
 
-const isShowTTSSamples = computed(() => shouldShowTTSSamples.value || abTest?.isVariant('tts-sample'))
+const isShowTTSSamples = computed(() => shouldShowTTSSamples.value || abTest?.isVariant('tts-sample') || props.mustShowTtsOnMobile)
 
 const utmCampaign = computed(() => {
   return getRouteQuery('utm_campaign') || props.utmCampaign

--- a/components/PricingPageContent.vue
+++ b/components/PricingPageContent.vue
@@ -119,7 +119,10 @@
           :description="campaignContent?.description"
           :is-compact="isShowTTSSamples"
         />
-        <TTSSamplesSection :class="{ 'laptop:hidden': !isShowTTSSamples }" />
+        <TTSSamplesSection
+          v-if="isShowTTSSamples || props.forceShowTTSOnMobile"
+          :class="{ 'laptop:hidden': !isShowTTSSamples }"
+        />
 
         <div class="flex flex-col w-full mt-6 laptop:mt-8">
           <div

--- a/pages/member.vue
+++ b/pages/member.vue
@@ -9,7 +9,7 @@
     utm-source="website"
     utm-medium="web"
     :coupon="coupon"
-    :force-show-t-t-s-on-mobile="isMobileRegisterCTATestVariant"
+    :must-show-tts-on-mobile="isMobileRegisterCTATestVariant"
     @open="handleOpen"
     @subscribe="handleSubscribe"
   >

--- a/pages/member.vue
+++ b/pages/member.vue
@@ -9,6 +9,7 @@
     utm-source="website"
     utm-medium="web"
     :coupon="coupon"
+    :force-show-t-t-s-on-mobile="mobileRegisterCTATest.isVariant('test')"
     @open="handleOpen"
     @subscribe="handleSubscribe"
   >
@@ -24,7 +25,7 @@
     </template>
 
     <template
-      v-if="!hasLoggedIn"
+      v-if="!hasLoggedIn && mobileRegisterCTATest.isVariant('test')"
       #pricing-mobile
     >
       <div class="flex flex-col items-center gap-3">
@@ -66,6 +67,7 @@ const baseURL = config.public.baseURL
 const { isApp } = useAppDetection()
 const { loggedIn: hasLoggedIn } = useUserSession()
 const accountStore = useAccountStore()
+const mobileRegisterCTATest = useABTest({ experimentKey: 'pricing-page-mobile-register-cta' })
 const selectedPlan = ref<SubscriptionPlan>('yearly')
 
 const { memberProgramData } = useMemberProgramStructuredData()

--- a/pages/member.vue
+++ b/pages/member.vue
@@ -9,7 +9,7 @@
     utm-source="website"
     utm-medium="web"
     :coupon="coupon"
-    :force-show-t-t-s-on-mobile="mobileRegisterCTATest.isVariant('test')"
+    :force-show-t-t-s-on-mobile="isMobileRegisterCTATestVariant"
     @open="handleOpen"
     @subscribe="handleSubscribe"
   >
@@ -25,7 +25,7 @@
     </template>
 
     <template
-      v-if="!hasLoggedIn && mobileRegisterCTATest.isVariant('test')"
+      v-if="!hasLoggedIn && isMobileRegisterCTATestVariant"
       #pricing-mobile
     >
       <div class="flex flex-col items-center gap-3">
@@ -68,6 +68,7 @@ const { isApp } = useAppDetection()
 const { loggedIn: hasLoggedIn } = useUserSession()
 const accountStore = useAccountStore()
 const mobileRegisterCTATest = useABTest({ experimentKey: 'pricing-page-mobile-register-cta' })
+const isMobileRegisterCTATestVariant = computed(() => mobileRegisterCTATest.isVariant('test'))
 const selectedPlan = ref<SubscriptionPlan>('yearly')
 
 const { memberProgramData } = useMemberProgramStructuredData()


### PR DESCRIPTION
Wrap the mobile-only register CTA and force-show TTS samples behavior behind a PostHog experiment (pricing-page-mobile-register-cta) instead of deploying directly to all users.