### PR TITLE
📈 Share hashed wallet User-ID with native Firebase Analytics

### DIFF
--- a/composables/use-logger.ts
+++ b/composables/use-logger.ts
@@ -168,6 +168,10 @@ export function useSetLogUser(user: User | null, locale: string) {
     })
   }
 
+  const hashedWallet = user
+    ? sha256(user.evmWallet as `0x${string}`)
+    : undefined
+
   // Set user ID in Google Analytics
   const { gtag } = useGtag()
   try {
@@ -178,7 +182,7 @@ export function useSetLogUser(user: User | null, locale: string) {
     }
     else {
       gtag('set', {
-        user_id: sha256(user.evmWallet as `0x${string}`),
+        user_id: hashedWallet,
         user_data: { email: user.email || undefined },
       })
       gtag('set', 'user_properties', {
@@ -198,7 +202,7 @@ export function useSetLogUser(user: User | null, locale: string) {
     try {
       proxy.fbq('init', metaPixelId, {
         em: user?.email,
-        external_id: sha256(user?.evmWallet as `0x${string}`),
+        external_id: hashedWallet,
       })
     }
     catch (error) {
@@ -281,10 +285,12 @@ export function useSetLogUser(user: User | null, locale: string) {
       postToNative({
         type: 'identifyUser',
         userId: user.evmWallet,
+        gaUserId: hashedWallet,
         email: user.email || undefined,
         displayName: user.displayName || user.evmWallet || user.likeWallet,
         isLikerPlus: !!user.isLikerPlus,
         loginMethod: user.loginMethod,
+        locale,
       })
     }
     else {


### PR DESCRIPTION
Hoist the SHA-256 wallet used as gtag's user_id so it can be reused by Meta Pixel (dropping a redundant hash per login) and sent to the native app via the identifyUser bridge as gaUserId. Also forward locale so the native SDKs match what gtag already receives.