### PR TITLE
[TAS-5620] ✨ Show free month of Plus alert on promo-eligible book pages

### DIFF
--- a/components/BookPlusPromoAlert.vue
+++ b/components/BookPlusPromoAlert.vue
@@ -3,12 +3,11 @@
     :title="$t('product_page_plus_promo_title')"
     :description="$t('product_page_plus_promo_description')"
     icon="i-material-symbols-celebration-outline-rounded"
-    color="primary"
+    color="neutral"
     variant="subtle"
     orientation="horizontal"
     :ui="{
-      root: 'rounded-lg items-center gap-3 py-2 px-3',
-      wrapper: 'gap-0.5',
+      root: 'rounded-xl items-center gap-3',
       title: 'text-sm font-bold',
       description: 'text-xs',
       icon: 'size-5',

--- a/components/BookPlusPromoAlert.vue
+++ b/components/BookPlusPromoAlert.vue
@@ -1,0 +1,17 @@
+<template>
+  <UAlert
+    :title="$t('product_page_plus_promo_title')"
+    :description="$t('product_page_plus_promo_description')"
+    icon="i-material-symbols-celebration-outline-rounded"
+    color="primary"
+    variant="subtle"
+    orientation="horizontal"
+    :ui="{
+      root: 'rounded-lg items-center gap-3 py-2 px-3',
+      wrapper: 'gap-0.5',
+      title: 'text-sm font-bold',
+      description: 'text-xs',
+      icon: 'size-5',
+    }"
+  />
+</template>

--- a/composables/use-book-info.ts
+++ b/composables/use-book-info.ts
@@ -189,6 +189,10 @@ export default function (
     return bookstoreInfo.value?.hideUpsell || false
   })
 
+  const isPlusPromoEnabled = computed(() => {
+    return bookstoreInfo.value?.plusPromoEnabled || false
+  })
+
   const formattedReadingMethods = computed(() => {
     const methods = [$t('reading_method_read_online')]
     if (isDownloadable.value) {
@@ -336,6 +340,7 @@ export default function (
     isDownloadable,
     isAudioHidden,
     isUpsellDisabled,
+    isPlusPromoEnabled,
     formattedTTSSupportLabel,
     formattedReadingMethods,
     tableOfContents,

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -591,6 +591,8 @@
   "product_page_info_tab_preview_content": "Preview",
   "product_page_info_tab_table_of_contents": "Table of Contents",
   "product_page_not_found_error": "Book not found",
+  "product_page_plus_promo_description": "Get 1 month of 3ook.com Plus free after purchasing this book. We'll email you a coupon code.",
+  "product_page_plus_promo_title": "Free month of Plus included",
   "product_page_preview_content_login_prompt": "Log in to read the preview content",
   "product_page_pricing_title": "Versions",
   "product_page_publish_date_label": "Publish Date",

--- a/i18n/locales/zh-Hant.json
+++ b/i18n/locales/zh-Hant.json
@@ -591,6 +591,8 @@
   "product_page_info_tab_preview_content": "試閱",
   "product_page_info_tab_table_of_contents": "目錄",
   "product_page_not_found_error": "找不到書本",
+  "product_page_plus_promo_description": "購買本書後，即可免費獲得一個月 3ook.com Plus 會籍，優惠碼將以電郵寄送。",
+  "product_page_plus_promo_title": "加贈一個月免費 Plus 會籍",
   "product_page_preview_content_login_prompt": "請先登入以閱讀試閱內容",
   "product_page_pricing_title": "購買版本",
   "product_page_publish_date_label": "上架日期",

--- a/pages/store/[nftClassId]/index.vue
+++ b/pages/store/[nftClassId]/index.vue
@@ -1,11 +1,17 @@
 <template>
   <main
     :class="[
+      'max-tablet:relative',
       'items-center',
       'px-4 laptop:px-12',
       pricingItems.length > 1 ? 'pb-[152px]' : 'pb-[120px]',
     ]"
   >
+    <BookPlusPromoAlert
+      v-if="isPlusPromoBannerVisible"
+      class="tablet:hidden sticky max-w-[1280px] rounded-t-none top-0 z-20 bg-theme-white shadow-lg"
+    />
+
     <div
       :class="[
         'z-10',
@@ -435,6 +441,11 @@
         ]"
       >
         <div class="sticky top-0 flex flex-col gap-4 tablet:pt-5">
+          <BookPlusPromoAlert
+            v-if="isPlusPromoBannerVisible"
+            class="max-tablet:hidden"
+          />
+
           <StakingControl
             v-if="isStakingTabActive"
             class="max-tablet:hidden"
@@ -589,7 +600,6 @@
                 </li>
               </ul>
               <footer class="flex flex-col gap-3">
-                <BookPlusPromoAlert v-if="bookInfo.isPlusPromoEnabled.value && !isLikerPlus && !isApp && !isUserBookOwner" />
                 <UButton
                   v-if="isUserBookOwner"
                   :label="$t('product_page_read_button_label')"
@@ -1039,6 +1049,10 @@ const from = computed(() => getRouteQuery('from') || undefined)
 const coupon = computed(() => getRouteQuery('coupon') || undefined)
 const quantity = computed(() => Math.max(parseInt(getRouteQuery('quantity'), 10) || 1, 1))
 const isRedirectedFromUpsell = computed(() => getRouteQuery('upsell') === '1')
+
+const isPlusPromoBannerVisible = computed(() => {
+  return bookInfo.isPlusPromoEnabled.value && !isLikerPlus.value && !isApp.value && !isUserBookOwner.value
+})
 
 const descriptionTags = computed(() => {
   const tags: string[] = []

--- a/pages/store/[nftClassId]/index.vue
+++ b/pages/store/[nftClassId]/index.vue
@@ -589,6 +589,7 @@
                 </li>
               </ul>
               <footer class="flex flex-col gap-3">
+                <BookPlusPromoAlert v-if="bookInfo.isPlusPromoEnabled.value && !isLikerPlus && !isApp && !isUserBookOwner" />
                 <UButton
                   v-if="isUserBookOwner"
                   :label="$t('product_page_read_button_label')"
@@ -1619,7 +1620,7 @@ async function handlePurchaseButtonClick() {
       await accountStore.login()
       if (!hasLoggedIn.value) return
     }
-    if (!isApp.value && !isRedirectedFromUpsell.value && !bookInfo.isUpsellDisabled.value) {
+    if (!isApp.value && !isRedirectedFromUpsell.value && !bookInfo.isUpsellDisabled.value && !bookInfo.isPlusPromoEnabled.value) {
       const isStartSubscription = await openUpsellPlusModalIfEligible({
         nftClassId: nftClassId.value,
         bookPrice: selectedPricingItem.value.price,

--- a/types/bookstore.d.ts
+++ b/types/bookstore.d.ts
@@ -85,6 +85,7 @@ declare interface BookstoreInfo {
   recommendedClassIds?: string[]
   promotionalImages?: string[]
   promotionalVideos?: string[]
+  plusPromoEnabled?: boolean
   timestamp: number
 }
 


### PR DESCRIPTION
Surfaces the bonus on the product page purchase panel when the book is flagged with plusPromoEnabled, hidden for existing Plus members and in-app to match the promotion code gating.

<img width="438" height="437" alt="image" src="https://github.com/user-attachments/assets/577c1cba-7a55-4330-a665-5c5e23853c39" />

Related: https://github.com/likecoin/likecoin-api-public/pull/1223