### PR TITLE
⚡️ Redirect TTS cached audio to Firebase Storage for mobile playback

### DIFF
--- a/server/api/reader/tts.get.ts
+++ b/server/api/reader/tts.get.ts
@@ -18,8 +18,9 @@ async function redirectToCachedAudio(
     : await getOrCreatePersistentDownloadURL(file)
   // Short-lived cache so Safari/AVPlayer can reuse the 302 for range probes
   // within a single segment playback instead of re-auth'ing on every probe.
-  // Each TTS segment has a distinct text+sig, so a new segment still mints
-  // a fresh redirect and runs analytics + Liker+ checks.
+  // Tradeoff: same-segment replays within 60s skip the Liker+ quota check
+  // and TTSCacheHit analytics. Per-segment text+sig means new segments still
+  // mint a fresh redirect and re-run both checks.
   setHeader(event, 'cache-control', 'private, max-age=60')
   return sendRedirect(event, downloadURL, 302)
 }

--- a/server/api/reader/tts.get.ts
+++ b/server/api/reader/tts.get.ts
@@ -8,6 +8,19 @@ import { computeTTSTextSig } from '~/shared/utils/tts-sig'
 const inFlightWrites = new Map<string, Promise<void>>()
 const IN_FLIGHT_TIMEOUT_MS = 120_000
 
+async function redirectToCachedAudio(
+  event: H3Event,
+  file: StorageFile,
+  isCustomVoice: boolean,
+) {
+  const downloadURL = isCustomVoice
+    ? await getEphemeralSignedDownloadURL(file)
+    : await getOrCreatePersistentDownloadURL(file)
+  // Per-play revalidation keeps analytics and Liker+ enforcement on this endpoint.
+  setHeader(event, 'cache-control', 'private, max-age=0, must-revalidate')
+  return sendRedirect(event, downloadURL, 302)
+}
+
 function parseRangeHeader(rangeHeader: string, totalSize: number): { start: number, end: number } | null {
   const match = rangeHeader.match(/^bytes=(\d*)-(\d*)$/)
   if (!match) return null
@@ -165,6 +178,12 @@ export default defineEventHandler(async (event) => {
       const [exists] = await file.exists()
       if (exists) {
         publishEvent(event, 'TTSCacheHit', ttsEventBase)
+        try {
+          return await redirectToCachedAudio(event, file, isCustomVoice)
+        }
+        catch (error) {
+          console.warn(`[Speech] Failed to mint download URL for ${cacheKey}, falling back to proxy:`, error)
+        }
         return await serveCachedTTS(event, bucket, cacheKey!, provider.format, isCustomVoice, session.user.evmWallet)
       }
     }
@@ -181,7 +200,14 @@ export default defineEventHandler(async (event) => {
       console.log(`[Speech] In-flight dedup for user ${session.user.evmWallet}: ${cacheKey}`)
       try {
         await pending
-        return await serveCachedTTS(event, bucket!, cacheKey, provider.format, isCustomVoice, session.user.evmWallet)
+        const cachedFile = bucket!.file(cacheKey)
+        try {
+          return await redirectToCachedAudio(event, cachedFile, isCustomVoice)
+        }
+        catch (error) {
+          console.warn(`[Speech] Dedup redirect failed for ${cacheKey}, falling back to proxy:`, error)
+          return await serveCachedTTS(event, bucket!, cacheKey, provider.format, isCustomVoice, session.user.evmWallet)
+        }
       }
       catch {
         console.warn(`[Speech] In-flight request failed, generating own for user ${session.user.evmWallet}`)
@@ -242,9 +268,29 @@ export default defineEventHandler(async (event) => {
 
   try {
     if (isBlocking) {
-      // Blocking path: full buffer with content-length (needed by native app)
       const rawBuffer = await provider.processRequest(requestParams)
       const buffer = Buffer.concat([id3Tag, rawBuffer])
+
+      publishEvent(event, 'TTSComplete', { ...ttsEventBase, audioSize: buffer.length, mode: 'blocking' })
+
+      // Prefer redirecting to the freshly-cached file so the native app
+      // streams from a CDN. Awaiting the cache write costs a small amount
+      // of latency but lets us share the cache-hit redirect path.
+      if (isCacheEnabled) {
+        const cacheFile = bucket.file(cacheKey!)
+        try {
+          await cacheFile.save(buffer, { metadata: cacheMetadata })
+          resolveInFlight?.()
+          return await redirectToCachedAudio(event, cacheFile, isCustomVoice)
+        }
+        catch (error) {
+          console.warn(`[Speech] Blocking cache write or redirect failed for user ${session.user.evmWallet}, falling back to inline buffer:`, error)
+          rejectInFlight?.(error)
+        }
+      }
+      else {
+        resolveInFlight?.()
+      }
 
       const etag = cacheKey
         ? `"${createHash('sha256').update(cacheKey).digest('hex').substring(0, 16)}"`
@@ -254,21 +300,6 @@ export default defineEventHandler(async (event) => {
       setHeader(event, 'accept-ranges', 'bytes')
       setHeader(event, 'vary', 'Range')
       setHeader(event, 'etag', etag)
-
-      if (isCacheEnabled) {
-        const cacheFile = bucket.file(cacheKey!)
-        cacheFile.save(buffer, { metadata: cacheMetadata })
-          .then(() => resolveInFlight?.())
-          .catch((error: unknown) => {
-            console.warn(`[Speech] Cache write failed for user ${session.user.evmWallet}:`, error)
-            rejectInFlight?.(error)
-          })
-      }
-      else {
-        resolveInFlight?.()
-      }
-
-      publishEvent(event, 'TTSComplete', { ...ttsEventBase, audioSize: buffer.length, mode: 'blocking' })
 
       const rangeHeader = getHeader(event, 'range')
       if (rangeHeader) {

--- a/server/api/reader/tts.get.ts
+++ b/server/api/reader/tts.get.ts
@@ -16,8 +16,11 @@ async function redirectToCachedAudio(
   const downloadURL = isCustomVoice
     ? await getEphemeralSignedDownloadURL(file)
     : await getOrCreatePersistentDownloadURL(file)
-  // Per-play revalidation keeps analytics and Liker+ enforcement on this endpoint.
-  setHeader(event, 'cache-control', 'private, max-age=0, must-revalidate')
+  // Short-lived cache so Safari/AVPlayer can reuse the 302 for range probes
+  // within a single segment playback instead of re-auth'ing on every probe.
+  // Each TTS segment has a distinct text+sig, so a new segment still mints
+  // a fresh redirect and runs analytics + Liker+ checks.
+  setHeader(event, 'cache-control', 'private, max-age=60')
   return sendRedirect(event, downloadURL, 302)
 }
 
@@ -256,6 +259,7 @@ export default defineEventHandler(async (event) => {
 
   const cacheMetadata = {
     contentType: provider.format,
+    cacheControl: isCustomVoice ? 'private, max-age=604800' : 'public, max-age=604800',
     metadata: {
       language,
       voiceId,

--- a/server/utils/storage.ts
+++ b/server/utils/storage.ts
@@ -97,16 +97,38 @@ export function getFirebaseStorageDownloadURL(bucketName: string, filePath: stri
 
 export type StorageFile = ReturnType<NonNullable<ReturnType<typeof getTTSCacheBucket>>['file']>
 
+// Narrow a possibly comma-separated token list (Firebase supports multiple
+// tokens per file for rotation) to one usable token.
+function firstToken(raw: unknown): string | undefined {
+  if (typeof raw !== 'string') return undefined
+  return raw.split(',').map(t => t.trim()).find(Boolean)
+}
+
+// Optimistic concurrency: concurrent first-time mints on the same file would
+// otherwise race on setMetadata and hand out URLs for tokens that get
+// immediately overwritten.
+const TOKEN_MINT_MAX_ATTEMPTS = 3
+
 export async function getOrCreatePersistentDownloadURL(file: StorageFile): Promise<string> {
-  const [metadata] = await file.getMetadata()
-  let token = metadata.metadata?.firebaseStorageDownloadTokens as string | undefined
-  if (!token) {
-    token = generateFirebaseDownloadToken()
-    await file.setMetadata({
-      metadata: { firebaseStorageDownloadTokens: token },
-    })
+  for (let attempt = 1; ; attempt++) {
+    const [metadata] = await file.getMetadata()
+    const existingToken = firstToken(metadata.metadata?.firebaseStorageDownloadTokens)
+    if (existingToken) {
+      return getFirebaseStorageDownloadURL(file.bucket.name, file.name, existingToken)
+    }
+    const newToken = generateFirebaseDownloadToken()
+    try {
+      await file.setMetadata(
+        { metadata: { ...metadata.metadata, firebaseStorageDownloadTokens: newToken } },
+        { ifMetagenerationMatch: metadata.metageneration },
+      )
+      return getFirebaseStorageDownloadURL(file.bucket.name, file.name, newToken)
+    }
+    catch (error) {
+      const code = (error as { code?: number }).code
+      if (code !== 412 || attempt >= TOKEN_MINT_MAX_ATTEMPTS) throw error
+    }
   }
-  return getFirebaseStorageDownloadURL(file.bucket.name, file.name, token)
 }
 
 const CUSTOM_VOICE_SIGNED_URL_TTL_MS = 60 * 60 * 1000

--- a/server/utils/storage.ts
+++ b/server/utils/storage.ts
@@ -94,3 +94,28 @@ export function generateFirebaseDownloadToken(): string {
 export function getFirebaseStorageDownloadURL(bucketName: string, filePath: string, token: string): string {
   return `https://firebasestorage.googleapis.com/v0/b/${bucketName}/o/${encodeURIComponent(filePath)}?alt=media&token=${token}`
 }
+
+export type StorageFile = ReturnType<NonNullable<ReturnType<typeof getTTSCacheBucket>>['file']>
+
+export async function getOrCreatePersistentDownloadURL(file: StorageFile): Promise<string> {
+  const [metadata] = await file.getMetadata()
+  let token = metadata.metadata?.firebaseStorageDownloadTokens as string | undefined
+  if (!token) {
+    token = generateFirebaseDownloadToken()
+    await file.setMetadata({
+      metadata: { firebaseStorageDownloadTokens: token },
+    })
+  }
+  return getFirebaseStorageDownloadURL(file.bucket.name, file.name, token)
+}
+
+const CUSTOM_VOICE_SIGNED_URL_TTL_MS = 60 * 60 * 1000
+
+export async function getEphemeralSignedDownloadURL(file: StorageFile): Promise<string> {
+  const [url] = await file.getSignedUrl({
+    version: 'v4',
+    action: 'read',
+    expires: Date.now() + CUSTOM_VOICE_SIGNED_URL_TTL_MS,
+  })
+  return url
+}


### PR DESCRIPTION
Instead of re-streaming cached TTS audio through Nuxt, 302-redirect to a direct Firebase Storage URL so mobile players (iOS AVPlayer in particular) can talk to a real CDN with proper range-request handling. All three cached code paths redirect: cache hits, in-flight dedup wakeups, and the blocking path once its buffer has been persisted. Public voices use a permanent Firebase download token; custom voices use a 1-hour V4 signed URL so a leaked URL cannot outlive a Liker+ revocation. Cache-Control on the 302 forces clients to revalidate per play so analytics and Liker+ checks still run through this endpoint, and a graceful fallback preserves the proxy or inline-buffer paths if URL minting fails.