### PR TITLE
🐛 Persist TTS cache custom metadata via admin SDK key

### DIFF
--- a/server/api/reader/tts.get.ts
+++ b/server/api/reader/tts.get.ts
@@ -230,7 +230,7 @@ export default defineEventHandler(async (event) => {
 
   const cacheMetadata = {
     contentType: provider.format,
-    customMetadata: {
+    metadata: {
       language,
       voiceId,
       provider: provider.provider,


### PR DESCRIPTION
The `customMetadata` key is from the Firebase client SDK; the server uses `firebase-admin/storage` (GCS), which expects user-defined fields under a nested `metadata` key. As a result the language/voice/text fields were silently dropped from cached TTS objects.