### PR TITLE
⚡️ Defer Meta Pixel composable lookup to mapped events

### DIFF
--- a/composables/use-logger.ts
+++ b/composables/use-logger.ts
@@ -28,7 +28,6 @@ export function useLogEvent(eventName: string, eventParams: EventParams = {}) {
     console.error(`Failed to track event: ${eventName}`, eventParams)
   }
 
-  const { proxy } = useScriptMetaPixel()
   try {
     const eventNameMapping: { [key: string]: string } = {
       view_item: 'ViewContent',
@@ -48,6 +47,7 @@ export function useLogEvent(eventName: string, eventParams: EventParams = {}) {
         predicted_ltv: predictedLTV,
       } = eventParams
       const eventId = paymentId ? `${eventNameMapping[eventName]}_${paymentId}` : undefined
+      const { proxy } = useScriptMetaPixel()
       proxy.fbq('track', eventNameMapping[eventName], {
         currency,
         value,


### PR DESCRIPTION
useScriptMetaPixel() was called on every useLogEvent invocation, including hot-path reader events (arrow-key, swipe). Only 7 events map to fbq, so hoist the lookup inside the mapping-table branch.