### PR TITLE
⚡️ Balance TTS segment lengths to reduce playback lag

### DIFF
--- a/test/unit/tts.test.ts
+++ b/test/unit/tts.test.ts
@@ -177,6 +177,27 @@ describe('splitTextIntoSegments', () => {
     const result = splitTextIntoSegments(text)
     expect(result.join('')).toBe(text)
   })
+
+  // Regression: balanced splitter must not strand consecutive punctuation in
+  // its own segment (which would then be filtered as non-speakable and lost)
+  it('preserves consecutive punctuation between long passages', () => {
+    const long = 'あ'.repeat(100)
+    const text = `${long}。。${long}`
+    const result = splitTextIntoSegments(text)
+    expect(result.join('')).toBe(text)
+  })
+
+  it('produces segments with uniform length variance to smooth TTS playback', () => {
+    const clause = 'あ'.repeat(29)
+    const text = `${clause}。${clause}。${clause}。${clause}。${clause}。${clause}。${clause}。${clause}。`
+    const result = splitTextIntoSegments(text)
+    expect(result.join('')).toBe(text)
+    const target = text.length / result.length
+    for (const seg of result) {
+      expect(seg.length).toBeLessThanOrEqual(100)
+      expect(Math.abs(seg.length - target)).toBeLessThan(target * 0.5)
+    }
+  })
 })
 
 describe('mergeShortTTSSegments', () => {

--- a/test/unit/tts.test.ts
+++ b/test/unit/tts.test.ts
@@ -192,11 +192,16 @@ describe('splitTextIntoSegments', () => {
     const text = `${clause}。${clause}。${clause}。${clause}。${clause}。${clause}。${clause}。${clause}。`
     const result = splitTextIntoSegments(text)
     expect(result.join('')).toBe(text)
-    const target = text.length / result.length
-    for (const seg of result) {
-      expect(seg.length).toBeLessThanOrEqual(100)
-      expect(Math.abs(seg.length - target)).toBeLessThan(target * 0.5)
+    const lengths = result.map(seg => seg.length)
+    for (const length of lengths) {
+      expect(length).toBeLessThanOrEqual(100)
     }
+    // Tight spread catches regressions to a greedy fill pattern (e.g.
+    // 100/100/40) which a weaker 50%-variance bound would silently accept.
+    const maxLen = Math.max(...lengths)
+    const minLen = Math.min(...lengths)
+    expect(maxLen - minLen).toBeLessThanOrEqual(30)
+    expect(minLen).toBeGreaterThanOrEqual(60)
   })
 })
 

--- a/utils/tts.ts
+++ b/utils/tts.ts
@@ -33,18 +33,34 @@ const MIN_SEGMENT_LENGTH = 15
  * smooths streaming playback.
  */
 function mergeParts(parts: string[]): string[] {
+  // Keep every entry speakable so the balanced splitter can't strand a
+  // punctuation-only segment, which would be filtered and break the
+  // `result.join('') === text` integrity invariant.
   const cleaned: string[] = []
-  let totalLength = 0
-  let maxPartLen = 0
+  let pendingPrefix = ''
   for (const part of parts) {
     const trimmed = part.replace(/[\s\u200B]+/g, ' ').trim()
     if (!trimmed) continue
-    cleaned.push(trimmed)
-    totalLength += trimmed.length
-    if (trimmed.length > maxPartLen) maxPartLen = trimmed.length
+    if (SPEAKABLE_REGEX.test(trimmed)) {
+      cleaned.push(pendingPrefix + trimmed)
+      pendingPrefix = ''
+    }
+    else if (cleaned.length > 0) {
+      cleaned[cleaned.length - 1] += trimmed
+    }
+    else {
+      pendingPrefix += trimmed
+    }
   }
   const n = cleaned.length
   if (!n) return []
+
+  let totalLength = 0
+  let maxPartLen = 0
+  for (const p of cleaned) {
+    totalLength += p.length
+    if (p.length > maxPartLen) maxPartLen = p.length
+  }
 
   const prefix: number[] = new Array(n + 1)
   prefix[0] = 0
@@ -82,8 +98,7 @@ function mergeParts(parts: string[]): string[] {
     for (let j = 0; j < splits.length - 1; j++) {
       const len = prefix[splits[j + 1]!]! - prefix[splits[j]!]!
       if (len > maxLen) maxLen = len
-      const segment = cleaned.slice(splits[j]!, splits[j + 1]!).join('')
-      if (SPEAKABLE_REGEX.test(segment)) segments.push(segment)
+      segments.push(cleaned.slice(splits[j]!, splits[j + 1]!).join(''))
     }
     return { segments, maxLen }
   }

--- a/utils/tts.ts
+++ b/utils/tts.ts
@@ -75,7 +75,7 @@ function mergeParts(parts: string[]): string[] {
     const splits: number[] = [0]
     for (let j = 1; j < k; j++) {
       const goal = j * target
-      const prev = splits.at(-1)!
+      const prev = splits[splits.length - 1]!
       const maxIdx = n - (k - j)
       let best = prev + 1
       let bestDiff = Math.abs(prefix[best]! - goal)
@@ -106,7 +106,10 @@ function mergeParts(parts: string[]): string[] {
   const initialK = Math.min(n, Math.ceil(totalLength / MAX_SEGMENT_LENGTH))
 
   // If a single atomic part is already larger than MAX, no amount of
-  // re-partitioning fits it — let the caller re-split via a finer delimiter.
+  // re-partitioning fits it. Return the initialK split; when called with
+  // sentence parts, splitTextIntoSegments retries via CLAUSE_REGEX. At the
+  // clause level there is no finer delimiter, so oversize segments pass
+  // through — the TTS backend must tolerate them.
   if (maxPartLen > MAX_SEGMENT_LENGTH) return buildSegments(initialK).segments
 
   for (let k = initialK; k <= n; k++) {

--- a/utils/tts.ts
+++ b/utils/tts.ts
@@ -26,35 +26,79 @@ const SPEAKABLE_REGEX = /[\p{L}\p{N}]/u
 const MAX_SEGMENT_LENGTH = 100
 const MIN_SEGMENT_LENGTH = 15
 
+/**
+ * Merge tokenized parts (from a punctuation split) into segments that are as
+ * uniform in length as possible, while always breaking at a punctuation
+ * boundary. Uniform segments reduce variance in TTS API generation time, which
+ * smooths streaming playback.
+ */
 function mergeParts(parts: string[]): string[] {
-  const result: string[] = []
-  let current = ''
+  const cleaned: string[] = []
+  let totalLength = 0
+  let maxPartLen = 0
   for (const part of parts) {
     const trimmed = part.replace(/[\s\u200B]+/g, ' ').trim()
     if (!trimmed) continue
-    if (
-      trimmed.length === 1
-      || current.length + trimmed.length < MAX_SEGMENT_LENGTH
-      || (trimmed.length < MIN_SEGMENT_LENGTH && current.length + trimmed.length <= MAX_SEGMENT_LENGTH * 1.5)
-    ) {
-      current += trimmed
-    }
-    else {
-      if (SPEAKABLE_REGEX.test(current)) result.push(current)
-      current = trimmed
-    }
+    cleaned.push(trimmed)
+    totalLength += trimmed.length
+    if (trimmed.length > maxPartLen) maxPartLen = trimmed.length
   }
-  if (SPEAKABLE_REGEX.test(current)) {
-    // Merge short trailing text into the previous segment
-    if (current.length < MIN_SEGMENT_LENGTH && result.length > 0
-      && result[result.length - 1]!.length + current.length <= MAX_SEGMENT_LENGTH) {
-      result[result.length - 1] += current
+  const n = cleaned.length
+  if (!n) return []
+
+  const prefix: number[] = new Array(n + 1)
+  prefix[0] = 0
+  for (let i = 0; i < n; i++) prefix[i + 1] = prefix[i]! + cleaned[i]!.length
+
+  // Place each of k-1 boundaries at whichever part boundary lands closest to
+  // an evenly-spaced target (j * totalLength / k). Because prefix sums are
+  // monotonic, |prefix[i] - goal| is unimodal, so the search short-circuits
+  // as soon as distance stops shrinking.
+  const buildSegments = (k: number): { segments: string[], maxLen: number } => {
+    const target = totalLength / k
+    const splits: number[] = [0]
+    for (let j = 1; j < k; j++) {
+      const goal = j * target
+      const prev = splits.at(-1)!
+      const maxIdx = n - (k - j)
+      let best = prev + 1
+      let bestDiff = Math.abs(prefix[best]! - goal)
+      for (let i = prev + 2; i <= maxIdx; i++) {
+        const diff = Math.abs(prefix[i]! - goal)
+        if (diff < bestDiff) {
+          best = i
+          bestDiff = diff
+        }
+        else {
+          break
+        }
+      }
+      splits.push(best)
     }
-    else {
-      result.push(current)
+    splits.push(n)
+
+    const segments: string[] = []
+    let maxLen = 0
+    for (let j = 0; j < splits.length - 1; j++) {
+      const len = prefix[splits[j + 1]!]! - prefix[splits[j]!]!
+      if (len > maxLen) maxLen = len
+      const segment = cleaned.slice(splits[j]!, splits[j + 1]!).join('')
+      if (SPEAKABLE_REGEX.test(segment)) segments.push(segment)
     }
+    return { segments, maxLen }
   }
-  return result
+
+  const initialK = Math.min(n, Math.ceil(totalLength / MAX_SEGMENT_LENGTH))
+
+  // If a single atomic part is already larger than MAX, no amount of
+  // re-partitioning fits it — let the caller re-split via a finer delimiter.
+  if (maxPartLen > MAX_SEGMENT_LENGTH) return buildSegments(initialK).segments
+
+  for (let k = initialK; k <= n; k++) {
+    const result = buildSegments(k)
+    if (result.maxLen <= MAX_SEGMENT_LENGTH) return result.segments
+  }
+  return buildSegments(n).segments
 }
 
 export function splitTextIntoSegments(text: string): string[] {


### PR DESCRIPTION
Greedy pack-to-MAX merging produced uneven segments (e.g. 100/100/50), which translated into uneven TTS generation times and audible stalls during streaming playback. Replace it with a closest-to-target split over prefix sums so segments cluster tightly around totalLength / k.