### PR TITLE
[TAS-5656] 🔧 Update TTS voice IDs to normalized versions

### DIFF
--- a/server/utils/tts-minimax.ts
+++ b/server/utils/tts-minimax.ts
@@ -15,10 +15,10 @@ interface VoiceConfig {
 const VOICE_CONFIG: Record<string, VoiceConfig> = {
   0: { minimaxVoiceId: 'Chinese (Mandarin)_Warm_Bestie', displayName: 'Female Narrator' },
   1: { minimaxVoiceId: 'Chinese (Mandarin)_Southern_Young_Man', displayName: 'Male Narrator' },
-  astro: { minimaxVoiceId: 'three_book_astro_v0', displayName: 'Astro' },
-  aurora: { minimaxVoiceId: 'three_book_aurora_v0', displayName: 'Aurora' },
-  pazu: { minimaxVoiceId: 'book_pazu_v2', displayName: 'Pazu' },
-  phoebe: { minimaxVoiceId: 'phoebe_v1', model: 'speech-2.6-hd', displayName: 'Phoebe' },
+  astro: { minimaxVoiceId: 'three_book_astro_v1', displayName: 'Astro' },
+  aurora: { minimaxVoiceId: 'three_book_aurora_v1', displayName: 'Aurora' },
+  pazu: { minimaxVoiceId: 'three_book_pazu_v3', displayName: 'Pazu' },
+  phoebe: { minimaxVoiceId: 'three_book_phoebe_v2', model: 'speech-2.6-hd', displayName: 'Phoebe' },
 }
 
 export const KNOWN_VOICE_IDS = new Set(Object.keys(VOICE_CONFIG))


### PR DESCRIPTION
Switch Astro, Aurora, Pazu, and Phoebe to the new `three_book_*` voice IDs with normalization enabled on the Minimax side.