### PR TITLE
♻️ Dedupe custom voice fetches inside useCustomVoice

### DIFF
--- a/components/TTSPlayerModal.vue
+++ b/components/TTSPlayerModal.vue
@@ -219,7 +219,7 @@ const { user } = useUserSession()
 const subscription = useSubscriptionModal()
 const { errorModal, handleError } = useErrorHandler()
 
-const { customVoice, hasCustomVoice, isLoading: isCustomVoiceLoading, fetchCustomVoice } = useCustomVoice()
+const { customVoice, hasCustomVoice, fetchCustomVoice } = useCustomVoice()
 const localeRoute = useLocaleRoute()
 
 const emit = defineEmits<{
@@ -463,7 +463,7 @@ watch(
 
 onMounted(() => {
   setTTSLanguageVoice(props.specificLanguageVoice)
-  if (user.value && !customVoice.value && !isCustomVoiceLoading.value) {
+  if (user.value) {
     fetchCustomVoice()
   }
 })

--- a/composables/use-custom-voice.ts
+++ b/composables/use-custom-voice.ts
@@ -6,29 +6,38 @@ export function useCustomVoice() {
   const isLoading = useState<boolean>('custom-voice-loading', () => false)
   const inflightFetch = useState<Promise<void> | null>('custom-voice-inflight', () => null)
 
+  const { loggedIn: hasLoggedIn } = useUserSession()
+
   const hasCustomVoice = computed(() => !!customVoice.value?.voiceId)
 
   function fetchCustomVoice(): Promise<void> {
     if (isLoaded.value) return Promise.resolve()
     if (inflightFetch.value) return inflightFetch.value
     const task = (async () => {
-      isLoading.value = true
       try {
         const data = await $fetch<CustomVoiceData | null>('/api/user/custom-voice')
+        if (!hasLoggedIn.value) return
         customVoice.value = data
+        isLoaded.value = true
       }
       catch (error) {
         console.error('[CustomVoice] Failed to fetch:', error)
       }
       finally {
-        isLoaded.value = true
-        isLoading.value = false
         inflightFetch.value = null
       }
     })()
     inflightFetch.value = task
     return task
   }
+
+  watch(hasLoggedIn, (loggedIn, wasLoggedIn) => {
+    if (!loggedIn && wasLoggedIn) {
+      customVoice.value = null
+      isLoaded.value = false
+      inflightFetch.value = null
+    }
+  })
 
   async function uploadCustomVoice(params: { audio: File, voiceName: string, voiceLanguage?: string, avatar?: File, promptAudio?: File, promptText?: string }) {
     if (isLoading.value) return

--- a/composables/use-custom-voice.ts
+++ b/composables/use-custom-voice.ts
@@ -2,22 +2,32 @@ import type { CustomVoiceData } from '~/shared/types/custom-voice'
 
 export function useCustomVoice() {
   const customVoice = useState<CustomVoiceData | null>('custom-voice', () => null)
+  const isLoaded = useState<boolean>('custom-voice-loaded', () => false)
   const isLoading = useState<boolean>('custom-voice-loading', () => false)
+  const inflightFetch = useState<Promise<void> | null>('custom-voice-inflight', () => null)
 
   const hasCustomVoice = computed(() => !!customVoice.value?.voiceId)
 
-  async function fetchCustomVoice() {
-    isLoading.value = true
-    try {
-      const data = await $fetch<CustomVoiceData | null>('/api/user/custom-voice')
-      customVoice.value = data
-    }
-    catch (error) {
-      console.error('[CustomVoice] Failed to fetch:', error)
-    }
-    finally {
-      isLoading.value = false
-    }
+  function fetchCustomVoice(): Promise<void> {
+    if (isLoaded.value) return Promise.resolve()
+    if (inflightFetch.value) return inflightFetch.value
+    const task = (async () => {
+      isLoading.value = true
+      try {
+        const data = await $fetch<CustomVoiceData | null>('/api/user/custom-voice')
+        customVoice.value = data
+      }
+      catch (error) {
+        console.error('[CustomVoice] Failed to fetch:', error)
+      }
+      finally {
+        isLoaded.value = true
+        isLoading.value = false
+        inflightFetch.value = null
+      }
+    })()
+    inflightFetch.value = task
+    return task
   }
 
   async function uploadCustomVoice(params: { audio: File, voiceName: string, voiceLanguage?: string, avatar?: File, promptAudio?: File, promptText?: string }) {
@@ -44,6 +54,7 @@ export function useCustomVoice() {
         body: formData,
       })
       customVoice.value = data
+      isLoaded.value = true
       return data
     }
     finally {
@@ -74,6 +85,7 @@ export function useCustomVoice() {
     try {
       await $fetch('/api/user/custom-voice', { method: 'DELETE' })
       customVoice.value = null
+      isLoaded.value = true
     }
     finally {
       isLoading.value = false

--- a/pages/account/index.vue
+++ b/pages/account/index.vue
@@ -783,13 +783,10 @@ function handleMigrateLegacyBookButtonClick() {
   useLogEvent('migrate_legacy_book_button_click')
 }
 
-async function handleOpenCustomVoiceModal() {
-  await customVoiceModal.open({
+function handleOpenCustomVoiceModal() {
+  customVoiceModal.open({
     existingVoice: customVoice.value,
-    onUploaded: () => fetchCustomVoice(),
-    onDeleted: () => fetchCustomVoice(),
-  }).result
-  fetchCustomVoice()
+  })
 }
 
 async function handleClaimStakingRewardButtonClick() {

--- a/pages/reader/epub.vue
+++ b/pages/reader/epub.vue
@@ -353,9 +353,9 @@ if (!hasLoggedIn.value) {
   await navigateTo(localeRoute({ name: 'account', query: route.query }))
 }
 
-const { customVoice, isLoading: isCustomVoiceLoading, fetchCustomVoice } = useCustomVoice()
+const { fetchCustomVoice } = useCustomVoice()
 onMounted(() => {
-  if (hasLoggedIn.value && !customVoice.value && !isCustomVoiceLoading.value) {
+  if (hasLoggedIn.value) {
     fetchCustomVoice()
   }
 })

--- a/pages/reader/pdf.vue
+++ b/pages/reader/pdf.vue
@@ -42,9 +42,9 @@ if (!hasLoggedIn.value) {
   await navigateTo(localeRoute({ name: 'account', query: route.query }))
 }
 
-const { customVoice, isLoading: isCustomVoiceLoading, fetchCustomVoice } = useCustomVoice()
+const { fetchCustomVoice } = useCustomVoice()
 onMounted(() => {
-  if (hasLoggedIn.value && !customVoice.value && !isCustomVoiceLoading.value) {
+  if (hasLoggedIn.value) {
     fetchCustomVoice()
   }
 })


### PR DESCRIPTION
Move the fetch-once guard from three mount-time call sites into the composable itself, and cache the in-flight promise so concurrent awaiters (e.g. account page modal gate) resolve once data is ready rather than short-circuiting to undefined.