### PR TITLE
✨ Hint Plus promo coupon delivery on claim page

### DIFF
--- a/components/BookPlusPromoAlert.vue
+++ b/components/BookPlusPromoAlert.vue
@@ -1,7 +1,14 @@
+<script setup lang="ts">
+defineProps<{
+  title: string
+  description: string
+}>()
+</script>
+
 <template>
   <UAlert
-    :title="$t('product_page_plus_promo_title')"
-    :description="$t('product_page_plus_promo_description')"
+    :title="title"
+    :description="description"
     icon="i-material-symbols-celebration-outline-rounded"
     color="secondary"
     variant="subtle"

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -288,6 +288,8 @@
   "claim_page_login_cta_description": "Only one step away from reading your book",
   "claim_page_missing_parameters": "Invalid URL",
   "claim_page_no_wallet_connected": "No wallet connected",
+  "claim_page_plus_promo_description": "We'll email you a Plus coupon code shortly. Redeem it to activate your free month of 3ook.com Plus.",
+  "claim_page_plus_promo_title": "Free month of Plus included",
   "claim_page_purchase_successful_label": "You've purchased successfully",
   "claim_page_start_reading_button_label": "Start Reading",
   "claim_page_start_reading_footer_label": "Your book is ready",

--- a/i18n/locales/zh-Hant.json
+++ b/i18n/locales/zh-Hant.json
@@ -288,6 +288,8 @@
   "claim_page_login_cta_description": "距離閲讀只差一步",
   "claim_page_missing_parameters": "網址不正確",
   "claim_page_no_wallet_connected": "沒有連接錢包",
+  "claim_page_plus_promo_description": "我們將盡快以電郵發送 Plus 優惠碼給您，兌換後即可啟用一個月免費 3ook.com Plus 會籍。",
+  "claim_page_plus_promo_title": "加贈一個月免費 Plus 會籍",
   "claim_page_purchase_successful_label": "你已成功購買",
   "claim_page_start_reading_button_label": "開始閱讀",
   "claim_page_start_reading_footer_label": "書籍已抵達您的書架！",

--- a/pages/store/[nftClassId]/index.vue
+++ b/pages/store/[nftClassId]/index.vue
@@ -11,7 +11,11 @@
       v-if="isPlusPromoBannerVisible"
       class="tablet:hidden sticky top-0 z-20 w-full max-w-[1280px] bg-(--app-bg) shadow-lg rounded-b-xl"
     >
-      <BookPlusPromoAlert class="rounded-t-none" />
+      <BookPlusPromoAlert
+        class="rounded-t-none"
+        :title="$t('product_page_plus_promo_title')"
+        :description="$t('product_page_plus_promo_description')"
+      />
     </aside>
 
     <div
@@ -457,6 +461,8 @@
           <BookPlusPromoAlert
             v-if="isPlusPromoBannerVisible"
             class="max-tablet:hidden"
+            :title="$t('product_page_plus_promo_title')"
+            :description="$t('product_page_plus_promo_description')"
           />
 
           <StakingControl

--- a/pages/store/claim.vue
+++ b/pages/store/claim.vue
@@ -31,6 +31,13 @@
         />
       </div>
 
+      <BookPlusPromoAlert
+        v-if="isPlusPromoBannerVisible"
+        class="w-full max-w-[348px] mb-6"
+        :title="$t('claim_page_plus_promo_title')"
+        :description="$t('claim_page_plus_promo_description')"
+      />
+
       <BookLoadingScreen
         :book-name="bookInfo?.name.value"
         :book-cover-src="bookCoverSrc"
@@ -96,6 +103,7 @@ const likeCoinSessionAPI = useLikeCoinSessionAPI()
 const localeRoute = useLocaleRoute()
 const getRouteQuery = useRouteQuery()
 const { loggedIn: hasLoggedIn, user } = useUserSession()
+const { isApp } = useAppDetection()
 const accountStore = useAccountStore()
 const nftStore = useNFTStore()
 const bookshelfStore = useBookshelfStore()
@@ -213,6 +221,10 @@ const receivedNFTId = computed(() => bookInfo.firstUserOwnedNFTId.value)
 const canStartReading = computed(() => !!receivedNFTId.value)
 const isCheckingItemsDelivery = ref(false)
 const hasBypassedIndexer = ref(false)
+
+const isPlusPromoBannerVisible = computed(() => {
+  return bookInfo.isPlusPromoEnabled.value && !user.value?.isLikerPlus && !isApp.value
+})
 
 onMounted(async () => {
   isLoading.value = true


### PR DESCRIPTION
Surfaces a post-purchase banner for non-Plus buyers of a plusPromoEnabled book, letting them know the coupon code will arrive by email. Refactors BookPlusPromoAlert to accept title and description props so the product and claim pages can reuse the same alert with context-appropriate copy.
<img width="534" height="660" alt="image" src="https://github.com/user-attachments/assets/0d6e6648-8769-4b72-ae52-dc1404004794" />
