### PR TITLE
📈 Instrument TTS trial usage for conversion analysis

### DIFF
--- a/components/TTSPlayerModal.vue
+++ b/components/TTSPlayerModal.vue
@@ -291,6 +291,7 @@ const {
   cyclePlaybackRate,
   showOfflineModal,
   forceResume,
+  buildTTSEventPayload,
 } = useTextToSpeech({
   nftClassId: props.nftClassId,
   bookName: props.bookTitle,
@@ -313,10 +314,9 @@ const {
       )
     ) {
       stopTextToSpeech()
-      useLogEvent('tts_trial_exhausted', {
-        nft_class_id: props.nftClassId,
+      useLogEvent('tts_trial_exhausted', buildTTSEventPayload({
         is_app: isApp.value,
-      })
+      }))
       if (isApp.value) {
         errorModal.open({
           title: $t('tts_free_trial_limit_error_title'),

--- a/components/TTSPlayerModal.vue
+++ b/components/TTSPlayerModal.vue
@@ -313,6 +313,10 @@ const {
       )
     ) {
       stopTextToSpeech()
+      useLogEvent('tts_trial_exhausted', {
+        nft_class_id: props.nftClassId,
+        is_app: isApp.value,
+      })
       if (isApp.value) {
         errorModal.open({
           title: $t('tts_free_trial_limit_error_title'),

--- a/composables/use-logger.ts
+++ b/composables/use-logger.ts
@@ -61,6 +61,7 @@ const INTERCOM_EVENT_ALLOWLIST = new Set<string>([
   'tts_completed',
   'tts_error',
   'tts_try_modal_open',
+  'tts_trial_exhausted',
 
   // Annotations
   'annotation_created',

--- a/composables/use-text-to-speech.ts
+++ b/composables/use-text-to-speech.ts
@@ -46,14 +46,26 @@ export function useTextToSpeech(options: TTSOptions) {
     setTTSLanguageVoice,
   } = useTTSVoice({ bookLanguage, customVoice: options.customVoice })
 
-  function buildTTSEventBase(extras: Record<string, unknown> = {}) {
+  function parseLanguageVoice(languageVoice: string) {
+    const [language = '', ...voiceIdParts] = languageVoice.split('_')
+    return { language, voiceId: voiceIdParts.join('_') }
+  }
+
+  function buildTTSEventPayload(extras: Record<string, unknown> = {}) {
+    const languageVoice = ttsLanguageVoice.value || ''
+    const { voiceId } = parseLanguageVoice(languageVoice)
     return {
       nft_class_id: nftClassId,
       is_liker_plus_at_event_time: !!sessionUser.value?.isLikerPlus,
-      cumulative_chars_used: ttsTrialUsage.charactersUsed.value,
-      chars_remaining: ttsTrialUsage.charactersRemaining.value,
+      ...(ttsTrialUsage.isLoaded.value
+        ? {
+            cumulative_chars_used: ttsTrialUsage.charactersUsed.value,
+            chars_remaining: ttsTrialUsage.charactersRemaining.value,
+          }
+        : {}),
       book_language: toValue(bookLanguage) || undefined,
-      voice_id: ttsLanguageVoice.value,
+      voice_id: voiceId || languageVoice || undefined,
+      language_voice: languageVoice || undefined,
       ...extras,
     }
   }
@@ -157,7 +169,7 @@ export function useTextToSpeech(options: TTSOptions) {
   player.on('allEnded', () => {
     isTextToSpeechPlaying.value = false
     isTextToSpeechLoading.value = false
-    useLogEvent('tts_completed', buildTTSEventBase())
+    useLogEvent('tts_completed', buildTTSEventPayload())
     options.onAllSegmentsPlayed?.()
   })
 
@@ -202,7 +214,7 @@ export function useTextToSpeech(options: TTSOptions) {
     options.onError?.(error)
     if (consecutiveAudioErrors.value >= MAX_CONSECUTIVE_ERRORS) {
       console.warn(`TTS paused after ${MAX_CONSECUTIVE_ERRORS} consecutive audio errors`)
-      useLogEvent('tts_error', buildTTSEventBase({ consecutive_errors: consecutiveAudioErrors.value }))
+      useLogEvent('tts_error', buildTTSEventPayload({ consecutive_errors: consecutiveAudioErrors.value }))
       pauseTextToSpeech()
       return
     }
@@ -440,9 +452,9 @@ export function useTextToSpeech(options: TTSOptions) {
       return `/api/reader/tts?${params.toString()}`
     }
 
-    const [languagePart, ...voiceIdParts] = ttsLanguageVoice.value.split('_')
-    const language = languagePart || 'zh-HK'
-    const voiceId = voiceIdParts.join('_')
+    const parsed = parseLanguageVoice(ttsLanguageVoice.value)
+    const language = parsed.language || 'zh-HK'
+    const voiceId = parsed.voiceId
     const params = new URLSearchParams({
       text: sanitizedText,
       language,
@@ -494,7 +506,7 @@ export function useTextToSpeech(options: TTSOptions) {
       consecutiveAudioErrors.value = 0
       isTextToSpeechOn.value = true
 
-      useLogEvent('tts_start', buildTTSEventBase())
+      useLogEvent('tts_start', buildTTSEventPayload())
 
       isTextToSpeechLoading.value = true
       player.load({
@@ -652,5 +664,6 @@ export function useTextToSpeech(options: TTSOptions) {
     stopTextToSpeech,
     cyclePlaybackRate,
     forceResume,
+    buildTTSEventPayload,
   }
 }

--- a/composables/use-text-to-speech.ts
+++ b/composables/use-text-to-speech.ts
@@ -31,6 +31,9 @@ export function useTextToSpeech(options: TTSOptions) {
 
   const config = useRuntimeConfig()
 
+  const ttsTrialUsage = useTTSTrialUsage()
+  ttsTrialUsage.fetchUsage()
+
   // Use the TTS voice composable
   const {
     isBookEnglish,
@@ -42,6 +45,18 @@ export function useTextToSpeech(options: TTSOptions) {
     ttsLanguageVoiceValues,
     setTTSLanguageVoice,
   } = useTTSVoice({ bookLanguage, customVoice: options.customVoice })
+
+  function buildTTSEventBase(extras: Record<string, unknown> = {}) {
+    return {
+      nft_class_id: nftClassId,
+      is_liker_plus_at_event_time: !!sessionUser.value?.isLikerPlus,
+      cumulative_chars_used: ttsTrialUsage.charactersUsed.value,
+      chars_remaining: ttsTrialUsage.charactersRemaining.value,
+      book_language: toValue(bookLanguage) || undefined,
+      voice_id: ttsLanguageVoice.value,
+      ...extras,
+    }
+  }
 
   // Pick player implementation — both are created upfront (inert until load()),
   // and the proxy delegates to the correct one based on the reactive flag.
@@ -142,7 +157,7 @@ export function useTextToSpeech(options: TTSOptions) {
   player.on('allEnded', () => {
     isTextToSpeechPlaying.value = false
     isTextToSpeechLoading.value = false
-    useLogEvent('tts_completed', { nft_class_id: nftClassId })
+    useLogEvent('tts_completed', buildTTSEventBase())
     options.onAllSegmentsPlayed?.()
   })
 
@@ -187,7 +202,7 @@ export function useTextToSpeech(options: TTSOptions) {
     options.onError?.(error)
     if (consecutiveAudioErrors.value >= MAX_CONSECUTIVE_ERRORS) {
       console.warn(`TTS paused after ${MAX_CONSECUTIVE_ERRORS} consecutive audio errors`)
-      useLogEvent('tts_error', { nft_class_id: nftClassId, consecutive_errors: consecutiveAudioErrors.value })
+      useLogEvent('tts_error', buildTTSEventBase({ consecutive_errors: consecutiveAudioErrors.value }))
       pauseTextToSpeech()
       return
     }
@@ -392,10 +407,24 @@ export function useTextToSpeech(options: TTSOptions) {
     }
   }
 
+  // Mirrors the server's per-segment `updateUserTTSCharacterUsage` charge.
+  // Key includes voiceId because switching voice invalidates the server's
+  // TTS cache and produces a new charge.
+  const optimisticallyCountedSegments = new Set<string>()
+
+  function recordOptimisticSegmentUsage(element: TTSSegment, sanitizedText: string) {
+    if (sessionUser.value?.isLikerPlus) return
+    const key = `${ttsLanguageVoice.value}:${element.id}`
+    if (optimisticallyCountedSegments.has(key)) return
+    optimisticallyCountedSegments.add(key)
+    ttsTrialUsage.recordOptimisticUsage(sanitizedText.length)
+  }
+
   function getAudioSrc(element: TTSSegment): string {
     if (element.audioSrc) return element.audioSrc
 
     const sanitizedText = sanitizeTTSText(element.text)
+    recordOptimisticSegmentUsage(element, sanitizedText)
 
     if (ttsLanguageVoice.value === 'custom') {
       const language = resolveCustomVoiceLanguage()
@@ -465,9 +494,7 @@ export function useTextToSpeech(options: TTSOptions) {
       consecutiveAudioErrors.value = 0
       isTextToSpeechOn.value = true
 
-      useLogEvent('tts_start', {
-        nft_class_id: nftClassId,
-      })
+      useLogEvent('tts_start', buildTTSEventBase())
 
       isTextToSpeechLoading.value = true
       player.load({

--- a/composables/use-text-to-speech.ts
+++ b/composables/use-text-to-speech.ts
@@ -419,20 +419,19 @@ export function useTextToSpeech(options: TTSOptions) {
     }
   }
 
-  // Mirrors the server's per-segment `updateUserTTSCharacterUsage` charge.
-  // Key includes voiceId because switching voice invalidates the server's
-  // TTS cache and produces a new charge.
-  const optimisticallyCountedSegments = new Set<string>()
+  // Estimate only: the server charges on cache miss, so we dedupe by the
+  // same shape (language+voice+text) that determines its cache key.
+  const optimisticallyCountedRequests = new Set<string>()
 
-  function recordOptimisticSegmentUsage(element: TTSSegment, sanitizedText: string) {
+  function recordOptimisticSegmentUsage(sanitizedText: string) {
     if (sessionUser.value?.isLikerPlus) return
     // Custom voice is gated to Plus; the server rejects non-Plus requests
     // before charging, so decrementing here would drift the local counter.
     if (ttsLanguageVoice.value === 'custom') return
     if (!ttsTrialUsage.isLoaded.value) return
-    const key = `${ttsLanguageVoice.value}:${element.id}`
-    if (optimisticallyCountedSegments.has(key)) return
-    optimisticallyCountedSegments.add(key)
+    const key = `${ttsLanguageVoice.value}:${sanitizedText}`
+    if (optimisticallyCountedRequests.has(key)) return
+    optimisticallyCountedRequests.add(key)
     ttsTrialUsage.recordOptimisticUsage(sanitizedText.length)
   }
 
@@ -440,7 +439,7 @@ export function useTextToSpeech(options: TTSOptions) {
     if (element.audioSrc) return element.audioSrc
 
     const sanitizedText = sanitizeTTSText(element.text)
-    recordOptimisticSegmentUsage(element, sanitizedText)
+    recordOptimisticSegmentUsage(sanitizedText)
 
     if (ttsLanguageVoice.value === 'custom') {
       const language = resolveCustomVoiceLanguage()

--- a/composables/use-text-to-speech.ts
+++ b/composables/use-text-to-speech.ts
@@ -426,6 +426,9 @@ export function useTextToSpeech(options: TTSOptions) {
 
   function recordOptimisticSegmentUsage(element: TTSSegment, sanitizedText: string) {
     if (sessionUser.value?.isLikerPlus) return
+    // Custom voice is gated to Plus; the server rejects non-Plus requests
+    // before charging, so decrementing here would drift the local counter.
+    if (ttsLanguageVoice.value === 'custom') return
     if (!ttsTrialUsage.isLoaded.value) return
     const key = `${ttsLanguageVoice.value}:${element.id}`
     if (optimisticallyCountedSegments.has(key)) return

--- a/composables/use-text-to-speech.ts
+++ b/composables/use-text-to-speech.ts
@@ -426,6 +426,7 @@ export function useTextToSpeech(options: TTSOptions) {
 
   function recordOptimisticSegmentUsage(element: TTSSegment, sanitizedText: string) {
     if (sessionUser.value?.isLikerPlus) return
+    if (!ttsTrialUsage.isLoaded.value) return
     const key = `${ttsLanguageVoice.value}:${element.id}`
     if (optimisticallyCountedSegments.has(key)) return
     optimisticallyCountedSegments.add(key)

--- a/composables/use-tts-trial-usage.ts
+++ b/composables/use-tts-trial-usage.ts
@@ -35,7 +35,7 @@ export function useTTSTrialUsage() {
   }
 
   function recordOptimisticUsage(charactersDelta: number): void {
-    if (!data.value || data.value.isLikerPlus) return
+    if (!data.value || data.value.isLikerPlus || user.value?.isLikerPlus) return
     const newUsed = data.value.charactersUsed + charactersDelta
     const newRemaining = Math.max(data.value.limit - newUsed, 0)
     data.value = {
@@ -46,8 +46,8 @@ export function useTTSTrialUsage() {
     }
   }
 
-  watch(hasLoggedIn, (loggedIn, wasLoggedIn) => {
-    if (!loggedIn && wasLoggedIn) {
+  watch([hasLoggedIn, () => user.value?.isLikerPlus], () => {
+    if (!hasLoggedIn.value || user.value?.isLikerPlus) {
       data.value = null
       inflightFetch.value = null
     }

--- a/composables/use-tts-trial-usage.ts
+++ b/composables/use-tts-trial-usage.ts
@@ -6,15 +6,16 @@ export function useTTSTrialUsage() {
 
   const { loggedIn: hasLoggedIn, user } = useUserSession()
 
+  const isLoaded = computed(() => data.value !== null)
   const charactersUsed = computed(() => data.value?.charactersUsed ?? 0)
   const limit = computed(() => data.value?.limit ?? 0)
   const charactersRemaining = computed(() => data.value?.charactersRemaining ?? null)
   const isExhausted = computed(() => data.value?.isExhausted ?? false)
 
   function fetchUsage(): Promise<void> {
-    if (!hasLoggedIn.value) return Promise.resolve()
-    if (user.value?.isLikerPlus) return Promise.resolve()
-    if (data.value !== null) return Promise.resolve()
+    if (!hasLoggedIn.value || user.value?.isLikerPlus || data.value !== null) {
+      return Promise.resolve()
+    }
     if (inflightFetch.value) return inflightFetch.value
     const task = (async () => {
       try {
@@ -53,6 +54,7 @@ export function useTTSTrialUsage() {
   })
 
   return {
+    isLoaded,
     charactersUsed,
     limit,
     charactersRemaining,

--- a/composables/use-tts-trial-usage.ts
+++ b/composables/use-tts-trial-usage.ts
@@ -1,0 +1,63 @@
+import type { TTSTrialUsageData } from '~/shared/types/tts'
+
+export function useTTSTrialUsage() {
+  const data = useState<TTSTrialUsageData | null>('tts-trial-usage', () => null)
+  const inflightFetch = useState<Promise<void> | null>('tts-trial-usage-inflight', () => null)
+
+  const { loggedIn: hasLoggedIn, user } = useUserSession()
+
+  const charactersUsed = computed(() => data.value?.charactersUsed ?? 0)
+  const limit = computed(() => data.value?.limit ?? 0)
+  const charactersRemaining = computed(() => data.value?.charactersRemaining ?? null)
+  const isExhausted = computed(() => data.value?.isExhausted ?? false)
+
+  function fetchUsage(): Promise<void> {
+    if (!hasLoggedIn.value) return Promise.resolve()
+    if (user.value?.isLikerPlus) return Promise.resolve()
+    if (data.value !== null) return Promise.resolve()
+    if (inflightFetch.value) return inflightFetch.value
+    const task = (async () => {
+      try {
+        const res = await $fetch<TTSTrialUsageData>('/api/reader/tts/usage')
+        if (!hasLoggedIn.value) return
+        data.value = res
+      }
+      catch (error) {
+        console.error('[TTSTrialUsage] Failed to fetch:', error)
+      }
+      finally {
+        inflightFetch.value = null
+      }
+    })()
+    inflightFetch.value = task
+    return task
+  }
+
+  function recordOptimisticUsage(charactersDelta: number): void {
+    if (!data.value || data.value.isLikerPlus) return
+    const newUsed = data.value.charactersUsed + charactersDelta
+    const newRemaining = Math.max(data.value.limit - newUsed, 0)
+    data.value = {
+      ...data.value,
+      charactersUsed: newUsed,
+      charactersRemaining: newRemaining,
+      isExhausted: newRemaining <= 0,
+    }
+  }
+
+  watch(hasLoggedIn, (loggedIn, wasLoggedIn) => {
+    if (!loggedIn && wasLoggedIn) {
+      data.value = null
+      inflightFetch.value = null
+    }
+  })
+
+  return {
+    charactersUsed,
+    limit,
+    charactersRemaining,
+    isExhausted,
+    fetchUsage,
+    recordOptimisticUsage,
+  }
+}

--- a/composables/use-tts-trial-usage.ts
+++ b/composables/use-tts-trial-usage.ts
@@ -13,6 +13,10 @@ export function useTTSTrialUsage() {
   const isExhausted = computed(() => data.value?.isExhausted ?? false)
 
   function fetchUsage(): Promise<void> {
+    // Client-only: SSR fetch would hit Firestore for data that's consumed
+    // only in client-side analytics payloads, and a pending Promise cannot
+    // round-trip through the SSR payload into inflightFetch.
+    if (!import.meta.client) return Promise.resolve()
     if (!hasLoggedIn.value || user.value?.isLikerPlus || data.value !== null) {
       return Promise.resolve()
     }
@@ -50,6 +54,10 @@ export function useTTSTrialUsage() {
     if (!hasLoggedIn.value || user.value?.isLikerPlus) {
       data.value = null
       inflightFetch.value = null
+      return
+    }
+    if (data.value === null) {
+      void fetchUsage()
     }
   })
 

--- a/server/api/reader/tts/usage.get.ts
+++ b/server/api/reader/tts/usage.get.ts
@@ -1,0 +1,36 @@
+import type { TTSTrialUsageData } from '~/shared/types/tts'
+import { TTS_TRIAL_CHARACTER_LIMIT } from '~/server/utils/api-tts'
+
+export default defineEventHandler(async (event): Promise<TTSTrialUsageData> => {
+  const session = await requireUserSession(event)
+  const wallet = session.user.evmWallet
+  if (!wallet) {
+    throw createError({ statusCode: 401, message: 'WALLET_NOT_FOUND' })
+  }
+
+  setHeader(event, 'Cache-Control', 'private, no-cache, no-store, must-revalidate')
+
+  const limit = TTS_TRIAL_CHARACTER_LIMIT
+
+  if (session.user.isLikerPlus) {
+    return {
+      isLikerPlus: true,
+      charactersUsed: 0,
+      limit,
+      charactersRemaining: null,
+      isExhausted: false,
+    }
+  }
+
+  const userDoc = await getUserDoc(wallet)
+  const charactersUsed = Number(userDoc?.ttsCharactersUsed || 0)
+  const charactersRemaining = Math.max(limit - charactersUsed, 0)
+
+  return {
+    isLikerPlus: false,
+    charactersUsed,
+    limit,
+    charactersRemaining,
+    isExhausted: charactersRemaining <= 0,
+  }
+})

--- a/server/api/reader/tts/usage.get.ts
+++ b/server/api/reader/tts/usage.get.ts
@@ -2,11 +2,8 @@ import type { TTSTrialUsageData } from '~/shared/types/tts'
 import { TTS_TRIAL_CHARACTER_LIMIT } from '~/server/utils/api-tts'
 
 export default defineEventHandler(async (event): Promise<TTSTrialUsageData> => {
+  const wallet = await requireUserWallet(event)
   const session = await requireUserSession(event)
-  const wallet = session.user.evmWallet
-  if (!wallet) {
-    throw createError({ statusCode: 401, message: 'WALLET_NOT_FOUND' })
-  }
 
   setHeader(event, 'Cache-Control', 'private, no-cache, no-store, must-revalidate')
 

--- a/server/utils/api-tts.ts
+++ b/server/utils/api-tts.ts
@@ -1,7 +1,7 @@
 import { randomBytes } from 'node:crypto'
 import type { H3Event } from 'h3'
 
-const TTS_TRIAL_CHARACTER_LIMIT = 5000
+export const TTS_TRIAL_CHARACTER_LIMIT = 5000
 
 export function generateTTSKey(): string {
   return randomBytes(16).toString('hex')

--- a/shared/types/tts.d.ts
+++ b/shared/types/tts.d.ts
@@ -1,0 +1,7 @@
+export interface TTSTrialUsageData {
+  isLikerPlus: boolean
+  charactersUsed: number
+  limit: number
+  charactersRemaining: number | null
+  isExhausted: boolean
+}


### PR DESCRIPTION
Adds an internal usage endpoint plus richer event properties (is_liker_plus_at_event_time, cumulative_chars_used, chars_remaining, book_language, voice_id) so the TTS free→Plus funnel can be measured before any product change lands. Fires tts_trial_exhausted on the paywall path and ships an optimistic client-side char decrement so a future trial chip has accurate state without extra round-trips.