### PR TITLE
💄 Use plus icon for add-to-bookshelf button

### DIFF
--- a/pages/store/[nftClassId]/index.vue
+++ b/pages/store/[nftClassId]/index.vue
@@ -675,7 +675,7 @@
                   variant="outline"
                   color="primary"
                   size="lg"
-                  :leading-icon="isInBookList ? 'i-material-symbols-favorite-rounded' : 'i-material-symbols-favorite-outline-rounded'"
+                  :leading-icon="isInBookList ? 'i-material-symbols-favorite-rounded' : 'i-material-symbols-add-2-rounded'"
                   :loading="isCheckingBookList || isUpdatingBookList"
                   @click="handleBookListButtonClickDebounced"
                 />
@@ -827,7 +827,7 @@
               @click="handleGiftButtonClick"
             />
             <UButton
-              :icon="isInBookList ? 'i-material-symbols-favorite-rounded' : 'i-material-symbols-favorite-outline-rounded'"
+              :icon="isInBookList ? 'i-material-symbols-favorite-rounded' : 'i-material-symbols-add-2-rounded'"
               color="primary"
               variant="outline"
               size="sm"


### PR DESCRIPTION
Swap the hollow heart for a plus sign when a book isn't yet in the reader's bookshelf, so the action reads as "add" rather than "favorite".
<img width="896" height="750" alt="image" src="https://github.com/user-attachments/assets/1fee3f77-bf79-4923-a148-a367bbcee059" />
