### PR TITLE
📈 Track login email input and Plus Liker ID gate

### DIFF
--- a/components/LoginPanel.vue
+++ b/components/LoginPanel.vue
@@ -15,6 +15,7 @@
         type="email"
         :placeholder="$t('login_panel_email_placeholder')"
         size="lg"
+        @input.once="useLogEvent('login_panel_email_input')"
       />
       <UButton
         type="submit"

--- a/composables/use-subscription-checkout.ts
+++ b/composables/use-subscription-checkout.ts
@@ -80,6 +80,7 @@ export function useSubscriptionCheckout() {
       blockingModal.open({ title: $t('common_processing') })
 
       if (!user.value?.likerId) {
+        useLogEvent('subscription_liker_id_required')
         toast.add({
           title: $t('pricing_page_liker_id_required'),
           description: $t('pricing_page_liker_id_required_description'),

--- a/stores/account.ts
+++ b/stores/account.ts
@@ -388,7 +388,9 @@ export const useAccountStore = defineStore('account', () => {
       isLoggingIn.value = true
 
       // Disconnect any existing connection
-      await disconnectAsync()
+      if (isConnected.value) {
+        await disconnectAsync().catch(() => {})
+      }
       let magicEmail: string | undefined = preferredEmail
       if (!connectorId || !connectors.some((c: { id: string }) => c.id === connectorId)) {
         useLogEvent('login_panel_open')


### PR DESCRIPTION
Fire `login_panel_email_input` on first email input and `subscription_liker_id_required` when a user tries to subscribe without a Liker ID. Fills two gaps in the login→subscribe funnel — top-of-funnel engagement intent and a known conversion blocker.