### PR TITLE
✨ Add assetlinks.json and apple-app-site-association

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -129,6 +129,9 @@ export default defineNuxtConfig({
   },
 
   routeRules: {
+    '/.well-known/apple-app-site-association': {
+      headers: { 'Content-Type': 'application/json' },
+    },
     '/api/store/products': {
       security: {
         corsHandler: {

--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -1,0 +1,17 @@
+{
+  "applinks": {
+    "details": [
+      {
+        "appIDs": ["SQMQJBU5RU.land.liker.book3app"],
+        "components": [
+          {
+            "/": "*"
+          }
+        ]
+      }
+    ]
+  },
+  "webcredentials": {
+    "apps": ["SQMQJBU5RU.land.liker.book3app"]
+  }
+}

--- a/public/.well-known/assetlinks.json
+++ b/public/.well-known/assetlinks.json
@@ -1,0 +1,15 @@
+[
+  {
+    "relation": [
+      "delegate_permission/common.handle_all_urls",
+      "delegate_permission/common.get_login_creds"
+    ],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "land.liker.book3app",
+      "sha256_cert_fingerprints": [
+        "CF:DD:F5:A1:DC:D8:8B:9F:14:CF:81:FF:43:DA:3B:1E:87:FF:49:B1:FC:E4:06:C5:36:76:BE:44:08:EF:C5:81"
+      ]
+    }
+  }
+]


### PR DESCRIPTION
Enable Android App Links and iOS Universal Links for land.liker.book3app, plus shared web credentials (autofill) on both platforms.

Needs: https://github.com/likecoin/3ook-com-app/pull/45 to work