### PR TITLE
🏗️ Flush book settings on native foreground re-sync

### DIFF
--- a/components/TTSPlayerModal.props.ts
+++ b/components/TTSPlayerModal.props.ts
@@ -12,5 +12,5 @@ export interface TTSPlayerModalProps {
   isAutoClose?: boolean
   isFullscreen?: boolean
   onClose?: () => void
-  onSegmentChange?: (segment: TTSSegment & { index: number }) => void
+  onSegmentChange?: (segment: TTSSegment & { index: number, isResync?: boolean }) => void
 }

--- a/components/TTSPlayerModal.vue
+++ b/components/TTSPlayerModal.vue
@@ -225,7 +225,7 @@ const localeRoute = useLocaleRoute()
 
 const emit = defineEmits<{
   close: []
-  segmentChange: [segment: TTSSegment & { index: number }]
+  segmentChange: [segment: TTSSegment & { index: number, isResync?: boolean }]
 }>()
 
 const props = withDefaults(
@@ -308,6 +308,7 @@ const {
   skipBackward,
   stopTextToSpeech,
   currentTTSSegmentIndex,
+  consumeTrackChangeResync,
   cyclePlaybackRate,
   showOfflineModal,
   forceResume,
@@ -529,7 +530,7 @@ function getSegmentClass(index: number) {
 
 watch(currentTTSSegment, (newSegment: TTSSegment | undefined) => {
   if (newSegment) {
-    emit('segmentChange', { index: currentTTSSegmentIndex.value, ...newSegment })
+    emit('segmentChange', { index: currentTTSSegmentIndex.value, ...newSegment, isResync: consumeTrackChangeResync() })
   }
 })
 

--- a/composables/use-native-audio-player.ts
+++ b/composables/use-native-audio-player.ts
@@ -31,7 +31,7 @@ export function useNativeAudioPlayer(isActive: Ref<boolean | undefined>): TTSAud
         break
       case 'trackChanged':
         if (typeof detail.index === 'number') {
-          handlers.trackChanged?.(detail.index)
+          handlers.trackChanged?.(detail.index, detail.isResync ? { isResync: true } : undefined)
         }
         break
       case 'queueEnded':

--- a/composables/use-text-to-speech.ts
+++ b/composables/use-text-to-speech.ts
@@ -230,10 +230,18 @@ export function useTextToSpeech(options: TTSOptions) {
     playNextElement()
   })
 
-  player.on('trackChanged', (index) => {
+  let isLastTrackChangeResync = false
+  function consumeTrackChangeResync(): boolean {
+    const value = isLastTrackChangeResync
+    isLastTrackChangeResync = false
+    return value
+  }
+
+  player.on('trackChanged', (index, meta) => {
     if (index !== currentTTSSegmentIndex.value) {
       consecutiveAudioErrors.value = 0
     }
+    isLastTrackChangeResync = !!meta?.isResync
     currentTTSSegmentIndex.value = index
     startSegmentLoadTimer(index)
   })
@@ -756,6 +764,7 @@ export function useTextToSpeech(options: TTSOptions) {
     currentTTSSegment,
     currentTTSSegmentText,
     currentTTSSegmentIndex,
+    consumeTrackChangeResync,
     pauseTextToSpeech,
     startTextToSpeech,
     setTTSSegments,

--- a/composables/use-tts-player-modal.ts
+++ b/composables/use-tts-player-modal.ts
@@ -5,7 +5,7 @@ import { isUploadedBookId } from '~/shared/utils/uploaded-book'
 
 interface TTSPlayerOptions {
   nftClassId: MaybeRef<string>
-  onSegmentChange?: (segment: TTSSegment & { index: number }) => void
+  onSegmentChange?: (segment: TTSSegment & { index: number, isResync?: boolean }) => void
   onClose?: () => void
 }
 

--- a/pages/reader/epub.vue
+++ b/pages/reader/epub.vue
@@ -584,6 +584,9 @@ const { setTTSSegments, setChapterTitles, openPlayer } = useTTSPlayerModal({
         percentage.value = locations.percentageFromCfi(segment.cfi) ?? 0
         readingProgress.value = percentage.value
       }
+      if (segment.isResync) {
+        useBookSettingsStore().flushBatch(nftClassId.value)
+      }
     }
 
     // Skip navigation if the segment is already visible on the current page

--- a/pages/reader/pdf.vue
+++ b/pages/reader/pdf.vue
@@ -112,6 +112,9 @@ const { setTTSSegments, setChapterTitles, openPlayer } = useTTSPlayerModal({
           pdfReaderRef.value.goToPage(newPageIndex)
         }
       }
+      if (segment.isResync) {
+        useBookSettingsStore().flushBatch(nftClassId.value)
+      }
     }
   },
 })

--- a/types/tts-audio-player.d.ts
+++ b/types/tts-audio-player.d.ts
@@ -3,7 +3,7 @@ declare interface TTSAudioPlayerEvents {
   pause: () => void
   buffering: () => void
   ended: () => void
-  trackChanged: (index: number) => void
+  trackChanged: (index: number, meta?: { isResync?: boolean }) => void
   allEnded: () => void
   error: (error: string | Event | MediaError) => void
   positionState: (state: { position: number, duration: number }) => void


### PR DESCRIPTION
Thread isResync flag from native trackChanged through the TTS event chain so EPUB/PDF readers can call flushBatch immediately, eliminating the 1s debounce window where a kill would lose progress.

Adds support for https://github.com/likecoin/3ook-com-app/pull/44