### PR TITLE
⬆️ Upgrade @likecoin/wagmi-connector to v2.4.1-like.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@farcaster/miniapp-sdk": "^0.2.1",
         "@google-cloud/pubsub": "^5.3.0",
         "@likecoin/epub-ts": "^0.6.3",
-        "@likecoin/wagmi-connector": "2.4.0-like.0",
+        "@likecoin/wagmi-connector": "2.4.1-like.0",
         "@nuxt/icon": "^1.11.0",
         "@nuxt/scripts": "^0.13.2",
         "@nuxt/ui": "^3.2.0",
@@ -5375,9 +5375,9 @@
       }
     },
     "node_modules/@likecoin/wagmi-connector": {
-      "version": "2.4.0-like.0",
-      "resolved": "https://registry.npmjs.org/@likecoin/wagmi-connector/-/wagmi-connector-2.4.0-like.0.tgz",
-      "integrity": "sha512-+hncq9Xwok9k+mosma+NxjFmzC2rsoAxP5D3Lot6bkQlx0yNwbxutT7MtThYyFPuzGQv1kfhImo8ivA/bkNsWA==",
+      "version": "2.4.1-like.0",
+      "resolved": "https://registry.npmjs.org/@likecoin/wagmi-connector/-/wagmi-connector-2.4.1-like.0.tgz",
+      "integrity": "sha512-Iv0RfmhVUuVcIvFD4rZ/nZXdFjltdauQpHdck0ln248L6PKAK3dVIwKWxmS7ZawCZxp0srC5DLVPzOjNt/8t+A==",
       "license": "MIT",
       "dependencies": {
         "@magic-ext/evm": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@farcaster/miniapp-sdk": "^0.2.1",
     "@google-cloud/pubsub": "^5.3.0",
     "@likecoin/epub-ts": "^0.6.3",
-    "@likecoin/wagmi-connector": "2.4.0-like.0",
+    "@likecoin/wagmi-connector": "2.4.1-like.0",
     "@nuxt/icon": "^1.11.0",
     "@nuxt/scripts": "^0.13.2",
     "@nuxt/ui": "^3.2.0",

--- a/wagmi.ts
+++ b/wagmi.ts
@@ -24,6 +24,24 @@ export function createWagmiConfig({
   const logoURL = customLogoURL || 'https://3ook.com/pwa-64x64.png'
   const connectors: CreateConnectorFn[] = [
     injected(),
+    dedicatedWalletConnector({
+      chains: [chain],
+      options: {
+        apiKey,
+        accentColor: '#131313',
+        customHeaderText: '3ook.com',
+        customLogo: logoURL,
+        isDarkMode: false,
+        isCustomModal: true,
+        magicSdkConfiguration: {
+          deferPreload: true,
+          network: {
+            rpcUrl: chain.rpcUrls.default.http[0],
+            chainId: chain.id,
+          },
+        },
+      },
+    }) as CreateConnectorFn,
   ]
   if (import.meta.client && window && !isApp && (!!window.ReactNativeWebView || window !== window.parent)) {
     connectors.push(
@@ -46,37 +64,6 @@ export function createWagmiConfig({
           },
         }))
     }
-    const magicConnectorFn = dedicatedWalletConnector({
-      chains: [chain],
-      options: {
-        apiKey,
-        accentColor: '#131313',
-        customHeaderText: '3ook.com',
-        customLogo: logoURL,
-        isDarkMode: false,
-        isCustomModal: true,
-        magicSdkConfiguration: {
-          deferPreload: true,
-          network: {
-            rpcUrl: chain.rpcUrls.default.http[0],
-            chainId: chain.id,
-          },
-        },
-      },
-    }) as CreateConnectorFn
-    // Wrap to make 'magic' non-enumerable on the connector object.
-    // Magic SDK instances have circular references (module.sdk → magic),
-    // and wagmi's deepEqual in getConnections() blows the stack traversing them.
-    connectors.push((config) => {
-      const connector = magicConnectorFn(config)
-      Object.defineProperty(connector, 'magic', {
-        value: undefined,
-        writable: true,
-        enumerable: false,
-        configurable: true,
-      })
-      return connector
-    })
   }
 
   return createConfig({


### PR DESCRIPTION
Magic SDK circular-reference fix now ships in the connector, so drop the local non-enumerable `magic` wrapper and register the connector unconditionally alongside the other base connectors.