### PR TITLE
[TAS-5454] 🐛 Suppress error popup on TTS autoplay block

### DIFF
--- a/components/TTSPlayerModal.vue
+++ b/components/TTSPlayerModal.vue
@@ -214,6 +214,7 @@
 
 <script setup lang="ts">
 import type { TTSPlayerModalProps } from './TTSPlayerModal.props'
+import { TTS_ERROR_NOT_ALLOWED } from '~/composables/use-text-to-speech'
 import { encodeAffiliateVoiceId } from '~/shared/utils/tts-sig'
 
 const { user } = useUserSession()
@@ -322,6 +323,13 @@ const {
   customVoice,
   affiliateVoices,
   onError: (error: string | Event | MediaError) => {
+    // Autoplay was blocked by the browser because the modal auto-started
+    // without a user gesture (e.g. reloading the reader with ?tts=1). The
+    // composable has already reset playback state — leave the modal open so
+    // the play button is visible and the user can tap to resume.
+    if (error === TTS_ERROR_NOT_ALLOWED) {
+      return
+    }
     if (
       !user.value?.isLikerPlus
       && (

--- a/composables/use-text-to-speech.ts
+++ b/composables/use-text-to-speech.ts
@@ -257,6 +257,16 @@ export function useTextToSpeech(options: TTSOptions) {
     isTextToSpeechLoading.value = false
     console.warn('Audio playback error:', error)
 
+    if (error === TTS_ERROR_NOT_ALLOWED) {
+      // Autoplay blocked is not a load failure — skip the analytics event
+      // but still clear the timer so a subsequent real error isn't measured
+      // against this one's start time.
+      clearSegmentLoadTimer()
+      stopTextToSpeech()
+      options.onError?.(error)
+      return
+    }
+
     const timing = consumeSegmentLoadTimer()
     if (timing && timing.index === currentTTSSegmentIndex.value) {
       useLogEvent('tts_segment_load_failed', buildTTSEventPayload({
@@ -266,12 +276,6 @@ export function useTextToSpeech(options: TTSOptions) {
         is_first_segment: timing.index === 0,
         error: formatTTSError(error),
       }))
-    }
-
-    if (error === TTS_ERROR_NOT_ALLOWED) {
-      stopTextToSpeech()
-      options.onError?.(error)
-      return
     }
 
     // Check if this is a network error (require both error code AND offline status to avoid misjudgment)


### PR DESCRIPTION
Reloading the reader with ?tts=1 auto-starts TTS without a user gesture, so the browser rejects play() with NotAllowedError. Swallow it in the modal's onError so the play button stays visible for the user to tap, and short-circuit before the tts_segment_load_failed event so analytics isn't polluted with fake load failures.