### PR TITLE
[TAS-5704] 🐛 Fix currency setting resetting to auto on reload

### DIFF
--- a/composables/use-adult-content-setting.ts
+++ b/composables/use-adult-content-setting.ts
@@ -1,6 +1,6 @@
 export function useAdultContentSetting() {
   const { isApp } = useAppDetection()
-  const setting = useSyncedUserSettings<boolean>({
+  const setting = useSyncedUserSettings({
     key: 'isAdultContentEnabled',
     defaultValue: false,
   })

--- a/composables/use-auto-locale.ts
+++ b/composables/use-auto-locale.ts
@@ -22,7 +22,7 @@ export function useAutoLocale() {
   const { loggedIn: hasLoggedIn } = useUserSession()
   const { detectedCountry, initializeClientGeolocation } = useDetectedGeolocation()
 
-  const syncedLocale = useSyncedUserSettings<LocaleCode | null>({
+  const syncedLocale = useSyncedUserSettings({
     key: 'locale',
     defaultValue: null,
   })

--- a/composables/use-color-mode-sync.ts
+++ b/composables/use-color-mode-sync.ts
@@ -3,7 +3,7 @@ export function useColorModeSync() {
   const { loggedIn: hasLoggedIn, user } = useUserSession()
   const userSettingsStore = useUserSettingsStore()
 
-  const syncedColorMode = useSyncedUserSettings<ColorMode>({
+  const syncedColorMode = useSyncedUserSettings({
     key: 'colorMode',
     defaultValue: 'light',
   })

--- a/composables/use-payment-currency.ts
+++ b/composables/use-payment-currency.ts
@@ -18,7 +18,7 @@ export function usePaymentCurrency() {
   const { loggedIn: hasLoggedIn } = useUserSession()
   const { detectedCountry, initializeClientGeolocation } = useDetectedGeolocation()
 
-  const syncedCurrency = useSyncedUserSettings<PaymentCurrency>({
+  const syncedCurrency = useSyncedUserSettings({
     key: 'currency',
     defaultValue: 'auto',
   })
@@ -56,11 +56,13 @@ export function usePaymentCurrency() {
       initializeClientGeolocation()
     }
 
+    let storedCurrency: PaymentCurrency | undefined
     if (hasLoggedIn.value) {
       await userSettingsStore.ensureInitialized()
+      storedCurrency = userSettingsStore.getSettings()?.currency
     }
 
-    setCurrency(syncedCurrency.value || localStorageCurrency.value || 'auto')
+    setCurrency(storedCurrency || localStorageCurrency.value || 'auto')
   }
 
   return {

--- a/composables/use-synced-user-settings.ts
+++ b/composables/use-synced-user-settings.ts
@@ -28,14 +28,13 @@ export function useSyncedUserSettings<K extends UserSettingKey>({
     }
   }
 
-  function syncFromStore() {
-    if (storeValue.value !== undefined) {
-      localState.value = storeValue.value
-    }
-  }
-
   const state = computed({
-    get: () => localState.value,
+    get: () => {
+      if (userSettingsStore.isInitialized() && storeValue.value !== undefined) {
+        return storeValue.value
+      }
+      return localState.value
+    },
     set: (newValue) => {
       localState.value = newValue
       if (!hasLoggedIn.value) {
@@ -43,12 +42,6 @@ export function useSyncedUserSettings<K extends UserSettingKey>({
       }
       userSettingsStore.queueUpdate(key, newValue)
     },
-  })
-
-  watch(storeValue, (newValue) => {
-    if (newValue !== undefined) {
-      localState.value = newValue
-    }
   })
 
   watch(hasLoggedIn, (isLoggedIn, wasLoggedIn) => {
@@ -63,12 +56,7 @@ export function useSyncedUserSettings<K extends UserSettingKey>({
   })
 
   onMounted(() => {
-    if (hasLoggedIn.value) {
-      if (!userSettingsStore.isInitialized()) {
-        ensureInitialized()
-      }
-      syncFromStore()
-    }
+    ensureInitialized()
   })
 
   onBeforeUnmount(() => {

--- a/composables/use-synced-user-settings.ts
+++ b/composables/use-synced-user-settings.ts
@@ -1,22 +1,25 @@
 import type { UserSettingsData } from '~/types/user-settings'
+import type { UserSettingKey } from '~/shared/types/user-settings'
 
-interface UseSyncedUserSettingsOptions<T> {
-  key: UserSettingKey
-  defaultValue: T
+type SettingValue<K extends UserSettingKey> = Exclude<UserSettingsData[K], undefined>
+
+interface UseSyncedUserSettingsOptions<K extends UserSettingKey> {
+  key: K
+  defaultValue: SettingValue<K>
 }
 
-export function useSyncedUserSettings<T>({
+export function useSyncedUserSettings<K extends UserSettingKey>({
   key,
   defaultValue,
-}: UseSyncedUserSettingsOptions<T>): Ref<T> {
+}: UseSyncedUserSettingsOptions<K>): Ref<SettingValue<K>> {
   const { loggedIn: hasLoggedIn } = useUserSession()
   const userSettingsStore = useUserSettingsStore()
 
-  const localState = ref<T>(defaultValue)
+  const localState = ref(defaultValue) as Ref<SettingValue<K>>
 
   const storeValue = computed(() => {
     const settings = userSettingsStore.getSettings()
-    return settings?.[key as keyof UserSettingsData] as T | undefined
+    return settings?.[key] as SettingValue<K> | undefined
   })
 
   function ensureInitialized() {
@@ -72,5 +75,5 @@ export function useSyncedUserSettings<T>({
     userSettingsStore.flushBatch()
   })
 
-  return state as Ref<T>
+  return state as Ref<SettingValue<K>>
 }

--- a/stores/user-settings.ts
+++ b/stores/user-settings.ts
@@ -1,5 +1,6 @@
 import { useDebounceFn } from '@vueuse/core'
 import type { UserSettingsData } from '~/types/user-settings'
+import type { UserSettingKey } from '~/shared/types/user-settings'
 
 interface UserSettingsEntry {
   data: UserSettingsData
@@ -11,7 +12,7 @@ export const useUserSettingsStore = defineStore('user-settings', () => {
   const settingsEntry = ref<UserSettingsEntry | null>(null)
   const fetchPromise = ref<Promise<UserSettingsData> | null>(null)
 
-  const batchQueue = ref<Map<string, unknown>>(new Map())
+  const batchQueue = ref<Map<UserSettingKey, UserSettingsData[UserSettingKey]>>(new Map())
 
   function isInitialized(): boolean {
     return settingsEntry.value !== null
@@ -87,11 +88,15 @@ export const useUserSettingsStore = defineStore('user-settings', () => {
 
   const debouncedFlush = useDebounceFn(() => flushBatch(), 1000)
 
-  function queueUpdate(key: string, value: unknown) {
+  function queueUpdate<K extends UserSettingKey>(key: K, value: UserSettingsData[K]) {
     if (!hasLoggedIn.value) return
 
+    const currentValue = settingsEntry.value?.data?.[key]
+    const hasPendingUpdate = batchQueue.value.has(key)
+    if (currentValue === value && !hasPendingUpdate) return
+
     if (settingsEntry.value?.data) {
-      (settingsEntry.value.data as Record<string, unknown>)[key] = value
+      settingsEntry.value.data[key] = value
     }
 
     batchQueue.value.set(key, value)

--- a/stores/user-settings.ts
+++ b/stores/user-settings.ts
@@ -92,8 +92,7 @@ export const useUserSettingsStore = defineStore('user-settings', () => {
     if (!hasLoggedIn.value) return
 
     const currentValue = settingsEntry.value?.data?.[key]
-    const hasPendingUpdate = batchQueue.value.has(key)
-    if (currentValue === value && !hasPendingUpdate) return
+    if (currentValue === value) return
 
     if (settingsEntry.value?.data) {
       settingsEntry.value.data[key] = value


### PR DESCRIPTION
`initializePaymentCurrency` read `syncedCurrency.value` right after `await ensureInitialized()`, but `useSyncedUserSettings` only updates its `localState` asynchronously via a `watch(storeValue)` callback. Because the default `'auto'` is truthy, the `||` fallback swallowed `localStorageCurrency` and the user's saved currency was lost.

Read the freshly fetched value directly from the settings store so the initializer no longer races the watcher.