### PR TITLE
📈 Track TTS browser cache hit/miss per segment

### DIFF
--- a/composables/use-native-audio-player.ts
+++ b/composables/use-native-audio-player.ts
@@ -108,6 +108,10 @@ export function useNativeAudioPlayer(isActive: Ref<boolean | undefined>): TTSAud
     return false
   }
 
+  function getCurrentURL(): string {
+    return ''
+  }
+
   return {
     load,
     resume,
@@ -118,6 +122,7 @@ export function useNativeAudioPlayer(isActive: Ref<boolean | undefined>): TTSAud
     seek,
     getPosition,
     wasInterruptedByBackground,
+    getCurrentURL,
     on,
   }
 }

--- a/composables/use-native-audio-player.ts
+++ b/composables/use-native-audio-player.ts
@@ -109,6 +109,7 @@ export function useNativeAudioPlayer(isActive: Ref<boolean | undefined>): TTSAud
   }
 
   function getCurrentURL(): string {
+    // Native app owns track URLs internally; not exposed to the web layer
     return ''
   }
 

--- a/composables/use-text-to-speech.ts
+++ b/composables/use-text-to-speech.ts
@@ -118,6 +118,7 @@ export function useTextToSpeech(options: TTSOptions) {
     seek: time => activePlayer().seek(time),
     getPosition: () => activePlayer().getPosition(),
     wasInterruptedByBackground: () => activePlayer().wasInterruptedByBackground(),
+    getCurrentURL: () => activePlayer().getCurrentURL(),
     on(event, handler) {
       // Register on both — the inactive player won't fire events
       nativePlayer.on(event, handler)
@@ -194,6 +195,11 @@ export function useTextToSpeech(options: TTSOptions) {
     return currentTTSSegment.value?.text || ''
   })
 
+  function resolveCacheStatus() {
+    if (isNativeBridge.value) return 'native' as const
+    return classifyTTSCacheStatus(player.getCurrentURL())
+  }
+
   // Wire player events
   player.on('play', () => {
     isTextToSpeechPlaying.value = true
@@ -205,6 +211,7 @@ export function useTextToSpeech(options: TTSOptions) {
         load_time_ms: timing.loadMs,
         had_buffering: timing.hadBuffering,
         is_first_segment: timing.index === 0,
+        cache_status: resolveCacheStatus(),
       }))
     }
   })
@@ -281,6 +288,7 @@ export function useTextToSpeech(options: TTSOptions) {
         had_buffering: timing.hadBuffering,
         is_first_segment: timing.index === 0,
         error: formatTTSError(error),
+        cache_status: resolveCacheStatus(),
       }))
     }
 

--- a/composables/use-web-audio-player.ts
+++ b/composables/use-web-audio-player.ts
@@ -450,6 +450,10 @@ export function useWebAudioPlayer(): TTSAudioPlayer {
     return { position: audio.currentTime, duration: audio.duration }
   }
 
+  function getCurrentURL(): string {
+    return getActiveAudio()?.currentSrc || ''
+  }
+
   return {
     load,
     resume,
@@ -460,6 +464,7 @@ export function useWebAudioPlayer(): TTSAudioPlayer {
     seek,
     getPosition,
     wasInterruptedByBackground,
+    getCurrentURL,
     on,
   }
 }

--- a/types/tts-audio-player.d.ts
+++ b/types/tts-audio-player.d.ts
@@ -26,5 +26,6 @@ declare interface TTSAudioPlayer {
   seek(time: number): void
   getPosition(): { position: number, duration: number } | null
   wasInterruptedByBackground(): boolean
+  getCurrentURL(): string
   on<K extends keyof TTSAudioPlayerEvents>(event: K, handler: TTSAudioPlayerEvents[K]): void
 }

--- a/utils/resource-timing.ts
+++ b/utils/resource-timing.ts
@@ -1,0 +1,40 @@
+export type TTSCacheStatus = 'hit' | 'miss' | 'unknown'
+
+const TTS_URL_PATTERN = /\/api\/reader\/tts(?:\?|$)/
+const MAX_TRACKED_URLS = 200
+
+const latestByUrl = new Map<string, PerformanceResourceTiming>()
+let observer: PerformanceObserver | null = null
+
+function ensureObserver() {
+  if (observer || typeof PerformanceObserver === 'undefined') return
+  if (!PerformanceObserver.supportedEntryTypes?.includes('resource')) return
+  const nextObserver = new PerformanceObserver((list) => {
+    for (const entry of list.getEntries()) {
+      if (!TTS_URL_PATTERN.test(entry.name)) continue
+      // delete+set so repeat URLs refresh their insertion order (LRU eviction)
+      latestByUrl.delete(entry.name)
+      latestByUrl.set(entry.name, entry as PerformanceResourceTiming)
+      if (latestByUrl.size > MAX_TRACKED_URLS) {
+        const oldest = latestByUrl.keys().next().value
+        if (oldest) latestByUrl.delete(oldest)
+      }
+    }
+  })
+  try {
+    nextObserver.observe({ type: 'resource', buffered: true })
+    observer = nextObserver
+  }
+  catch {
+    // Environment accepts PerformanceObserver but not this entry type / buffered
+  }
+}
+
+export function classifyTTSCacheStatus(audioUrl: string): TTSCacheStatus {
+  if (!audioUrl || typeof PerformanceObserver === 'undefined') return 'unknown'
+  ensureObserver()
+  const entry = latestByUrl.get(audioUrl)
+  // decodedBodySize === 0 means cross-origin without Timing-Allow-Origin
+  if (!entry || entry.decodedBodySize === 0) return 'unknown'
+  return entry.transferSize === 0 ? 'hit' : 'miss'
+}

--- a/utils/resource-timing.ts
+++ b/utils/resource-timing.ts
@@ -3,7 +3,7 @@ export type TTSCacheStatus = 'hit' | 'miss' | 'unknown'
 const TTS_URL_PATTERN = /\/api\/reader\/tts(?:\?|$)/
 const MAX_TRACKED_URLS = 200
 
-const latestByUrl = new Map<string, PerformanceResourceTiming>()
+const latestByURL = new Map<string, PerformanceResourceTiming>()
 let observer: PerformanceObserver | null = null
 
 function ensureObserver() {
@@ -13,11 +13,11 @@ function ensureObserver() {
     for (const entry of list.getEntries()) {
       if (!TTS_URL_PATTERN.test(entry.name)) continue
       // delete+set so repeat URLs refresh their insertion order (LRU eviction)
-      latestByUrl.delete(entry.name)
-      latestByUrl.set(entry.name, entry as PerformanceResourceTiming)
-      if (latestByUrl.size > MAX_TRACKED_URLS) {
-        const oldest = latestByUrl.keys().next().value
-        if (oldest) latestByUrl.delete(oldest)
+      latestByURL.delete(entry.name)
+      latestByURL.set(entry.name, entry as PerformanceResourceTiming)
+      if (latestByURL.size > MAX_TRACKED_URLS) {
+        const oldest = latestByURL.keys().next().value
+        if (oldest) latestByURL.delete(oldest)
       }
     }
   })
@@ -30,10 +30,13 @@ function ensureObserver() {
   }
 }
 
-export function classifyTTSCacheStatus(audioUrl: string): TTSCacheStatus {
-  if (!audioUrl || typeof PerformanceObserver === 'undefined') return 'unknown'
+export function classifyTTSCacheStatus(audioURL: string): TTSCacheStatus {
+  if (!audioURL || typeof PerformanceObserver === 'undefined') return 'unknown'
   ensureObserver()
-  const entry = latestByUrl.get(audioUrl)
+  // Buffered observer entries flush asynchronously, so on the first call
+  // fall back to a synchronous query against the browser's resource buffer.
+  const entry = latestByURL.get(audioURL)
+    ?? (performance.getEntriesByName(audioURL, 'resource').at(-1) as PerformanceResourceTiming | undefined)
   // decodedBodySize === 0 means cross-origin without Timing-Allow-Origin
   if (!entry || entry.decodedBodySize === 0) return 'unknown'
   return entry.transferSize === 0 ? 'hit' : 'miss'


### PR DESCRIPTION
had_buffering conflates a browser <audio> stall (web) with a fresh playTrack call (native), so it can't answer "was this segment cached". Classify each web load via PerformanceResourceTiming.transferSize and emit a cache_status property on tts_segment_loaded / tts_segment_load_failed; native bridge reports 'native' since browser cache doesn't apply.