### PR TITLE
♻️ Gate Plus embedded checkout via A/B test variant

### DIFF
--- a/composables/use-subscription-checkout.ts
+++ b/composables/use-subscription-checkout.ts
@@ -25,7 +25,7 @@ export function useSubscriptionCheckout() {
   const { getAnalyticsParameters } = useAnalytics()
   const { isApp } = useAppDetection()
   const runtimeConfig = useRuntimeConfig()
-  const isEmbeddedCheckoutFlagEnabled = useFeatureFlagEnabled('plus-embedded-checkout')
+  const embeddedCheckoutABTest = useABTest({ experimentKey: 'plus-embedded-checkout' })
 
   const isProcessingSubscription = ref(false)
 
@@ -107,7 +107,7 @@ export function useSubscriptionCheckout() {
       else {
         const canUseEmbeddedCheckout = (
           !isApp.value
-          && !!isEmbeddedCheckoutFlagEnabled.value
+          && embeddedCheckoutABTest.isVariant('test')
           && !!runtimeConfig.public.stripePublishableKey
         )
         const uiMode: CheckoutUIMode = canUseEmbeddedCheckout ? 'embedded' : 'hosted'


### PR DESCRIPTION
Swap the boolean plus-embedded-checkout feature flag for an A/B test read via useABTest, so assignment and conversion can be measured per variant rather than as a blanket rollout. Embedded mode now requires the 'test' variant in addition to the existing non-app + Stripe key capability checks.