### PR TITLE
📈 Attach source context to upsell modal events

### DIFF
--- a/components/UpsellPlusModal.props.ts
+++ b/components/UpsellPlusModal.props.ts
@@ -29,5 +29,5 @@ export interface UpsellPlusModalProps {
   from?: string
   onSubscribe?: (payload: UpsellPlusModalSubscribeEventPayload) => void
   onOpen?: () => void
-  onClose?: () => void
+  onClose?: (isSuccess: boolean) => void
 }

--- a/composables/use-subscription-modal.ts
+++ b/composables/use-subscription-modal.ts
@@ -58,9 +58,6 @@ export function useSubscriptionModal() {
       isLikerPlus: isLikerPlus.value,
       likerPlusPeriod: likerPlusPeriod.value,
       onSubscribe: startSubscription,
-      onClose: () => {
-        useLogEvent('subscription_button_click_skip')
-      },
     }
   }
 
@@ -120,10 +117,23 @@ export function useSubscriptionModal() {
       nftClassId = undefined
     }
     if (!isLikerPlus.value && (!props.from || nftClassId)) {
+      const upsellEventPayload = {
+        nft_class_id: nftClassId,
+        source_nft_class_id: props.nftClassId,
+        book_price: props.bookPrice,
+        from: props.from,
+        selected_pricing_item_index: props.selectedPricingItemIndex,
+      }
       const upsellModalProps: UpsellPlusModalProps = {
         ...props,
         ...getUpsellPlusModalProps(),
         nftClassId,
+        onClose: (isSuccess: boolean) => {
+          if (!isSuccess) {
+            useLogEvent('subscription_button_click_skip', upsellEventPayload)
+          }
+          props.onClose?.(isSuccess)
+        },
       }
       if (props.nftClassId) {
         shownUpsellClassIds.value = [...shownUpsellClassIds.value, props.nftClassId]
@@ -131,7 +141,7 @@ export function useSubscriptionModal() {
       else {
         hasShownGenericUpsell.value = true
       }
-      useLogEvent('upsell_plus_modal_open')
+      useLogEvent('upsell_plus_modal_open', upsellEventPayload)
       return upsellPlusModal.open(upsellModalProps).result
     }
   }


### PR DESCRIPTION
upsell_plus_modal_open and subscription_button_click_skip were firing with empty payloads, so modal opens and explicit-skip events could not be attributed to the triggering book or entry point in analytics.