### PR TITLE
🚀 Preconnect to api.like.co and PostHog globally

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -19,6 +19,8 @@ const ogDescription = $t('app_description')
 const ogURL = config.public.baseURL
 const ogImage = `${ogURL}/images/og/default.jpg`
 const isTestnet = !!config.public.isTestnet
+const likeCoinAPIEndpoint = config.public.likeCoinAPIEndpoint as string | undefined
+const posthogHost = config.public.posthogHost as string | undefined
 
 const { memberProgramData } = useMemberProgramStructuredData()
 
@@ -132,6 +134,15 @@ useHead({
       rel: 'me',
       href: 'https://www.threads.com/@3ookcom',
     },
+    ...(likeCoinAPIEndpoint
+      ? [
+          { rel: 'preconnect', href: likeCoinAPIEndpoint },
+          { rel: 'preconnect', href: likeCoinAPIEndpoint, crossorigin: '' },
+        ]
+      : []),
+    ...(posthogHost
+      ? [{ rel: 'preconnect', href: posthogHost, crossorigin: '' }]
+      : []),
     ...(i18nHead.value.link || []),
   ],
   script: [


### PR DESCRIPTION
Warms TLS to api.like.co (NFT metadata, profile, avatars, checkout, ebook CORS proxy) and t.3ook.com (PostHog ingest) on every page. Emits both crossorigin and plain variants for api.like.co so that CORS fetches and no-cors <img> avatar requests share warmed sockets.