### PR TITLE
📈 Send browser PostHog distinct_id on checkout requests

### DIFF
--- a/composables/use-analytics.ts
+++ b/composables/use-analytics.ts
@@ -1,6 +1,7 @@
 export function useAnalytics() {
   const getRouteQuery = useRouteQuery()
   const { gtag } = useGtag()
+  const { $posthog } = useNuxtApp()
   const googleAnalyticsTrackingId: string | undefined = useRuntimeConfig().public.googleAnalyticsTrackingId
 
   const gaClientId = ref('')
@@ -52,6 +53,7 @@ export function useAnalytics() {
       fbClickId: getRouteQuery('fbclid'),
       fbp: fbp.value || undefined,
       fbc: fbc.value || undefined,
+      posthogDistinctId: $posthog?.()?.get_distinct_id?.() || undefined,
     }
   }
 

--- a/composables/use-likecoin-session-api.ts
+++ b/composables/use-likecoin-session-api.ts
@@ -118,6 +118,7 @@ export function useLikeCoinSessionAPI() {
     fbClickId,
     fbp,
     fbc,
+    posthogDistinctId,
   }: {
     email?: string
     nftClassId: string
@@ -141,6 +142,7 @@ export function useLikeCoinSessionAPI() {
     fbClickId?: string
     fbp?: string
     fbc?: string
+    posthogDistinctId?: string
   }) {
     return fetch.value<{ url: string, paymentId: string }>(`/likernft/book/purchase/${nftClassId}/new`, {
       method: 'POST',
@@ -168,6 +170,7 @@ export function useLikeCoinSessionAPI() {
         fbClickId,
         fbp,
         fbc,
+        posthogDistinctId,
         site: '3ook.com',
         isApp: isApp.value || undefined,
       },
@@ -197,6 +200,7 @@ export function useLikeCoinSessionAPI() {
       fbClickId,
       fbp,
       fbc,
+      posthogDistinctId,
     }: {
       email?: string
       coupon?: string
@@ -218,6 +222,7 @@ export function useLikeCoinSessionAPI() {
       fbClickId?: string
       fbp?: string
       fbc?: string
+      posthogDistinctId?: string
     },
   ) {
     return fetch.value<{ url: string, paymentId: string }>(`/likernft/book/purchase/cart/new`, {
@@ -252,6 +257,7 @@ export function useLikeCoinSessionAPI() {
         fbClickId,
         fbp,
         fbc,
+        posthogDistinctId,
         site: '3ook.com',
         isApp: isApp.value || undefined,
       },
@@ -290,6 +296,7 @@ export function useLikeCoinSessionAPI() {
     fbClickId,
     fbp,
     fbc,
+    posthogDistinctId,
     coupon,
     uiMode,
   }: {
@@ -312,6 +319,7 @@ export function useLikeCoinSessionAPI() {
     fbClickId?: string
     fbp?: string
     fbc?: string
+    posthogDistinctId?: string
     coupon?: string
     uiMode?: CheckoutUIMode
   }) {
@@ -335,6 +343,7 @@ export function useLikeCoinSessionAPI() {
         fbClickId,
         fbp,
         fbc,
+        posthogDistinctId,
         coupon,
         uiMode,
         isApp: isApp.value || undefined,
@@ -380,6 +389,7 @@ export function useLikeCoinSessionAPI() {
     fbClickId,
     fbp,
     fbc,
+    posthogDistinctId,
   }: {
     period?: SubscriptionPlan
     giftInfo: {
@@ -404,6 +414,7 @@ export function useLikeCoinSessionAPI() {
     fbClickId?: string
     fbp?: string
     fbc?: string
+    posthogDistinctId?: string
   }) {
     return fetch.value<FetchLikerPlusCheckoutLinkResponseData>(`/plus/gift/new`, {
       method: 'POST',
@@ -423,6 +434,7 @@ export function useLikeCoinSessionAPI() {
         fbClickId,
         fbp,
         fbc,
+        posthogDistinctId,
         coupon,
         isApp: isApp.value || undefined,
       },


### PR DESCRIPTION
Read posthog.get_distinct_id() via getAnalyticsParameters() and forward it through the four checkout creators (book single, book cart, Plus, Plus gift). The API uses this as \$anon_distinct_id to stitch the anonymous browsing session to the identified evmWallet person in PostHog, backstopping the client-side identify() call for cross-device and race cases.