### PR TITLE
🚀 Skip wagmi auto-probe of unused wallet connectors

### DIFF
--- a/plugins/wagmi.ts
+++ b/plugins/wagmi.ts
@@ -1,4 +1,5 @@
 import { WagmiPlugin, type Config } from '@wagmi/vue'
+import { reconnect } from '@wagmi/core'
 import { VueQueryPlugin } from '@tanstack/vue-query'
 import { defineNuxtPlugin } from 'nuxt/app'
 
@@ -18,8 +19,35 @@ export default defineNuxtPlugin((nuxtApp) => {
     isApp: isApp.value,
   })
   nuxtApp.vueApp
-    .use(WagmiPlugin, { config: wagmiConfig as Config })
+    .use(WagmiPlugin, { config: wagmiConfig as Config, reconnectOnMount: false })
     .use(VueQueryPlugin, {})
+
+  // Avoid wagmi's default reconnectOnMount, which probes every connector —
+  // including walletConnect, which lazy-loads a ~451 KB chunk. Instead,
+  // reconnect only to the connector the user last used, deferred to an idle
+  // window so it stays off the hydration critical path.
+  if (import.meta.client) {
+    nuxtApp.hook('app:mounted', () => {
+      const reconnectLastUsed = async () => {
+        try {
+          const recentId = await wagmiConfig.storage?.getItem('recentConnectorId')
+          if (!recentId) return
+          const connector = wagmiConfig.connectors.find(c => c.id === recentId)
+          if (!connector) return
+          await reconnect(wagmiConfig, { connectors: [connector] })
+        }
+        catch (error) {
+          console.warn('[wagmi] Failed to reconnect last used connector', error)
+        }
+      }
+      if (typeof requestIdleCallback !== 'undefined') {
+        requestIdleCallback(reconnectLastUsed, { timeout: 2000 })
+      }
+      else {
+        setTimeout(reconnectLastUsed, 0)
+      }
+    })
+  }
 
   return {
     provide: {


### PR DESCRIPTION
wagmi's default reconnectOnMount iterates every configured connector and calls getProvider() on each, which pulls the WalletConnect ethereum-provider (~451 KB) on every page load — even for visitors who never connected a wallet. Disable the default and reconnect only to the last-used connector, deferred to requestIdleCallback so it stays off the hydration critical path.