### PR TITLE
⚗️ Isolate TTS sample A/B test from mobile register CTA variant

### DIFF
--- a/pages/member.vue
+++ b/pages/member.vue
@@ -9,7 +9,6 @@
     utm-source="website"
     utm-medium="web"
     :coupon="coupon"
-    :must-show-tts-on-mobile="isMobileRegisterCTATestVariant"
     @open="handleOpen"
     @subscribe="handleSubscribe"
   >


### PR DESCRIPTION
The mobile register CTA test variant was forcing TTS samples on via must-show-tts-on-mobile, cross-contaminating the pricing-page-tts-sample experiment readout. PricingPageContent already evaluates the TTS sample flag internally, so drop the stray binding and let each experiment gate its own UI independently.