### PR TITLE
[TAS-5733] 🐛 Fix stringify non-POJOs error in custom voice composable

### DIFF
--- a/composables/use-custom-voice.ts
+++ b/composables/use-custom-voice.ts
@@ -1,18 +1,21 @@
 import type { CustomVoiceData } from '~/shared/types/custom-voice'
 
+let inflightFetch: Promise<void> | null = null
+
 export function useCustomVoice() {
   const customVoice = useState<CustomVoiceData | null>('custom-voice', () => null)
   const isLoaded = useState<boolean>('custom-voice-loaded', () => false)
   const isLoading = useState<boolean>('custom-voice-loading', () => false)
-  const inflightFetch = useState<Promise<void> | null>('custom-voice-inflight', () => null)
 
   const { loggedIn: hasLoggedIn } = useUserSession()
 
   const hasCustomVoice = computed(() => !!customVoice.value?.voiceId)
 
   function fetchCustomVoice(): Promise<void> {
-    if (isLoaded.value) return Promise.resolve()
-    if (inflightFetch.value) return inflightFetch.value
+    if (import.meta.server || isLoaded.value) {
+      return Promise.resolve()
+    }
+    if (inflightFetch) return inflightFetch
     const task = (async () => {
       try {
         const data = await $fetch<CustomVoiceData | null>('/api/user/custom-voice')
@@ -24,10 +27,10 @@ export function useCustomVoice() {
         console.error('[CustomVoice] Failed to fetch:', error)
       }
       finally {
-        inflightFetch.value = null
+        inflightFetch = null
       }
     })()
-    inflightFetch.value = task
+    inflightFetch = task
     return task
   }
 
@@ -35,7 +38,7 @@ export function useCustomVoice() {
     if (!loggedIn && wasLoggedIn) {
       customVoice.value = null
       isLoaded.value = false
-      inflightFetch.value = null
+      inflightFetch = null
     }
   })
 


### PR DESCRIPTION
```
[CAUSE]
DevalueError {
  stack: 'Cannot stringify arbitrary non-POJOs\n' +
  'at flatten (./node_modules/devalue/src/stringify.js:201:13)\n' +
  'at flatten (./node_modules/devalue/src/stringify.js:229:43)\n' +
  'at flatten (./node_modules/devalue/src/stringify.js:65:39)\n' +
  'at flatten (./node_modules/devalue/src/stringify.js:229:43)\n' +
  'at flatten (./node_modules/devalue/src/stringify.js:65:39)\n' +
  'at stringify (./node_modules/devalue/src/stringify.js:241:16)\n' +
  'at renderPayloadJsonScript (./node_modules/@nuxt/nitro-server/dist/runtime/utils/renderer/payload.js:18:31)\n' +
  'at Object.render (./node_modules/@nuxt/nitro-server/dist/runtime/handlers/renderer.js:172:296)\n' +
  '    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\n' +
  'at async Object.handler (./node_modules/nitropack/dist/runtime/internal/ren'... 16 more characters,
  message: 'Cannot stringify arbitrary non-POJOs',
  name: 'DevalueError',
  path: '.state["$scustom-voice-inflight"]',
}
```