### PR TITLE
🚸 Default trial to 0 when coupon query param is set

### DIFF
--- a/pages/member.vue
+++ b/pages/member.vue
@@ -276,6 +276,7 @@ const trialPeriodDays = computed(() => {
     case '30d': return 30
     default:
       if (activeAffiliate.value?.giftOnTrial === false) return 0
+      if (coupon.value) return 0
       return DEFAULT_TRIAL_PERIOD_DAYS
   }
 })


### PR DESCRIPTION
Avoid stacking a free trial on top of a coupon discount on /member. Explicit ?trial=*d still wins.