### PR TITLE
🚀 Prioritize hero book cover with fetchpriority hint

### DIFF
--- a/components/BookCover.vue
+++ b/components/BookCover.vue
@@ -49,6 +49,7 @@
         :src="props.src"
         :alt="props.alt"
         :loading="props.lazy ? 'lazy' : 'eager'"
+        :fetchpriority="props.priority ? 'high' : undefined"
         @load="handleImageLoad"
         @error="handleImageError"
       >
@@ -144,6 +145,10 @@ const props = defineProps({
     default: false,
   },
   lazy: {
+    type: Boolean,
+    default: false,
+  },
+  priority: {
     type: Boolean,
     default: false,
   },

--- a/components/BookCoverCarousel.vue
+++ b/components/BookCoverCarousel.vue
@@ -27,6 +27,7 @@
           :src="item.src"
           :alt="props.alt"
           :is-vertical-center="true"
+          :priority="true"
         />
 
         <img
@@ -123,6 +124,7 @@
     :alt="props.alt"
     :is-vertical-center="true"
     :has-shadow="props.hasShadow"
+    :priority="true"
     @click="handleSingleCoverClick"
   />
 </template>


### PR DESCRIPTION
Mark eager-loaded covers as fetchpriority=high so the LCP image beats lower-priority resources to the network; lazy covers stay on auto.