### PR TITLE
🚀 Defer Intercom load until 3s idle

### DIFF
--- a/composables/use-logger.ts
+++ b/composables/use-logger.ts
@@ -221,16 +221,15 @@ export function useSetLogUser(user: User | null, locale: string) {
     }
   }
 
-  // Set user info in Intercom
-  if (window?.Intercom) {
+  if (import.meta.client) {
     try {
-      const intercom = window.Intercom
       if (!user) {
-        intercom('shutdown')
-        return
+        const { app_id } = window.intercomSettings || {}
+        window.intercomSettings = app_id ? { app_id } : {}
+        window.Intercom?.('shutdown')
       }
       else {
-        intercom('update', {
+        const userSettings = {
           intercom_user_jwt: user.intercomToken,
           session_duration: 2592000000, // 30d
           user_id: user.likerId,
@@ -246,7 +245,9 @@ export function useSetLogUser(user: User | null, locale: string) {
           like_wallet: user.likeWallet,
           login_method: user.loginMethod,
           locale,
-        })
+        }
+        window.intercomSettings = { ...window.intercomSettings, ...userSettings }
+        window.Intercom?.('update', userSettings)
       }
     }
     catch (error) {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -223,7 +223,9 @@ export default defineNuxtConfig({
     privacy: false,
     registry: {
       googleAnalytics: true,
-      intercom: true,
+      intercom: {
+        trigger: { idleTimeout: 3000 },
+      },
       metaPixel: true,
       posthog: POSTHOG_PUBLIC_KEY
         ? {


### PR DESCRIPTION
Set window.intercomSettings on login so Intercom picks up identity on first boot now that the widget no longer loads at Nuxt ready.

Also drop a stray early return on logout that previously skipped PostHog reset and native resetUser when Intercom was loaded.