### PR TITLE
✨ Bridge Intercom calls to native SDK in-app

### DIFF
--- a/components/AppFooter.vue
+++ b/components/AppFooter.vue
@@ -199,12 +199,11 @@ const { commitSHA } = useRuntimeConfig().public
 const { t: $t } = useI18n()
 const localeRoute = useLocaleRoute()
 const { isApp, buildVersion } = useAppDetection()
+const intercom = useIntercom()
 
 function onClickContactUs(event: MouseEvent) {
-  if (window?.Intercom) {
-    window.Intercom('show')
-    event.preventDefault()
-  }
+  event.preventDefault()
+  intercom.show()
 }
 
 function onClickAppStoreButton() {

--- a/components/PricingPlanBenefits.vue
+++ b/components/PricingPlanBenefits.vue
@@ -98,11 +98,10 @@ const isYearlyPlan = computed(() => {
 })
 
 const { t: $t } = useI18n()
+const intercom = useIntercom()
 
 function handleOpenIntercom() {
   useLogEvent('pricing_benefit_click_intercom')
-  if (window?.Intercom) {
-    window.Intercom('showNewMessage', $t('pricing_page_intercom_prefill'))
-  }
+  intercom.showNewMessage($t('pricing_page_intercom_prefill'))
 }
 </script>

--- a/composables/use-claimable-books.ts
+++ b/composables/use-claimable-books.ts
@@ -4,6 +4,7 @@ export function useClaimableBooks() {
   const blockingModal = useBlockingModal()
   const localeRoute = useLocaleRoute()
   const { handleError } = useErrorHandler()
+  const intercom = useIntercom()
 
   const nftClassIds = ref<string[]>([])
   const isLoading = ref(false)
@@ -52,9 +53,7 @@ export function useClaimableBooks() {
               {
                 label: $t('contact_cs'),
                 onClick: async () => {
-                  if (window.Intercom) {
-                    window.Intercom('show')
-                  }
+                  intercom.show()
                 },
               },
             ],

--- a/composables/use-intercom-visibility.ts
+++ b/composables/use-intercom-visibility.ts
@@ -8,7 +8,7 @@ export function useIntercomVisibility() {
   function markIntercomVisible() {
     isIntercomVisible.value = true
     if (hasRegisteredIntercomHide) return
-    if (!window.Intercom) return
+    if (!isWebIntercomReady()) return
     window.Intercom('onHide', () => {
       isIntercomVisible.value = false
     })

--- a/composables/use-intercom.ts
+++ b/composables/use-intercom.ts
@@ -1,0 +1,64 @@
+// Single entry point for Intercom on web. Picks among the native RN SDK
+// bridge, the window.Intercom JS SDK, and a mailto fallback so call sites
+// don't have to branch on isApp / SDK availability themselves.
+
+const SUPPORT_EMAIL = 'cs@3ook.com'
+
+type OpenResult = { method: 'chat' | 'link' }
+
+function openMailto(subject?: string, body?: string): void {
+  let mailto = `mailto:${SUPPORT_EMAIL}`
+  const params: string[] = []
+  if (subject) params.push(`subject=${encodeURIComponent(subject)}`)
+  if (body) params.push(`body=${encodeURIComponent(body)}`)
+  if (params.length) mailto += `?${params.join('&')}`
+  window.open(mailto, '_blank')
+}
+
+export function useIntercom() {
+  const { isApp } = useAppDetection()
+
+  function show(): OpenResult {
+    if (isApp.value) {
+      if (isNativeFeatureSupported('intercom')) {
+        postToNative({ type: 'intercomShow' })
+        return { method: 'chat' }
+      }
+      openMailto()
+      return { method: 'link' }
+    }
+    if (typeof window?.Intercom === 'function') {
+      window.Intercom('show')
+      return { method: 'chat' }
+    }
+    openMailto()
+    return { method: 'link' }
+  }
+
+  function showNewMessage(message?: string, mailtoSubject?: string): OpenResult {
+    if (isApp.value) {
+      if (isNativeFeatureSupported('intercom')) {
+        postToNative({ type: 'intercomShowNewMessage', message })
+        return { method: 'chat' }
+      }
+      openMailto(mailtoSubject ?? message, message)
+      return { method: 'link' }
+    }
+    if (typeof window?.Intercom === 'function') {
+      window.Intercom('showNewMessage', message ?? '')
+      return { method: 'chat' }
+    }
+    openMailto(mailtoSubject ?? message, message)
+    return { method: 'link' }
+  }
+
+  function trackEvent(name: string, params?: Record<string, unknown>): void {
+    if (isApp.value && isNativeFeatureSupported('intercom')) {
+      postToNative({ type: 'intercomTrackEvent', name, metaData: params })
+      return
+    }
+    window?.Intercom?.('trackEvent', name, params)
+  }
+
+  return { show, showNewMessage, trackEvent }
+}

--- a/composables/use-intercom.ts
+++ b/composables/use-intercom.ts
@@ -1,6 +1,9 @@
 // Single entry point for Intercom on web. Picks among the native RN SDK
 // bridge, the window.Intercom JS SDK, and a mailto fallback so call sites
-// don't have to branch on isApp / SDK availability themselves.
+// don't have to branch on bridge / SDK availability themselves. The web
+// SDK branch is gated on !isApp because plugins/intercom.client.ts hides
+// the messenger via CSS in app mode (real app or ?app=1) — calling
+// Intercom('show') there opens an invisible UI.
 
 const SUPPORT_EMAIL = 'cs@3ook.com'
 
@@ -18,38 +21,37 @@ function openMailto(subject?: string, body?: string): void {
 export function useIntercom() {
   const { isApp } = useAppDetection()
 
-  function show(): OpenResult {
-    if (isApp.value) {
-      if (isNativeIntercomAvailable()) {
-        postToNative({ type: 'intercomShow' })
-        return { method: 'chat' }
-      }
-      openMailto()
-      return { method: 'link' }
-    }
-    if (isWebIntercomReady()) {
-      window.Intercom('show')
+  function dispatch(
+    native: () => void,
+    web: () => void,
+    fallback: () => void,
+  ): OpenResult {
+    if (isNativeIntercomAvailable()) {
+      native()
       return { method: 'chat' }
     }
-    openMailto()
+    if (!isApp.value && isWebIntercomReady()) {
+      web()
+      return { method: 'chat' }
+    }
+    fallback()
     return { method: 'link' }
   }
 
+  function show(): OpenResult {
+    return dispatch(
+      () => postToNative({ type: 'intercomShow' }),
+      () => window.Intercom('show'),
+      () => openMailto(),
+    )
+  }
+
   function showNewMessage(message?: string, mailtoSubject?: string): OpenResult {
-    if (isApp.value) {
-      if (isNativeIntercomAvailable()) {
-        postToNative({ type: 'intercomShowNewMessage', message })
-        return { method: 'chat' }
-      }
-      openMailto(mailtoSubject ?? message, message)
-      return { method: 'link' }
-    }
-    if (isWebIntercomReady()) {
-      window.Intercom('showNewMessage', message ?? '')
-      return { method: 'chat' }
-    }
-    openMailto(mailtoSubject ?? message, message)
-    return { method: 'link' }
+    return dispatch(
+      () => postToNative({ type: 'intercomShowNewMessage', message }),
+      () => window.Intercom('showNewMessage', message ?? ''),
+      () => openMailto(mailtoSubject ?? message, message),
+    )
   }
 
   function trackEvent(name: string, params?: Record<string, unknown>): void {

--- a/composables/use-intercom.ts
+++ b/composables/use-intercom.ts
@@ -20,14 +20,14 @@ export function useIntercom() {
 
   function show(): OpenResult {
     if (isApp.value) {
-      if (isNativeFeatureSupported('intercom')) {
+      if (isNativeIntercomAvailable()) {
         postToNative({ type: 'intercomShow' })
         return { method: 'chat' }
       }
       openMailto()
       return { method: 'link' }
     }
-    if (typeof window?.Intercom === 'function') {
+    if (isWebIntercomReady()) {
       window.Intercom('show')
       return { method: 'chat' }
     }
@@ -37,14 +37,14 @@ export function useIntercom() {
 
   function showNewMessage(message?: string, mailtoSubject?: string): OpenResult {
     if (isApp.value) {
-      if (isNativeFeatureSupported('intercom')) {
+      if (isNativeIntercomAvailable()) {
         postToNative({ type: 'intercomShowNewMessage', message })
         return { method: 'chat' }
       }
       openMailto(mailtoSubject ?? message, message)
       return { method: 'link' }
     }
-    if (typeof window?.Intercom === 'function') {
+    if (isWebIntercomReady()) {
       window.Intercom('showNewMessage', message ?? '')
       return { method: 'chat' }
     }
@@ -53,11 +53,13 @@ export function useIntercom() {
   }
 
   function trackEvent(name: string, params?: Record<string, unknown>): void {
-    if (isApp.value && isNativeFeatureSupported('intercom')) {
+    if (isNativeIntercomAvailable()) {
       postToNative({ type: 'intercomTrackEvent', name, metaData: params })
       return
     }
-    window?.Intercom?.('trackEvent', name, params)
+    if (isWebIntercomReady()) {
+      window.Intercom('trackEvent', name, params)
+    }
   }
 
   return { show, showNewMessage, trackEvent }

--- a/composables/use-logger.ts
+++ b/composables/use-logger.ts
@@ -140,10 +140,10 @@ export function useLogEvent(eventName: string, eventParams: EventParams = {}) {
       // Forward via the native bridge when supported; otherwise use the
       // web SDK. Older app builds without the bridge keep the web SDK
       // active so events still reach Intercom for CS context.
-      if (isNativeWebView() && isNativeFeatureSupported('intercom')) {
+      if (isNativeIntercomAvailable()) {
         postToNative({ type: 'intercomTrackEvent', name: eventName, metaData: params })
       }
-      else if (window?.Intercom) {
+      else if (isWebIntercomReady()) {
         window.Intercom('trackEvent', eventName, params)
       }
     }
@@ -238,7 +238,7 @@ export function useSetLogUser(user: User | null, locale: string) {
   // identity (driven by the identifyUser/resetUser bridge below). Browser
   // sessions and older app builds without the bridge sync via the web SDK
   // so CS still has user context.
-  if (import.meta.client && (!isNativeWebView() || !isNativeFeatureSupported('intercom'))) {
+  if (import.meta.client && !isNativeIntercomAvailable()) {
     try {
       if (!user) {
         const { app_id } = window.intercomSettings || {}

--- a/composables/use-logger.ts
+++ b/composables/use-logger.ts
@@ -131,13 +131,21 @@ export function useLogEvent(eventName: string, eventParams: EventParams = {}) {
     console.error(`Failed to track event with Meta Pixel: ${eventName}`, eventParams)
   }
 
-  if (window?.Intercom && INTERCOM_EVENT_ALLOWLIST.has(eventName)) {
+  if (INTERCOM_EVENT_ALLOWLIST.has(eventName)) {
     try {
       const { items, ...params } = eventParams
       if (items) {
         params.items = JSON.stringify(items)
       }
-      window.Intercom('trackEvent', eventName, params)
+      // Forward via the native bridge when supported; otherwise use the
+      // web SDK. Older app builds without the bridge keep the web SDK
+      // active so events still reach Intercom for CS context.
+      if (isNativeWebView() && isNativeFeatureSupported('intercom')) {
+        postToNative({ type: 'intercomTrackEvent', name: eventName, metaData: params })
+      }
+      else if (window?.Intercom) {
+        window.Intercom('trackEvent', eventName, params)
+      }
     }
     catch (error) {
       console.error(`Failed to log event to Intercom: ${eventName}`, error)
@@ -226,7 +234,11 @@ export function useSetLogUser(user: User | null, locale: string) {
     }
   }
 
-  if (import.meta.client) {
+  // When the native Intercom bridge is supported, the native SDK owns
+  // identity (driven by the identifyUser/resetUser bridge below). Browser
+  // sessions and older app builds without the bridge sync via the web SDK
+  // so CS still has user context.
+  if (import.meta.client && (!isNativeWebView() || !isNativeFeatureSupported('intercom'))) {
     try {
       if (!user) {
         const { app_id } = window.intercomSettings || {}
@@ -299,6 +311,8 @@ export function useSetLogUser(user: User | null, locale: string) {
   }
 
   // Sync user identity to the native app for its own analytics SDKs
+  // and (when supported) the native Intercom SDK. Older app builds
+  // that don't know about intercomToken simply ignore the extra fields.
   if (isNativeWebView()) {
     if (user) {
       postToNative({
@@ -310,6 +324,11 @@ export function useSetLogUser(user: User | null, locale: string) {
         isLikerPlus: !!user.isLikerPlus,
         loginMethod: user.loginMethod,
         locale,
+        // Intercom Identity Verification token + correlation IDs.
+        intercomToken: user.intercomToken,
+        likerId: user.likerId,
+        evmWallet: user.evmWallet,
+        likeWallet: user.likeWallet,
       })
     }
     else {

--- a/pages/account/index.vue
+++ b/pages/account/index.vue
@@ -702,6 +702,7 @@ const { handleError } = useErrorHandler()
 const toast = useToast()
 const { copy: copyToClipboard } = useClipboard()
 const { isApp } = useAppDetection()
+const intercom = useIntercom()
 
 const isAdultContentEnabled = useAdultContentSetting()
 const isAdultContentConfirmOpen = ref(false)
@@ -1100,21 +1101,7 @@ async function handleLikerPlusButtonClick() {
 }
 
 function openIntercomWithEmailFallback(prefillMessage?: string) {
-  if (!isApp.value && window?.Intercom) {
-    if (prefillMessage) {
-      window.Intercom('showNewMessage', prefillMessage)
-    }
-    else {
-      window.Intercom('show')
-    }
-    return 'chat'
-  }
-  let mailto = 'mailto:cs@3ook.com'
-  if (prefillMessage) {
-    mailto += `?subject=${encodeURIComponent(prefillMessage)}`
-  }
-  window.open(mailto, '_blank')
-  return 'link'
+  return (prefillMessage ? intercom.showNewMessage(prefillMessage) : intercom.show()).method
 }
 
 function handleCustomerServiceLinkButtonClick() {

--- a/pages/reader/epub.vue
+++ b/pages/reader/epub.vue
@@ -817,6 +817,7 @@ let removeMouseUpListener: (() => void) | undefined
 let removeSelectionChangeListener: (() => void) | undefined
 let removeContextMenuListener: (() => void) | undefined
 const { isIntercomVisible, markIntercomVisible } = useIntercomVisibility()
+const intercom = useIntercom()
 useHead({
   htmlAttrs: {
     class: computed(() => (isIntercomVisible.value ? 'intercom-visible' : '')),
@@ -1862,14 +1863,10 @@ function handleAnnotationReportIssue() {
     cfi: selectedCfi.value,
   })
 
-  if (!isApp.value && window?.Intercom) {
+  const subject = $t('reader_annotation_report_issue_email_subject', { bookName: bookInfo.name.value })
+  const result = intercom.showNewMessage(prefillMessage, subject)
+  if (result.method === 'chat' && !isApp.value) {
     markIntercomVisible()
-    window.Intercom('showNewMessage', prefillMessage)
-  }
-  else {
-    const subject = $t('reader_annotation_report_issue_email_subject', { bookName: bookInfo.name.value })
-    const mailto = `mailto:cs@3ook.com?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(prefillMessage)}`
-    window.open(mailto, '_blank')
   }
 
   useLogEvent('reader_annotation_report_issue', {

--- a/pages/store/index.vue
+++ b/pages/store/index.vue
@@ -279,6 +279,7 @@ const storePageState = useStorePageState()
 const isMobile = useMediaQuery('(max-width: 425px)')
 const isAdultContentEnabled = useAdultContentSetting()
 const { isApp } = useAppDetection()
+const intercom = useIntercom()
 
 const querySearchTerm = computed(() => getRouteQuery('q', ''))
 const queryAuthorName = computed(() => getRouteQuery('author', ''))
@@ -974,12 +975,7 @@ function handleClearSearchInputButton() {
 function handleContactUsClick() {
   useLogEvent('store_no_search_results_contact_click', { search_term: querySearchTerm.value })
   const searchTerm = querySearchTerm.value || queryAuthorName.value || queryPublisherName.value || queryOwnerWallet.value
-  if (window?.Intercom) {
-    window.Intercom('showNewMessage', $t('store_no_search_results_contact_prefill', { term: searchTerm }))
-  }
-  else {
-    window.open(`mailto:cs@3ook.com?subject=${encodeURIComponent($t('store_no_search_results_contact_prefill', { term: searchTerm }))}`, '_blank')
-  }
+  intercom.showNewMessage($t('store_no_search_results_contact_prefill', { term: searchTerm }))
 }
 
 async function handleSearchSubmit() {

--- a/plugins/intercom.client.ts
+++ b/plugins/intercom.client.ts
@@ -11,7 +11,7 @@ export default defineNuxtPlugin(() => {
   // routes through the WebView bridge instead. Older app builds without
   // the bridge keep the web SDK active (identity + events still flow);
   // the CSS hide below keeps the launcher invisible.
-  if (isNativeFeatureSupported('intercom')) {
+  if (isNativeIntercomAvailable()) {
     const noop = () => {}
     ;(window as unknown as { Intercom: (...args: unknown[]) => void }).Intercom = noop
   }

--- a/plugins/intercom.client.ts
+++ b/plugins/intercom.client.ts
@@ -5,6 +5,17 @@ export default defineNuxtPlugin(() => {
     return
   }
 
+  // When the native Intercom bridge is supported, defang the web SDK so
+  // any stray window.Intercom(...) call becomes a no-op and can't open a
+  // duplicate web messenger on top of the native one — useIntercom()
+  // routes through the WebView bridge instead. Older app builds without
+  // the bridge keep the web SDK active (identity + events still flow);
+  // the CSS hide below keeps the launcher invisible.
+  if (isNativeFeatureSupported('intercom')) {
+    const noop = () => {}
+    ;(window as unknown as { Intercom: (...args: unknown[]) => void }).Intercom = noop
+  }
+
   // Hide Intercom UI elements via CSS in case it loads later
   const styleId = 'intercom-hide-style'
   if (!document.getElementById(styleId)) {

--- a/types/native-bridge.d.ts
+++ b/types/native-bridge.d.ts
@@ -2,6 +2,7 @@ interface Window {
   ReactNativeWebView?: {
     postMessage(message: string): void
   }
+  __nativeBridge?: { features?: readonly string[] }
 }
 
 interface WindowEventMap {

--- a/utils/native-bridge.ts
+++ b/utils/native-bridge.ts
@@ -1,3 +1,9 @@
+declare global {
+  interface Window {
+    __nativeBridge?: { features?: readonly string[] }
+  }
+}
+
 export function postToNative(data: { type: string, [key: string]: unknown }): void {
   if (typeof window === 'undefined') return
   window.ReactNativeWebView?.postMessage(JSON.stringify(data))
@@ -5,4 +11,10 @@ export function postToNative(data: { type: string, [key: string]: unknown }): vo
 
 export function isNativeWebView(): boolean {
   return typeof window !== 'undefined' && !!window.ReactNativeWebView
+}
+
+export function isNativeFeatureSupported(feature: string): boolean {
+  if (typeof window === 'undefined') return false
+  const features = window.__nativeBridge?.features
+  return Array.isArray(features) && features.includes(feature)
 }

--- a/utils/native-bridge.ts
+++ b/utils/native-bridge.ts
@@ -1,9 +1,3 @@
-declare global {
-  interface Window {
-    __nativeBridge?: { features?: readonly string[] }
-  }
-}
-
 export function postToNative(data: { type: string, [key: string]: unknown }): void {
   if (typeof window === 'undefined') return
   window.ReactNativeWebView?.postMessage(JSON.stringify(data))

--- a/utils/native-bridge.ts
+++ b/utils/native-bridge.ts
@@ -18,3 +18,11 @@ export function isNativeFeatureSupported(feature: string): boolean {
   const features = window.__nativeBridge?.features
   return Array.isArray(features) && features.includes(feature)
 }
+
+export function isNativeIntercomAvailable(): boolean {
+  return isNativeWebView() && isNativeFeatureSupported('intercom')
+}
+
+export function isWebIntercomReady(): boolean {
+  return typeof window !== 'undefined' && typeof window.Intercom === 'function'
+}


### PR DESCRIPTION
Adds useIntercom() — a single composable that picks among the native Intercom bridge (in-app + supported), window.Intercom (browser), and mailto fallback. Returns { method } so analytics events can still report 'chat' vs 'link'. All six direct window.Intercom call sites (AppFooter, PricingPlanBenefits, use-claimable-books, account, store, reader/epub) now go through it.

Capability is detected via window.__nativeBridge.features injected by the native shell, so older app builds fall back to mailto without a sync release. Extends the identifyUser bridge payload with intercomToken / likerId / evmWallet / likeWallet for the native SDK's Identity Verification flow, and skips window.Intercom('shutdown'| 'update'|'trackEvent') in-app — native owns that surface. Defangs window.Intercom to a no-op in-app so any stray third-party call can't pop a duplicate web messenger over the native one.

Hoists nativeFeatureSupported() into utils/native-bridge.ts and declares the global window.__nativeBridge type once.