### PR TITLE
🚸 Surface business identity in storefront metadata and chrome

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -160,8 +160,9 @@ useHead({
         '@context': 'https://schema.org',
         '@type': 'OnlineStore',
         'name': ogTitle,
+        'legalName': 'Liker Land, Inc.',
         'description': ogDescription,
-        'alternateName': ['3ook.com decentralized bookstore', 'Liker Land 電子書店', 'Liker Land'],
+        'alternateName': ['Liker Land 電子書店', 'Liker Land'],
         'sameAs': [
           'https://linktr.ee/3ookcom',
           'https://www.instagram.com/3ookcom',
@@ -169,9 +170,25 @@ useHead({
           'https://review.3ook.com',
           'https://x.com/3ookcom',
           'https://www.threads.com/@3ookcom',
+          'https://www.linkedin.com/company/3ookcom',
         ],
         'url': ogURL,
         'logo': ogImage,
+        'email': 'cs@3ook.com',
+        'contactPoint': [
+          {
+            '@type': 'ContactPoint',
+            'contactType': 'customer service',
+            'email': 'cs@3ook.com',
+            'availableLanguage': ['English', 'Chinese'],
+          },
+          {
+            '@type': 'ContactPoint',
+            'contactType': 'customer service',
+            'url': 'https://wa.me/15558049733',
+            'availableLanguage': ['English', 'Chinese'],
+          },
+        ],
         'brand': [
           {
             '@context': 'https://schema.org',

--- a/components/AppFooter.vue
+++ b/components/AppFooter.vue
@@ -27,11 +27,16 @@
       >
         <AppLogo v-if="props.isShowLogo" />
       </ULink>
-      <ULink
-        class="border-b leading-5"
-        to="https://github.com/likecoin/3ook-com?tab=GPL-3.0-1-ov-file#readme"
-        target="_blank"
-      >{{ $t('footer_license') }}</ULink>
+      <div class="flex items-center gap-2 leading-5">
+        <ULink
+          class="border-b"
+          to="https://github.com/likecoin/3ook-com?tab=GPL-3.0-1-ov-file#readme"
+          target="_blank"
+          rel="noopener noreferrer"
+        >{{ $t('footer_license') }}</ULink>
+        <span>·</span>
+        <span>Liker Land, Inc.</span>
+      </div>
       <nav>
         <ul class="flex justify-center items-center flex-wrap gap-4 gap-y-1">
           <li>

--- a/composables/use-structured-data.ts
+++ b/composables/use-structured-data.ts
@@ -73,22 +73,18 @@ export function useMemberProgramStructuredData() {
 }
 
 function generateBookOffer({
-  sellerWalletAddress,
   canonicalURL,
   priceIndex,
   price,
   isSoldOut,
-  isAutoDeliver,
   productId,
   baseURL,
   validForMemberTier,
 }: {
-  sellerWalletAddress?: string
   canonicalURL: string
   priceIndex: number
   price: number
   isSoldOut: boolean
-  isAutoDeliver: boolean
   productId: string
   baseURL: string
   validForMemberTier?: Array<{
@@ -103,49 +99,18 @@ function generateBookOffer({
   const offer: Record<string, unknown> = {
     '@context': 'https://schema.org',
     '@type': 'Offer',
-    'seller': sellerWalletAddress
-      ? {
-          '@context': 'https://schema.org',
-          '@type': 'Person',
-          'identifier': sellerWalletAddress,
-        }
-      : undefined,
+    'seller': {
+      '@type': 'Organization',
+      'name': '3ook.com',
+      'legalName': 'Liker Land, Inc.',
+      'url': baseURL,
+    },
     'url': `${canonicalURL}?price_index=${priceIndex}`,
     'price': price,
     'priceCurrency': 'USD',
-    'availability': isSoldOut ? 'https://schema.org/SoldOut' : 'https://schema.org/LimitedAvailability',
+    'availability': isSoldOut ? 'https://schema.org/SoldOut' : 'https://schema.org/InStock',
     'itemCondition': 'https://schema.org/NewCondition',
     'checkoutPageURLTemplate': `${baseURL}/checkout?products=${productId}&utm_medium=structured-data`,
-    'shippingDetails': {
-      '@type': 'OfferShippingDetails',
-      'shippingRate': {
-        '@type': 'MonetaryAmount',
-        'value': 0,
-        'currency': 'USD',
-      },
-      'deliveryTime': {
-        '@type': 'ShippingDeliveryTime',
-        'handlingTime': !isAutoDeliver
-          ? {
-              '@type': 'QuantitativeValue',
-              'minValue': 1,
-              'maxValue': 7,
-              'unitCode': 'DAY',
-            }
-          : {
-              '@type': 'QuantitativeValue',
-              'minValue': 0,
-              'maxValue': 0,
-              'unitCode': 'DAY',
-            },
-        'transitTime': {
-          '@type': 'QuantitativeValue',
-          'minValue': 0,
-          'maxValue': 0,
-          'unitCode': 'DAY',
-        },
-      },
-    },
     'hasMerchantReturnPolicy': {
       '@type': 'MerchantReturnPolicy',
       'returnPolicyCategory': 'https://schema.org/MerchantReturnNotPermitted',
@@ -162,13 +127,13 @@ function generateBookOffer({
 function generateReadAction({
   urlTemplate,
   nftClassId,
-  sellerWalletAddress,
+  baseURL,
   price,
   isSoldOut = false,
 }: {
   urlTemplate: string
   nftClassId: string
-  sellerWalletAddress?: string
+  baseURL: string
   price?: number
   isSoldOut?: boolean
 }) {
@@ -188,14 +153,12 @@ function generateReadAction({
   if (price !== undefined) {
     const productId = `${nftClassId}-${0}`
     const offer = generateBookOffer({
-      sellerWalletAddress: sellerWalletAddress,
       canonicalURL: urlTemplate,
       priceIndex: 0,
       price,
       isSoldOut,
-      isAutoDeliver: true,
       productId,
-      baseURL: urlTemplate,
+      baseURL,
     })
 
     action.expectsAcceptanceOf = offer
@@ -250,6 +213,7 @@ export function useStorePageStructuredData({
             'potentialAction': generateReadAction({
               nftClassId: item.classId!,
               urlTemplate: `${baseURL}/store/${item.classId}`,
+              baseURL,
               price: item.minPrice,
             }),
           },
@@ -327,7 +291,7 @@ export function useStructuredData(
     },
     {
       property: 'product:category',
-      content: 543542, // ebook
+      content: 'Media > Books > E-Books',
     },
     {
       property: 'product:condition',
@@ -459,25 +423,20 @@ export function useStructuredData(
           }),
         }),
         'offers': [
-          // Regular offer for all users
           generateBookOffer({
-            sellerWalletAddress: bookInfo.nftClassOwnerWalletAddress.value,
             canonicalURL,
             priceIndex: pricing.index,
             price: pricing?.price || 0,
             isSoldOut: pricing?.isSoldOut || false,
-            isAutoDeliver: pricing.isAutoDeliver,
             productId,
             baseURL,
           }),
           ...(pricing?.price > 0 && getPlusDiscountRate()
             ? [generateBookOffer({
-                sellerWalletAddress: bookInfo.nftClassOwnerWalletAddress.value,
                 canonicalURL,
                 priceIndex: pricing.index,
                 price: pricing.price * getPlusDiscountRate(),
                 isSoldOut: pricing?.isSoldOut || false,
-                isAutoDeliver: pricing.isAutoDeliver,
                 productId,
                 baseURL,
                 validForMemberTier: memberProgramTiers.value,
@@ -485,9 +444,9 @@ export function useStructuredData(
             : []),
         ],
         'potentialAction': generateReadAction({
-          sellerWalletAddress: bookInfo.nftClassOwnerWalletAddress.value,
           nftClassId: nftClassIdValue,
           urlTemplate: `${baseURL}/store/${nftClassIdValue}`,
+          baseURL,
           price: pricing?.price || 0,
           isSoldOut: pricing?.isSoldOut || false,
         }),


### PR DESCRIPTION
- OnlineStore JSON-LD: add legalName, customer-service contactPoint and email; drop "decentralized bookstore" alternateName
- Per-Offer seller: replace wallet-address Person with Liker Land, Inc. Organization; drop shippingDetails for digital goods; switch availability to InStock; use 'Media > Books > E-Books' for product:category
- generateReadAction: thread baseURL through (also fixes pre-existing 404 in checkoutPageURLTemplate when called from store-listing structured data)
- Footer: append "Liker Land, Inc." beside the GPL v3 license link