### PR TITLE
📈 Persist UTM attribution as PostHog super-properties

### DIFF
--- a/composables/use-logger.ts
+++ b/composables/use-logger.ts
@@ -166,6 +166,11 @@ export function useLogEvent(eventName: string, eventParams: EventParams = {}) {
   }
 }
 
+// Guards against `reset()` on the initial null user — stores/account.ts
+// watches with `immediate: true`, so cold loads enter this fn before login
+// state hydrates; resetting then would wipe attribution super-properties.
+let hasIdentifiedPostHog = false
+
 export function useSetLogUser(user: User | null, locale: string) {
   // Set user in Sentry
   if (!user) {
@@ -256,19 +261,38 @@ export function useSetLogUser(user: User | null, locale: string) {
   }
 
   try {
-    const { proxy } = useScriptPostHog()
-    proxy.posthog.identify(
-      user?.evmWallet,
-      user
-        ? {
-            email: user?.email || undefined,
-            name: user?.displayName || user?.evmWallet || user?.likeWallet,
+    const { proxy, onLoaded } = useScriptPostHog()
+    if (user) {
+      hasIdentifiedPostHog = true
+      onLoaded(({ posthog }) => {
+        // Source attribution from persisted super-properties; the URL may have
+        // been stripped by a Magic Link redirect before identify fires.
+        const lastTouch: Record<string, string> = {}
+        const firstTouch: Record<string, string> = {}
+        for (const key of POSTHOG_ATTRIBUTION_KEYS) {
+          const last = posthog.get_property(key)
+          if (typeof last === 'string' && last) lastTouch[key] = last
+          const first = posthog.get_property(`initial_${key}`)
+          if (typeof first === 'string' && first) firstTouch[`initial_${key}`] = first
+        }
+        posthog.identify(
+          user.evmWallet,
+          {
+            email: user.email || undefined,
+            name: user.displayName || user.evmWallet || user.likeWallet,
             locale,
             is_liker_plus: !!user.isLikerPlus,
             login_method: user.loginMethod,
-          }
-        : undefined,
-    )
+            ...lastTouch,
+          },
+          firstTouch,
+        )
+      })
+    }
+    else if (hasIdentifiedPostHog) {
+      hasIdentifiedPostHog = false
+      proxy.posthog.reset()
+    }
   }
   catch (error) {
     console.error('Failed to set user data in PostHog', error)

--- a/composables/use-posthog-attribution.ts
+++ b/composables/use-posthog-attribution.ts
@@ -1,0 +1,33 @@
+// Mirrors the fallback logic in `useAnalytics.getAnalyticsParameters()` so
+// PostHog ends up with the same normalized values the backend (Airtable) gets:
+// `ll_source`/`ll_medium` collapse into `utm_source`/`utm_medium`, and
+// `srsltid` becomes `utm_source=google` + `utm_medium=organic`.
+
+export const POSTHOG_ATTRIBUTION_KEYS = [
+  'utm_source',
+  'utm_medium',
+  'utm_campaign',
+  'utm_content',
+  'utm_term',
+  'gclid',
+  'gad_source',
+  'fbclid',
+] as const
+
+export function usePostHogAttribution(): Record<string, string> {
+  const getRouteQuery = useRouteQuery()
+
+  const hasSrsltid = !!getRouteQuery('srsltid')
+  const utmSource = getRouteQuery('utm_source') || (hasSrsltid ? 'google' : '') || getRouteQuery('ll_source')
+  const utmMedium = getRouteQuery('utm_medium') || (hasSrsltid ? 'organic' : '') || getRouteQuery('ll_medium')
+
+  const attribution: Record<string, string> = {}
+  if (utmSource) attribution.utm_source = utmSource
+  if (utmMedium) attribution.utm_medium = utmMedium
+  for (const key of POSTHOG_ATTRIBUTION_KEYS) {
+    if (key === 'utm_source' || key === 'utm_medium') continue
+    const value = getRouteQuery(key)
+    if (value) attribution[key] = value
+  }
+  return attribution
+}

--- a/plugins/posthog-attribution.client.ts
+++ b/plugins/posthog-attribution.client.ts
@@ -1,0 +1,18 @@
+// Persist UTM/click-id attribution as PostHog super-properties so they survive
+// the anon → identified transition. With `person_profiles: 'identified_only'`,
+// the person profile is only created at $identify, by which time the URL may
+// have lost its UTM (e.g. after a Magic Link redirect).
+
+export default defineNuxtPlugin(() => {
+  const { onLoaded } = useScriptPostHog()
+  const attribution = usePostHogAttribution()
+  if (!Object.keys(attribution).length) return
+
+  onLoaded(({ posthog }) => {
+    posthog.register(attribution)
+    const initialAttribution = Object.fromEntries(
+      Object.entries(attribution).map(([key, value]) => [`initial_${key}`, value]),
+    )
+    posthog.register_once(initialAttribution)
+  })
+})


### PR DESCRIPTION
Anonymous visitors lose UTMs by the time they identify (Magic Link redirect strips the URL), so PostHog person profiles never get $initial_utm_*. Register UTMs (with the same srsltid/ll_* normalization useAnalytics already applies) as super-properties on PostHog load and pass them as $set/$set_once on identify, so the attribution survives the anon → identified transition under person_profiles: 'identified_only'.

Also call posthog.reset() on logout instead of identify(undefined), to properly drop the anon↔user merge.