### PR TITLE
🐛 Avoid SSR 500 from JWT scope-mismatch logout

### DIFF
--- a/stores/account.ts
+++ b/stores/account.ts
@@ -76,11 +76,11 @@ export const useAccountStore = defineStore('account', () => {
     () => user.value,
     async (user) => {
       useSetLogUser(user, locale.value)
-      if (user?.token) {
-        const hasValidPermissions = verifyTokenPermissions(user.token)
-        if (!hasValidPermissions) {
-          await logout()
-        }
+      // logout() awaits client-only composables (wagmi disconnect, $fetch, useOverlay);
+      // running it during SSR drops the Nuxt instance after the first await and 500s.
+      if (!import.meta.client) return
+      if (user?.token && !verifyTokenPermissions(user.token)) {
+        await logout()
       }
     },
     { immediate: true, deep: true },


### PR DESCRIPTION
The account watcher fires with `immediate: true`, so it ran the scope-mismatch logout on SSR too. After the first `await` in `logout()` the Nuxt instance was lost, and downstream composables (wagmi disconnect, $fetch, useOverlay) threw "composable not in root", returning HTTP 500. Gate the check to client-only — the cookie gets cleared on hydration instead.