### PR TITLE
🐛 Allow same-origin iframes in CSP for proxied Meta Pixel

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -254,6 +254,7 @@ export default defineNuxtConfig({
         'frame-src': isDevelopment
           ? ['*']
           : [
+              '\'self\'',
               'https://auth.magic.link',
               'https://checkout.stripe.com',
               'https://js.stripe.com',


### PR DESCRIPTION
Nuxt Scripts proxies Meta Pixel through /_scripts/p/, so the noscript fallback iframe loads from our own origin and was blocked by frame-src not including 'self'.