### PR TITLE
🐛 Disable Meta Pixel proxy to avoid 431 on long product URLs

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -226,7 +226,9 @@ export default defineNuxtConfig({
       intercom: {
         trigger: { idleTimeout: 3000 },
       },
-      metaPixel: true,
+      metaPixel: {
+        proxy: false,
+      },
       posthog: POSTHOG_PUBLIC_KEY
         ? {
             trigger: 'onNuxtReady',


### PR DESCRIPTION
The metaPixel: true shorthand routes runtime calls through /_scripts/p/<host>/. On product pages with long descriptions and multiple price variants, Meta Pixel's auto-extracted page metadata pushed the URL past Node's 16 KB header limit, causing Cloud Run to reject with HTTP 431. proxy: false sends calls direct to facebook.com; bundle stays on so the script still loads first-party.