### PR TITLE
🔍️ Trim per-product description and drop from JSON-LD videos

### DIFF
--- a/composables/use-structured-data.ts
+++ b/composables/use-structured-data.ts
@@ -414,7 +414,6 @@ export function useStructuredData(
             return {
               '@type': 'VideoObject',
               'name': name,
-              'description': description,
               'contentUrl': url,
               ...(youtubeId && { embedUrl: `https://www.youtube.com/embed/${youtubeId}` }),
               'thumbnailUrl': youtubeId ? getYouTubeThumbnailUrl(youtubeId) : coverImage,
@@ -487,7 +486,6 @@ export function useStructuredData(
           return {
             '@type': 'VideoObject',
             'name': name,
-            'description': description,
             'contentUrl': url,
             ...(youtubeId && { embedUrl: `https://www.youtube.com/embed/${youtubeId}` }),
             'thumbnailUrl': youtubeId ? getYouTubeThumbnailUrl(youtubeId) : coverImage,

--- a/pages/store/[nftClassId]/index.vue
+++ b/pages/store/[nftClassId]/index.vue
@@ -1114,10 +1114,7 @@ const ogTitle = computed(() => {
   const titleWithSubtitle = subtitle ? `${title}${$t('text_separator_colon')}${subtitle}` : title
   return author ? `${titleWithSubtitle} - ${author}${ebookSuffix}` : `${titleWithSubtitle}${ebookSuffix}`
 })
-const ogDescription = computed(() => {
-  const description = bookInfo.description.value || ''
-  return description.length > 200 ? `${description.substring(0, 197)}...` : description
-})
+const ogDescription = computed(() => truncateText(bookInfo.description.value, 200))
 const canonicalURL = computed(() => {
   return `${baseURL}${route.path}`
 })

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -88,3 +88,10 @@ export function validateEmail(email: string): boolean {
 export function getStoreQueryRoute(title: string) {
   return { name: 'store', query: { q: title } }
 }
+
+export function truncateText(text: string, maxLength: number): string {
+  if (maxLength <= 0) return ''
+  if (text.length <= maxLength) return text
+  if (maxLength === 1) return '…'
+  return `${text.slice(0, maxLength - 1).replace(/\s+\S*$/, '')}…`
+}


### PR DESCRIPTION
Per-product Book/Product entries now cap og description at 200 chars; the parent ProductGroup retains the full canonical copy. VideoObject nodes no longer duplicate the book description. Shares a new truncateText util with og:description.