### PR TITLE
🐛 Fix indexer over-paginating past end of results

### DIFF
--- a/shared/utils/indexer.ts
+++ b/shared/utils/indexer.ts
@@ -132,24 +132,11 @@ export async function fetchNFTClassesByMetadata(
     const queryOptions = getIndexerQueryOptions(options)
     const actualLimit = parseInt(queryOptions['pagination.limit'] || '30')
 
-    let combinedNextKey: number | undefined
-    if (authorNameResult.pagination.count < actualLimit && authorResult.pagination.count < actualLimit) {
-      combinedNextKey = undefined
-    }
-    else {
-      const authorNameNextKey = authorNameResult.pagination.count === actualLimit ? authorNameResult.pagination.next_key : undefined
-      const authorNextKey = authorResult.pagination.count === actualLimit ? authorResult.pagination.next_key : undefined
-
-      if (authorNameNextKey !== undefined && authorNextKey !== undefined) {
-        combinedNextKey = Math.min(authorNameNextKey, authorNextKey)
-      }
-      else if (authorNameNextKey !== undefined) {
-        combinedNextKey = authorNameNextKey
-      }
-      else if (authorNextKey !== undefined) {
-        combinedNextKey = authorNextKey
-      }
-    }
+    const authorNameNextKey = authorNameResult.data.length >= actualLimit ? authorNameResult.pagination.next_key : undefined
+    const authorNextKey = authorResult.data.length >= actualLimit ? authorResult.pagination.next_key : undefined
+    const combinedNextKey = authorNameNextKey !== undefined && authorNextKey !== undefined
+      ? Math.min(authorNameNextKey, authorNextKey)
+      : authorNameNextKey ?? authorNextKey
 
     return {
       data: combinedData,

--- a/stores/bookshelf.ts
+++ b/stores/bookshelf.ts
@@ -125,7 +125,7 @@ export const useBookshelfStore = defineStore('bookshelf', () => {
       await bookSettingsStore.fetchBatchSettings(Array.from(progressFetchNFTClassIds), { force: isRefresh })
       if (isStale()) return
 
-      nextKey.value = res.pagination.count < limit ? undefined : res.pagination.next_key
+      nextKey.value = res.data.length < limit ? undefined : res.pagination.next_key
       persistedWalletAddress.value = normalizedWalletAddress ?? null
       lastError.value = null
     }


### PR DESCRIPTION
`pagination.count` is the cumulative total across the result set, not the page size, so `count < limit` becomes permanently false once enough rows have been seen and never signals the final page. Switch the exhaustion check to `data.length < limit` so callers stop refetching at the true end.