### PR TITLE
🚀 Reserve aspect ratio and render single orientation on /member

### DIFF
--- a/components/PricingPageCampaignMedia.vue
+++ b/components/PricingPageCampaignMedia.vue
@@ -3,6 +3,7 @@
     v-if="campaignContent?.isVideo"
     :src="videoSrc"
     :poster="imageSrc"
+    :class="aspectClass"
     :controls="false"
     preload="metadata"
     playsinline
@@ -13,6 +14,7 @@
   <img
     v-else-if="campaignContent?.isImage"
     class="object-contain object-center"
+    :class="aspectClass"
     :src="imageSrc"
     :alt="campaignContent?.title || ''"
   >
@@ -39,4 +41,6 @@ const filepath = computed(() => {
 })
 const videoSrc = computed(() => `${filepath.value}.mp4`)
 const imageSrc = computed(() => `${filepath.value}.jpg`)
+
+const aspectClass = computed(() => props.orientation === 'portrait' ? 'aspect-[9/16]' : 'aspect-video')
 </script>

--- a/components/PricingPageContent.vue
+++ b/components/PricingPageContent.vue
@@ -61,18 +61,24 @@
         v-else-if="campaignContent"
         class="relative max-laptop:shrink-0 w-full min-h-max bg-theme-black"
       >
-        <div class="max-laptop:hidden absolute inset-0 overflow-hidden">
+        <ClientOnly>
+          <div
+            v-if="isDesktopScreen"
+            class="absolute inset-0 overflow-hidden"
+          >
+            <PricingPageCampaignMedia
+              class="absolute inset-x-0 w-full top-1/2 -translate-y-1/2"
+              :campaign-id="campaignContent.id"
+              orientation="portrait"
+            />
+          </div>
           <PricingPageCampaignMedia
-            class="absolute inset-x-0 w-full top-1/2 -translate-y-1/2"
+            v-else
+            class="w-full"
             :campaign-id="campaignContent.id"
-            orientation="portrait"
+            orientation="landscape"
           />
-        </div>
-        <PricingPageCampaignMedia
-          class="laptop:hidden w-full"
-          :campaign-id="campaignContent.id"
-          orientation="landscape"
-        />
+        </ClientOnly>
       </aside>
       <aside
         v-else


### PR DESCRIPTION
- Apply aspect-video / aspect-[9/16] to the campaign <video>/<img> so layout reserves space before the poster decodes (lab CLS 0.29 → 0.02)
- Gate orientation render on useDesktopScreen instead of CSS hide, so only the matching orientation's mp4 + jpg are fetched per viewport
- Wrap in <ClientOnly> to avoid hydration mismatch from useDesktopScreen=false during SSR