### PR TITLE
🚀 Slow carousel autoplay so cover stays as LCP element

### DIFF
--- a/components/BookCoverCarousel.vue
+++ b/components/BookCoverCarousel.vue
@@ -10,7 +10,7 @@
       loop
       fade
       auto-height
-      :autoplay="{ delay: 3000, stopOnInteraction: true }"
+      :autoplay="{ delay: 5000, stopOnInteraction: true }"
       :ui="{
         item: 'basis-full aspect-2/3 cursor-pointer',
         dots: 'relative bottom-0 gap-2 mt-2',


### PR DESCRIPTION
3s rotation was advancing past the cover before browsers locked in LCP, letting a downstream YouTube thumbnail become the LCP target and pushing render delay to ~3.3s on /store product pages.