### PR TITLE
🚀 Cut wasted /store fetches and prioritize first-row covers

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -138,18 +138,18 @@ useHead({
     },
     ...(likeCoinAPIEndpoint
       ? [
-          { rel: 'preconnect', href: likeCoinAPIEndpoint },
-          { rel: 'preconnect', href: likeCoinAPIEndpoint, crossorigin: '' },
+          { rel: 'preconnect', href: likeCoinAPIEndpoint, key: 'preconnect-like-api' },
+          { rel: 'preconnect', href: likeCoinAPIEndpoint, crossorigin: '', key: 'preconnect-like-api-crossorigin' },
         ]
       : []),
     ...(likeCoinStaticEndpoint
-      ? [{ rel: 'preconnect', href: likeCoinStaticEndpoint }]
+      ? [{ rel: 'preconnect', href: likeCoinStaticEndpoint, key: 'preconnect-like-static' }]
       : []),
     ...(posthogHost
-      ? [{ rel: 'preconnect', href: posthogHost, crossorigin: '' }]
+      ? [{ rel: 'preconnect', href: posthogHost, crossorigin: '', key: 'preconnect-posthog' }]
       : []),
     ...(!isApp.value
-      ? [{ rel: 'preconnect', href: 'https://js.stripe.com', crossorigin: '' }]
+      ? [{ rel: 'preconnect', href: 'https://js.stripe.com', crossorigin: '', key: 'preconnect-stripe' }]
       : []),
     ...(i18nHead.value.link || []),
   ],

--- a/components/BookCover.vue
+++ b/components/BookCover.vue
@@ -34,7 +34,7 @@
           '-translate-x-[10px]',
           'pointer-events-none',
         ]"
-        :style="{ backgroundImage: hasLoaded && !hasError ? `url(${props.src})` : '' }"
+        :style="{ backgroundImage: props.src && !hasError ? `url(${props.src})` : '' }"
       />
       <img
         ref="imgElement"

--- a/components/BookstoreItem.vue
+++ b/components/BookstoreItem.vue
@@ -8,6 +8,7 @@
       :to="productPageRoute"
       :alt="bookName"
       :lazy="props.lazy"
+      :priority="props.priority"
       :has-shadow="true"
       @click="onBookCoverClick"
     />
@@ -79,6 +80,10 @@ const props = defineProps({
     default: 0,
   },
   lazy: {
+    type: Boolean,
+    default: false,
+  },
+  priority: {
     type: Boolean,
     default: false,
   },

--- a/pages/store/[nftClassId]/index.vue
+++ b/pages/store/[nftClassId]/index.vue
@@ -1138,7 +1138,7 @@ useHead(() => ({
   ],
   link: [
     { rel: 'canonical', href: canonicalURL.value },
-    { rel: 'preload', href: bookCoverSrc.value, as: 'image' },
+    { rel: 'preload', href: bookCoverSrc.value, as: 'image', key: 'preload-book-cover' },
   ],
   script: structuredData.value
     ? [

--- a/pages/store/index.vue
+++ b/pages/store/index.vue
@@ -343,6 +343,7 @@
           :price="item.minPrice"
           :like-rank="item.likeRank ?? 0"
           :lazy="index >= columnMax"
+          :priority="index < columnMax"
           :ll-medium="llMedium"
           ll-source="bookstore"
         />
@@ -804,6 +805,8 @@ useHead(() => {
       rel: 'preload',
       href: '/api/store/tags',
       as: 'fetch' as const,
+      crossorigin: 'anonymous' as const,
+      key: 'preload-store-tags',
     },
     ...(isStakingTagId.value
       ? [{
@@ -811,11 +814,14 @@ useHead(() => {
           href: `${runtimeConfig.public.likeCoinEVMChainCollectiveAPIEndpoint}/book-nfts?pagination.limit=100&sort_by=${mapTagIdToAPIStakingSortValue(tagId.value)}&sort_order=desc`,
           as: 'fetch' as const,
           crossorigin: 'anonymous' as const,
+          key: 'preload-staking-books',
         }]
       : [{
           rel: 'preload',
           href: `/api/store/products?tag=${tagId.value}&limit=100&ts=${getTimestampRoundedToMinute()}`,
           as: 'fetch' as const,
+          crossorigin: 'anonymous' as const,
+          key: 'preload-store-products',
         }]),
   ]
 

--- a/utils/api.ts
+++ b/utils/api.ts
@@ -14,8 +14,6 @@ export function fetchBookstoreCMSProductsByTagId(tagId: string, {
       limit,
       ts,
     },
-    credentials: 'include',
-    mode: 'no-cors',
   })
 }
 
@@ -35,8 +33,6 @@ export function fetchBookstoreCMSPublicationsBySearchTerm(searchTerm: string, {
       limit,
       ts,
     },
-    credentials: 'include',
-    mode: 'no-cors',
   })
 }
 
@@ -56,8 +52,6 @@ export function fetchBookstoreCMSPublicationsByGenre(genre: string, {
       limit,
       ts,
     },
-    credentials: 'include',
-    mode: 'no-cors',
   })
 }
 
@@ -76,16 +70,11 @@ export function fetchBookstoreCMSTagsForAll({
       limit,
       ts,
     },
-    credentials: 'include',
-    mode: 'no-cors',
   })
 }
 
 export function fetchBookstoreCMSTagById(tagId: string) {
-  return $fetch<BookstoreCMSTag>(`/api/store/tags/${tagId}`, {
-    credentials: 'include',
-    mode: 'no-cors',
-  })
+  return $fetch<BookstoreCMSTag>(`/api/store/tags/${tagId}`)
 }
 
 export function getEncryptedArweaveLinkAPIEndpoint() {


### PR DESCRIPTION
Drop credentials/no-cors from same-origin store $fetch calls so the existing useHead preloads finally match — eliminates duplicate /api/store/tags and book-nfts requests on every page load. Add stable key: identifiers to preconnect/preload entries so unhead deduplicates SSR-rendered and hydration-injected links instead of stacking them. Forward fetchpriority="high" to the first visible row of book covers and let BookCover render the blurred shadow as soon as src is set, removing one render cycle from LCP paint.