### PR TITLE
📈 Persist UTM attribution as PostHog super-properties

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -222,7 +222,10 @@ export default defineNuxtConfig({
   scripts: {
     privacy: false,
     registry: {
-      googleAnalytics: true,
+      googleAnalytics: {
+        bundle: false,
+        proxy: false,
+      },
       intercom: {
         trigger: { idleTimeout: 3000 },
       },


### PR DESCRIPTION
Anonymous visitors lose UTMs by the time they identify (Magic Link redirect strips the URL), so PostHog person profiles never get $initial_utm_*. Register UTMs (with the same srsltid/ll_* normalization useAnalytics already applies) as super-properties on PostHog load and pass them as $set/$set_once on identify, so the attribution survives the anon → identified transition under person_profiles: 'identified_only'.

Also call posthog.reset() on logout instead of identify(undefined), to properly drop the anon↔user merge.