### PR TITLE
🐛 Disable GA proxy to avoid 403 on regional Google domains

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -222,7 +222,10 @@ export default defineNuxtConfig({
   scripts: {
     privacy: false,
     registry: {
-      googleAnalytics: true,
+      googleAnalytics: {
+        bundle: false,
+        proxy: false,
+      },
       intercom: {
         trigger: { idleTimeout: 3000 },
       },


### PR DESCRIPTION
The googleAnalytics: true shorthand routes runtime calls through /_scripts/p/<host>/, but the registry's allowlist only covers www.google.com — not regional cctlds like google.com.tw used by gtag.js' ga-audiences remarketing beacon. Calls from non-US visitors were rejected with 403 "Domain not allowed". proxy: false sends GA direct to Google; bundle: false stops shipping a copy of gtag.js first-party since the runtime fetches no longer benefit from it.