### PR TITLE
[TAS-5619] 🚸 Polish reader search highlighting, keyboard, and viewport

### DIFF
--- a/components/BottomSlideover.vue
+++ b/components/BottomSlideover.vue
@@ -18,7 +18,7 @@
     <template #body>
       <div
         ref="bodyWrapperElement"
-        class=" max-h-[40vh] overflow-y-auto pb-2"
+        :class="['overflow-y-auto pb-2', props.bodyClass]"
       >
         <slot name="body" />
       </div>
@@ -47,8 +47,10 @@ const props = withDefaults(defineProps<{
   title?: string
   isDisabled?: boolean
   showCloseButton?: boolean
+  bodyClass?: string
 }>(), {
   showCloseButton: true,
+  bodyClass: 'max-h-[40vh]',
 })
 
 const open = defineModel<boolean>('open')

--- a/components/ReaderSearch.vue
+++ b/components/ReaderSearch.vue
@@ -1,7 +1,22 @@
 <template>
+  <!--
+    iOS Safari only opens the soft keyboard if .focus() runs synchronously
+    inside a user gesture; the slideover body is unmounted until open, so we
+    focus this hidden keeper on tap. text-base (16px) prevents the iOS
+    focus-zoom.
+  -->
+  <input
+    ref="mobileFocusKeeper"
+    class="sr-only laptop:hidden text-base"
+    type="search"
+    inputmode="search"
+    :aria-label="$t('reader_search_input_placeholder')"
+    tabindex="-1"
+  >
   <BottomSlideover
     v-model:open="isMobileOpen"
     :title="$t('reader_search_title')"
+    body-class="max-h-[75vh]"
     @update:open="handleOpenChange"
   >
     <UButton
@@ -9,6 +24,7 @@
       icon="i-material-symbols-search-rounded"
       variant="ghost"
       :aria-label="$t('reader_search_button')"
+      @click="handleMobileTriggerClick"
     />
     <template #body>
       <div class="flex flex-col gap-3 px-4 py-3">
@@ -38,15 +54,13 @@
           </template>
         </UInput>
       </div>
-      <div class="max-h-[40vh] overflow-y-auto">
-        <ReaderSearchResultList
-          :is-searching="isSearching"
-          :results="results"
-          :has-searched="hasSearched"
-          :query="submittedQuery"
-          @select="handleSelect"
-        />
-      </div>
+      <ReaderSearchResultList
+        :is-searching="isSearching"
+        :results="results"
+        :has-searched="hasSearched"
+        :query="submittedQuery"
+        @select="handleSelect"
+      />
     </template>
   </BottomSlideover>
 
@@ -146,6 +160,12 @@ const hasSearched = ref(false)
 
 const mobileInput = useTemplateRef<{ inputRef?: Ref<HTMLInputElement | null> } | null>('mobileInput')
 const desktopInput = useTemplateRef<{ inputRef?: Ref<HTMLInputElement | null> } | null>('desktopInput')
+const mobileFocusKeeper = useTemplateRef<HTMLInputElement | null>('mobileFocusKeeper')
+
+function handleMobileTriggerClick() {
+  if (isOpen.value) return
+  mobileFocusKeeper.value?.focus({ preventScroll: true })
+}
 
 let activeSearchController: AbortController | null = null
 

--- a/components/ReaderSearchResultList.vue
+++ b/components/ReaderSearchResultList.vue
@@ -72,33 +72,45 @@ const emit = defineEmits<{
 
 const { t: $t } = useI18n()
 
-function splitExcerpt(excerpt: string, trimmedQuery: string): ExcerptSegment[] {
-  if (!trimmedQuery) return [{ text: excerpt, isMatch: false }]
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+// `section.find()` (EPUB) and `getTextContent()` (PDF) normalize whitespace in
+// ways that a literal indexOf can miss.
+function buildHighlightRegex(trimmedQuery: string): RegExp | null {
+  const tokens = trimmedQuery.split(/\s+/).filter(Boolean).map(escapeRegExp)
+  if (!tokens.length) return null
+  return new RegExp(tokens.join('\\s+'), 'gi')
+}
+
+function splitExcerpt(excerpt: string, regex: RegExp | null): ExcerptSegment[] {
+  if (!regex) return [{ text: excerpt, isMatch: false }]
 
   const segments: ExcerptSegment[] = []
-  const haystack = excerpt.toLowerCase()
-  const needle = trimmedQuery.toLowerCase()
   let cursor = 0
-  while (cursor < excerpt.length) {
-    const found = haystack.indexOf(needle, cursor)
-    if (found === -1) {
-      segments.push({ text: excerpt.slice(cursor), isMatch: false })
-      break
+  for (const match of excerpt.matchAll(regex)) {
+    const matchText = match[0]
+    if (!matchText) continue
+    const start = match.index ?? 0
+    if (start > cursor) {
+      segments.push({ text: excerpt.slice(cursor, start), isMatch: false })
     }
-    if (found > cursor) {
-      segments.push({ text: excerpt.slice(cursor, found), isMatch: false })
-    }
-    segments.push({ text: excerpt.slice(found, found + trimmedQuery.length), isMatch: true })
-    cursor = found + trimmedQuery.length
+    segments.push({ text: matchText, isMatch: true })
+    cursor = start + matchText.length
+  }
+  if (cursor < excerpt.length) {
+    segments.push({ text: excerpt.slice(cursor), isMatch: false })
   }
   return segments
 }
 
 const segmentedResults = computed(() => {
   const trimmedQuery = props.query.trim()
+  const regex = trimmedQuery ? buildHighlightRegex(trimmedQuery) : null
   return props.results.map(result => ({
     ...result,
-    segments: splitExcerpt(result.excerpt, trimmedQuery),
+    segments: splitExcerpt(result.excerpt, regex),
   }))
 })
 


### PR DESCRIPTION
- Match highlighting case-insensitively with whitespace tolerance so EPUB/PDF results stay highlighted even when the engine matched across collapsed whitespace
- Focus a hidden keeper input synchronously on mobile tap so iOS keeps the soft keyboard up between trigger and slideover-mounted input
- Raise mobile slideover body cap to 75vh and drop the redundant inner 40vh wrapper so results use more screen real estate