### PR TITLE
🐛 Reload on chunk load errors to recover stale deploys

### DIFF
--- a/plugins/chunk-error.client.ts
+++ b/plugins/chunk-error.client.ts
@@ -1,0 +1,44 @@
+import { useSessionStorage } from '@vueuse/core'
+
+const CHUNK_ERROR_PATTERNS = [
+  'Failed to fetch dynamically imported module',
+  'error loading dynamically imported module',
+  'Importing a module script failed',
+]
+
+const RELOAD_COOLDOWN_MS = 10_000
+const RELOAD_FLUSH_DELAY_MS = 200
+
+export default defineNuxtPlugin((nuxtApp) => {
+  const lastReloadAt = useSessionStorage<number>('chunk_error_reload', 0)
+  let hasHandled = false
+
+  const handle = (error: unknown) => {
+    const message = getErrorMessage(error)
+    if (!CHUNK_ERROR_PATTERNS.some(pattern => message.includes(pattern))) return
+    if (hasHandled) return
+    hasHandled = true
+
+    const isLooping = Date.now() - lastReloadAt.value < RELOAD_COOLDOWN_MS
+
+    useLogEvent('chunk_error', {
+      error_message: message,
+      url: window.location.href,
+      reloaded: !isLooping,
+    })
+
+    if (isLooping) {
+      console.error('[chunk-error] reload already attempted recently, surfacing error', error)
+      return
+    }
+
+    lastReloadAt.value = Date.now()
+    // Give PostHog/GA a window to flush the event before navigating away
+    setTimeout(() => {
+      window.location.reload()
+    }, RELOAD_FLUSH_DELAY_MS)
+  }
+
+  nuxtApp.hook('app:chunkError', ({ error }) => handle(error))
+  nuxtApp.hook('vue:error', error => handle(error))
+})


### PR DESCRIPTION
Adds a client plugin that listens on app:chunkError and vue:error, detects dynamic-import failures across browser variants, and triggers a hard reload so users on a stale tab pick up the new deploy instead of seeing "importing a script module failed". Includes a sessionStorage cooldown to prevent reload loops on real server errors and a same-tick dedup guard so the two hooks don't double-emit the chunk_error event.