### PR TITLE
[TAS-5708] 🐛 Confine TTS cfi fallback to the current section

### DIFF
--- a/composables/use-tts-player-modal.ts
+++ b/composables/use-tts-player-modal.ts
@@ -100,12 +100,23 @@ export function useTTSPlayerModal(options: TTSPlayerOptions) {
         segmentIndex = Math.max(segmentIndex, 0)
       }
       if (cfi) {
-        const cfiIndex = ttsSegments.value
-          .slice(segmentIndex)
-          .findIndex(segment => segment.cfi && epubCFI.compare(segment.cfi, cfi) >= 0)
-        if (cfiIndex >= 1) {
+        // Constrain the cfi search to the current section. Without this,
+        // when the user's section has few or no matching segments, the
+        // search would silently resolve into the next chapter.
+        const sectionToStayIn = ttsSegments.value[segmentIndex]?.sectionIndex
+        let foundIndex = -1
+        for (let i = segmentIndex; i < ttsSegments.value.length; i++) {
+          const segment = ttsSegments.value[i]
+          if (!segment) continue
+          if (sectionToStayIn !== undefined && segment.sectionIndex > sectionToStayIn) break
+          if (segment.cfi && epubCFI.compare(segment.cfi, cfi) >= 0) {
+            foundIndex = i
+            break
+          }
+        }
+        if (foundIndex > segmentIndex) {
           // Retrieve the previous segment for better UX, as the segment might span multiple pages
-          segmentIndex += cfiIndex - 1
+          segmentIndex = foundIndex - 1
         }
       }
       startIndex.value = segmentIndex


### PR DESCRIPTION
Following d01931d0, the persisted ttsIndex stale check correctly falls through to a cfi-based lookup, but that lookup was unbounded across sections. When the user's section had few or no matching segments (footnote-only pages, image-only chapters, or paging past all segments in a section), the search silently resolved into the next chapter — surfacing as a "jump to next chapter" when re-entering TTS after moving in reader mode.

Constrain the cfi search to the section anchored at segmentIndex so the resolved start can no longer escape into the next chapter, and drop the slice allocation while we're at it.