### PR TITLE
🐛 Show login prompt for expired sessions in TTS player

### DIFF
--- a/components/TTSPlayerModal.vue
+++ b/components/TTSPlayerModal.vue
@@ -226,7 +226,8 @@ import { TTS_ERROR_NOT_ALLOWED } from '~/composables/use-text-to-speech'
 import { encodeAffiliateVoiceId } from '~/shared/utils/tts-sig'
 import { estimateTTSMinutes } from '~/shared/utils/tts-trial'
 
-const { user, loggedIn: hasLoggedIn } = useUserSession()
+const { user, loggedIn: hasLoggedIn, fetch: refreshSession } = useUserSession()
+const accountStore = useAccountStore()
 const subscription = useSubscriptionModal()
 const { errorModal, handleError } = useErrorHandler()
 
@@ -347,7 +348,7 @@ const {
   bookLanguage: props.bookLanguage,
   customVoice,
   affiliateVoices,
-  onError: (error: string | Event | MediaError) => {
+  onError: async (error: string | Event | MediaError) => {
     // Autoplay was blocked by the browser because the modal auto-started
     // without a user gesture (e.g. reloading the reader with ?tts=1). The
     // composable has already reset playback state — leave the modal open so
@@ -355,21 +356,30 @@ const {
     if (error === TTS_ERROR_NOT_ALLOWED) {
       return
     }
-    if (
-      !user.value?.isLikerPlus
-      && (
-        (
-          typeof error === 'string'
-          && error === 'NotSupportedError'
-        )
-        || (
-          error instanceof MediaError
-          && error.code === MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED
-        )
-      )
-    ) {
-      handleTrialExhausted('server_402')
-      return
+    const isAuthLikeError = (
+      typeof error === 'string' && error === 'NotSupportedError'
+    ) || (
+      error instanceof MediaError && error.code === MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED
+    )
+    if (isAuthLikeError) {
+      // <audio> collapses HTTP 401 / 402 / 403 into MEDIA_ERR_SRC_NOT_SUPPORTED,
+      // so a stale cached `user` would misclassify a logged-out cookie state
+      // as "non-Plus" and wrongly trigger the upsell. Refresh first.
+      try {
+        await refreshSession()
+      }
+      catch {
+        // Tolerate refresh failure — fall through with cached state.
+      }
+      if (!hasLoggedIn.value) {
+        handleSessionExpired()
+        return
+      }
+      if (!user.value?.isLikerPlus) {
+        handleTrialExhausted('server_402')
+        return
+      }
+      // Plus user → real media error, fall through.
     }
     if (error instanceof MediaError) {
       handleError(new Error(`MediaError ${formatTTSError(error)}`))
@@ -405,6 +415,25 @@ function handleTrialExhausted(source: 'server_402' | 'client_gate') {
     utmCampaign: props.nftClassId,
     utmMedium: 'tts',
     redirectRoute: buildSubscribeRedirectRoute(),
+  })
+}
+
+function handleSessionExpired() {
+  stopTextToSpeech()
+  useLogEvent('tts_session_expired', buildTTSEventPayload())
+  errorModal.open({
+    level: 'warning',
+    title: $t('tts_session_expired_title'),
+    description: $t('tts_session_expired_description'),
+    actions: [
+      {
+        label: $t('login_button'),
+        color: 'primary' as const,
+        onClick: () => {
+          accountStore.login()
+        },
+      },
+    ],
   })
 }
 

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -872,6 +872,8 @@
   "tts_sample_mandarin_description": "Read by Aurora",
   "tts_samples_section_footer": "Subscribe to Plus and unlock more voices to enjoy.",
   "tts_samples_section_title": "Try Text-to-Speech",
+  "tts_session_expired_description": "Please log in again to continue listening.",
+  "tts_session_expired_title": "Your session has expired",
   "tts_trial_chip_exhausted_label": "Free trial used. Upgrade now!",
   "tts_trial_chip_progress_label": "{minutes} min left in free trial",
   "tts_trial_chip_upgrade_cta": "Upgrade to Plus for unlimited listening and custom voices",

--- a/i18n/locales/zh-Hant.json
+++ b/i18n/locales/zh-Hant.json
@@ -872,6 +872,8 @@
   "tts_sample_mandarin_description": "由 Aurora 讀出",
   "tts_samples_section_footer": "訂閱 Plus 會員解鎖更多聲音，隨心體驗。",
   "tts_samples_section_title": "體驗朗讀",
+  "tts_session_expired_description": "請重新登入以繼續收聽。",
+  "tts_session_expired_title": "登入時段已過期",
   "tts_trial_chip_exhausted_label": "試用時數已用完，立即升級！",
   "tts_trial_chip_progress_label": "試用朗讀剩餘 {minutes} 分鐘",
   "tts_trial_chip_upgrade_cta": "升級 Plus 解鎖無限朗讀與自訂聲優",


### PR DESCRIPTION
The <audio> element collapses HTTP 401 / 402 / 403 into a single MEDIA_ERR_SRC_NOT_SUPPORTED, so the prior onError branched solely on cached !isLikerPlus — surfacing either a raw MediaError modal or the Plus upsell when the real cause was a logged-out session. Refresh the session on auth-shaped errors and route logged-out users to a login prompt, non-Plus to the existing upsell, and Plus through to the raw error.