### PR TITLE
🐛 Hide Stripe Connect on /account in-app

### DIFF
--- a/pages/account/index.vue
+++ b/pages/account/index.vue
@@ -461,7 +461,7 @@
       />
 
       <UCard
-        v-if="hasLoggedIn"
+        v-if="hasLoggedIn && !isApp"
         :ui="{ body: '!p-0 divide-y-1 divide-(--ui-border)' }"
       >
         <AccountSettingsItem
@@ -788,6 +788,7 @@ watch(() => user.value?.evmWallet, () => {
 })
 
 async function loadStripeConnectStatus() {
+  if (isApp.value) return
   if (!user.value?.evmWallet) return
   try {
     stripeConnectStatus.value = await likeCoinSessionAPI.fetchStripeConnectStatus({
@@ -800,6 +801,7 @@ async function loadStripeConnectStatus() {
 }
 
 async function refreshStripeConnectStatus() {
+  if (isApp.value) return
   try {
     await likeCoinSessionAPI.refreshStripeConnectStatus()
   }


### PR DESCRIPTION
Onboarding and management open via external redirects that don't survive the in-app webview, so hide the panel and skip the status fetch when running in-app.