### PR TITLE
🔥 Drop unused description field from session

### DIFF
--- a/server/api/account/refresh.post.ts
+++ b/server/api/account/refresh.post.ts
@@ -30,7 +30,6 @@ export default defineEventHandler(async (event) => {
       ...session.user,
       likerId: userInfoRes.user,
       displayName: userInfoRes.displayName,
-      description: userInfoRes.description,
       avatar: userInfoRes.avatar,
       isLikerPlus: userInfoRes.isLikerPlus || false,
       isExpiredLikerPlus: userInfoRes.isExpiredLikerPlus || false,

--- a/server/api/login.post.ts
+++ b/server/api/login.post.ts
@@ -64,7 +64,6 @@ export default defineEventHandler(async (event) => {
     intercomToken,
     likerId: userInfoRes.user,
     displayName: userInfoRes.displayName,
-    description: userInfoRes.description,
     avatar: userInfoRes.avatar,
     email: body.email || userInfoRes.email,
     loginMethod: body.loginMethod,

--- a/server/api/register.post.ts
+++ b/server/api/register.post.ts
@@ -64,7 +64,6 @@ export default defineEventHandler(async (event) => {
     evmWallet: body.walletAddress,
     likerId: userInfoRes.user,
     displayName: userInfoRes.displayName,
-    description: userInfoRes.description,
     avatar: userInfoRes.avatar,
     email: body.email,
     loginMethod: body.loginMethod,

--- a/types/nuxt-auth-utils.d.ts
+++ b/types/nuxt-auth-utils.d.ts
@@ -7,7 +7,6 @@ declare module '#auth-utils' {
     intercomToken?: string
     likerId?: string
     displayName?: string
-    description?: string
     avatar?: string
     email?: string
     loginMethod?: string


### PR DESCRIPTION
The user description was written into the auth cookie on login, register, and refresh, but never read anywhere in the app. Removing it shrinks the iron-sealed session cookie sent on every request.