### PR TITLE
[TAS-5901] 🏗️ Persist session tokens to Firestore subcollection

### DIFF
--- a/server/api/account/refresh.post.ts
+++ b/server/api/account/refresh.post.ts
@@ -41,10 +41,20 @@ export default defineEventHandler(async (event) => {
       // sessions that already have one.
       ttsKey: session.user.ttsKey ?? generateTTSKey(),
     },
+    secure: { token: session.user.token },
   })
 
   const userDocRef = getUserCollection().doc(walletAddress)
-  await userDocRef.set({
-    accessTimestamp: FieldValue.serverTimestamp(),
-  }, { merge: true })
+  await Promise.all([
+    userDocRef.set({
+      accessTimestamp: FieldValue.serverTimestamp(),
+    }, { merge: true }),
+    session.user.evmWallet && session.user.token && session.user.jwtId
+      ? saveSessionTokens(session.user.evmWallet, session.user.jwtId, {
+          token: session.user.token,
+          intercomToken: session.user.intercomToken,
+          loginMethod: session.user.loginMethod,
+        })
+      : Promise.resolve(),
+  ])
 })

--- a/server/api/login.post.ts
+++ b/server/api/login.post.ts
@@ -74,14 +74,26 @@ export default defineEventHandler(async (event) => {
     plusAffiliateFrom: userInfoRes.plusAffiliateFrom,
     ttsKey: generateTTSKey(),
   }
-  await setUserSession(event, { user: userInfo })
+  await setUserSession(event, {
+    user: userInfo,
+    secure: { token },
+  })
 
   const userDocRef = getUserCollection().doc(body.walletAddress)
-  await userDocRef.set({
-    loginTimestamp: FieldValue.serverTimestamp(),
-    accessTimestamp: FieldValue.serverTimestamp(),
-    loginMethod: body.loginMethod,
-  }, { merge: true })
+  await Promise.all([
+    userDocRef.set({
+      loginTimestamp: FieldValue.serverTimestamp(),
+      accessTimestamp: FieldValue.serverTimestamp(),
+      loginMethod: body.loginMethod,
+    }, { merge: true }),
+    token && jwtId
+      ? saveSessionTokens(body.walletAddress, jwtId, {
+          token,
+          intercomToken,
+          loginMethod: body.loginMethod,
+        })
+      : Promise.resolve(),
+  ])
 
   publishEvent(event, 'UserLogin', {
     evmWallet: body.walletAddress,

--- a/server/utils/session-tokens.ts
+++ b/server/utils/session-tokens.ts
@@ -1,0 +1,56 @@
+import { FieldValue, Timestamp } from 'firebase-admin/firestore'
+import { jwtDecode } from 'jwt-decode'
+
+const SESSIONS_SUBCOLLECTION = 'sessions'
+
+const FALLBACK_SESSION_LIFETIME_MS = 30 * 24 * 60 * 60 * 1000
+
+const FIRESTORE_ALREADY_EXISTS_CODE = 6
+
+export interface SessionTokenDoc {
+  token: string
+  intercomToken?: string
+  loginMethod?: string
+  createdAt: Timestamp
+  expiresAt: Timestamp
+}
+
+function getSessionDocRef(wallet: string, jwtId: string) {
+  return getUserCollection().doc(wallet).collection(SESSIONS_SUBCOLLECTION).doc(jwtId)
+}
+
+function getJWTExpiry(token: string): Date {
+  try {
+    const { exp } = jwtDecode<{ exp?: number }>(token)
+    if (typeof exp === 'number') return new Date(exp * 1000)
+  }
+  catch { /* ignore */ }
+  return new Date(Date.now() + FALLBACK_SESSION_LIFETIME_MS)
+}
+
+export async function saveSessionTokens(
+  wallet: string,
+  jwtId: string,
+  data: {
+    token: string
+    intercomToken?: string
+    loginMethod?: string
+  },
+): Promise<void> {
+  const docData: Record<string, unknown> = {
+    token: data.token,
+    createdAt: FieldValue.serverTimestamp(),
+    expiresAt: Timestamp.fromDate(getJWTExpiry(data.token)),
+  }
+  if (data.intercomToken) docData.intercomToken = data.intercomToken
+  if (data.loginMethod) docData.loginMethod = data.loginMethod
+
+  try {
+    await getSessionDocRef(wallet, jwtId).create(docData)
+  }
+  catch (error) {
+    const code = (error as { code?: number | string })?.code
+    if (code === FIRESTORE_ALREADY_EXISTS_CODE || code === 'already-exists') return
+    console.warn('[SessionTokens] Failed to persist session tokens:', error)
+  }
+}

--- a/types/nuxt-auth-utils.d.ts
+++ b/types/nuxt-auth-utils.d.ts
@@ -17,6 +17,9 @@ declare module '#auth-utils' {
     ttsKey?: string
     likerPlusSubscriptionStatus?: 'active' | 'past_due' | 'canceled'
   }
+  interface SecureSessionData {
+    token?: string
+  }
 }
 
 export {}


### PR DESCRIPTION
Dual-write the LikeCoin JWT and intercomToken to a per-jwtId doc at book-users/{wallet}/sessions/{jwtId} on login and refresh, alongside the existing cookie session. The Firestore copy is the foundation for moving the JWT out of the cookie in a later step; the cookie write is unchanged for now so legacy and in-flight sessions keep working.

Use create() with ALREADY_EXISTS swallowing so refresh-on-boot doesn't repeatedly rewrite the same immutable doc, and parallelize with the existing user-doc access-timestamp write to keep the boot path latency unchanged.