### PR TITLE
🚸 Rotate Intercom token through session refresh

### DIFF
--- a/server/api/account/refresh.post.ts
+++ b/server/api/account/refresh.post.ts
@@ -25,6 +25,14 @@ export default defineEventHandler(async (event) => {
   }
   if (!userInfoRes) return
 
+  // The upstream /users/profile mints a fresh Intercom Identity Verification
+  // JWT (1d lifetime). Rotate it through the session so the once-per-day
+  // mount-time refresh in app.vue self-heals every active user. Fall back to
+  // the existing token if upstream omits it (e.g. INTERCOM_API_SECRET unset)
+  // rather than nulling out a still-valid one.
+  const intercomToken = userInfoRes.intercomToken ?? session.user.intercomToken
+  const hasIntercomTokenRotated = !!userInfoRes.intercomToken && userInfoRes.intercomToken !== session.user.intercomToken
+
   await setUserSession(event, {
     user: {
       ...session.user,
@@ -36,6 +44,7 @@ export default defineEventHandler(async (event) => {
       likerPlusPeriod: userInfoRes.likerPlusPeriod,
       likerPlusSubscriptionStatus: userInfoRes.likerPlusSubscriptionStatus,
       plusAffiliateFrom: userInfoRes.plusAffiliateFrom,
+      intercomToken,
       // Backfill ttsKey for sessions that pre-date its introduction so they
       // can use the per-user TTS sig path without re-login. Safe no-op for
       // sessions that already have one.
@@ -49,10 +58,10 @@ export default defineEventHandler(async (event) => {
     userDocRef.set({
       accessTimestamp: FieldValue.serverTimestamp(),
     }, { merge: true }),
-    session.user.evmWallet && session.user.token && session.user.jwtId
-      ? saveSessionTokens(session.user.evmWallet, session.user.jwtId, {
+    hasIntercomTokenRotated && session.user.evmWallet && session.user.token && session.user.jwtId
+      ? refreshSessionTokens(session.user.evmWallet, session.user.jwtId, {
           token: session.user.token,
-          intercomToken: session.user.intercomToken,
+          intercomToken,
           loginMethod: session.user.loginMethod,
         })
       : Promise.resolve(),

--- a/server/utils/session-tokens.ts
+++ b/server/utils/session-tokens.ts
@@ -1,11 +1,13 @@
-import { FieldValue, Timestamp } from 'firebase-admin/firestore'
+import { FieldValue, GrpcStatus, Timestamp } from 'firebase-admin/firestore'
 import { jwtDecode } from 'jwt-decode'
 
 const SESSIONS_SUBCOLLECTION = 'sessions'
 
 const FALLBACK_SESSION_LIFETIME_MS = 30 * 24 * 60 * 60 * 1000
 
-const FIRESTORE_ALREADY_EXISTS_CODE = 6
+function getFirestoreErrorCode(error: unknown): number | string | undefined {
+  return (error as { code?: number | string })?.code
+}
 
 export interface SessionTokenDoc {
   token: string
@@ -49,8 +51,32 @@ export async function saveSessionTokens(
     await getSessionDocRef(wallet, jwtId).create(docData)
   }
   catch (error) {
-    const code = (error as { code?: number | string })?.code
-    if (code === FIRESTORE_ALREADY_EXISTS_CODE || code === 'already-exists') return
+    if (getFirestoreErrorCode(error) === GrpcStatus.ALREADY_EXISTS) return
     console.warn('[SessionTokens] Failed to persist session tokens:', error)
   }
+}
+
+export async function refreshSessionTokens(
+  wallet: string,
+  jwtId: string,
+  data: {
+    token: string
+    intercomToken?: string
+    loginMethod?: string
+  },
+): Promise<void> {
+  if (data.intercomToken) {
+    try {
+      await getSessionDocRef(wallet, jwtId).update({ intercomToken: data.intercomToken })
+      return
+    }
+    catch (error) {
+      if (getFirestoreErrorCode(error) !== GrpcStatus.NOT_FOUND) {
+        console.warn('[SessionTokens] Failed to update intercom token:', error)
+        return
+      }
+      // NOT_FOUND: legacy session pre-dates the sessions subcollection. Backfill below.
+    }
+  }
+  await saveSessionTokens(wallet, jwtId, data)
 }

--- a/shared/types/api.d.ts
+++ b/shared/types/api.d.ts
@@ -15,4 +15,5 @@ export interface LikerProfileResponseData extends LikerInfoResponseData {
   email?: string
   likerPlusPeriod?: LikerPlusStatus
   plusAffiliateFrom?: string
+  intercomToken?: string
 }


### PR DESCRIPTION
The Nuxt session lasts 30d but the Intercom Identity Verification JWT only lasts 1d, so the cached token in long-lived sessions expires and breaks the native messenger. Pick up the fresh token upstream now returns from /users/profile and write it through to both the session and the Firestore session-tokens doc, so the once-per-day mount-time refresh self-heals every active user without forcing a re-login.