### PR TITLE
🐛 Close TTS player when paywall hands off to checkout

### DIFF
--- a/components/TTSPlayerModal.vue
+++ b/components/TTSPlayerModal.vue
@@ -229,6 +229,7 @@ import { estimateTTSMinutes } from '~/shared/utils/tts-trial'
 const { user, loggedIn: hasLoggedIn, fetch: refreshSession } = useUserSession()
 const accountStore = useAccountStore()
 const subscription = useSubscriptionModal()
+const { isProcessingSubscription } = subscription
 const { errorModal, handleError } = useErrorHandler()
 
 const { customVoice, hasCustomVoice, fetchCustomVoice } = useCustomVoice()
@@ -441,6 +442,13 @@ const { isTTSPlaying } = useTTSPlayingState()
 watch(isTextToSpeechPlaying, playing => isTTSPlaying.value = playing, { immediate: true })
 onBeforeUnmount(() => {
   isTTSPlaying.value = false
+})
+
+// The route-watch in use-tts-player-modal.ts can race the reader page's
+// unmount and leave this fullscreen modal covering /plus/checkout. Close
+// explicitly when the subscription handoff begins.
+watch(isProcessingSubscription, (isProcessing) => {
+  if (isProcessing) handleModalClose()
 })
 
 interface VisibleParagraph {


### PR DESCRIPTION
The route-path watcher that closes the player on navigation lives in the reader page's setup scope and can race the page unmount, leaving the fullscreen modal covering /plus/checkout. Close it explicitly when the subscription handoff begins so Subscribe drops the player while Skip keeps it visible.