### PR TITLE
🐛 Skip PostHog for events the API server already fires

### DIFF
--- a/composables/use-logger.ts
+++ b/composables/use-logger.ts
@@ -82,6 +82,21 @@ const INTERCOM_EVENT_ALLOWLIST = new Set<string>([
   'deposit_claim_rewards_button_click',
 ])
 
+// Events whose authoritative source is the API server (likecoin-api-public): the server
+// fires them via posthog-node from the Stripe webhook handler. The matching client-side
+// fire to PostHog is suppressed here to avoid duplication, because posthog-js's capture()
+// doesn't accept a custom uuid and the two fires can't dedupe on PostHog's side. GA4 and
+// Meta Pixel still fire from both sides — they dedupe on transaction_id / eventID via
+// CAPI respectively, independent of the PostHog uuid issue. Re-enable the PostHog leg
+// once https://github.com/PostHog/posthog-js/issues/3546 lands and both sides can emit a
+// deterministic uuidv5(`${eventName}:${transaction_id}`, NS).
+const POSTHOG_SERVER_AUTHORITATIVE_EVENTS = new Set<string>([
+  'begin_checkout',
+  'purchase',
+  'start_trial',
+  'subscribe',
+])
+
 export function useLogEvent(eventName: string, eventParams: EventParams = {}) {
   try {
     const { proxy } = useScriptGoogleAnalytics()
@@ -152,6 +167,8 @@ export function useLogEvent(eventName: string, eventParams: EventParams = {}) {
     }
   }
 
+  if (POSTHOG_SERVER_AUTHORITATIVE_EVENTS.has(eventName)) return
+
   try {
     const { proxy } = useScriptPostHog()
     const posthogParams = { ...eventParams }
@@ -162,10 +179,6 @@ export function useLogEvent(eventName: string, eventParams: EventParams = {}) {
       if (classIds.length) {
         posthogParams.nft_class_ids = classIds.join(',')
       }
-    }
-    // Dedupe against the backend-fired counterpart (posthog-node) for the same transaction.
-    if (typeof eventParams.transaction_id === 'string' && eventParams.transaction_id) {
-      posthogParams.$insert_id = `${eventName}_${eventParams.transaction_id}`
     }
     proxy.posthog.capture(eventName, { app: '3ook', ...posthogParams })
   }


### PR DESCRIPTION
The browser and the API both call posthog.capture for `purchase`, `start_trial`, `subscribe`, and `begin_checkout`: the API fires from the Stripe webhook (likecoin-api-public src/util/api/{plus,likernft}) via posthog-node, and the browser fires again from the corresponding success page. PostHog's eventual deduplication keys on (timestamp, distinct_id, event, uuid) — but the two SDKs each generate their own uuidv7 and timestamp, so the tuples never match and ~2× event inflation lands in the data (most visibly on `start_trial` and `purchase`, which had ~1.8–2.0× event-to-user ratios over the past week).

Maintain a small server-authoritative event set in useLogEvent and short-circuit the PostHog leg for those names; the GA4 and Meta Pixel legs above are left untouched because GA4 dedupes on `transaction_id` and Meta CAPI dedupes on `eventID`, and both mechanisms already work across the server/browser boundary. Once posthog-js exposes a caller-supplied uuid (PostHog/posthog-js#3546) we can re-enable the PostHog leg and pass `uuidv5(\`${eventName}:${transaction_id}\`, NS)` on both sides so the tuples align.

Also drop the now-dead `\$insert_id` assignment that previously tried to bridge the same gap from the browser; with the four implicated events fully suppressed, no remaining code path reaches it with a `transaction_id`.