### PR TITLE
✨ Curate long-form demo script per affiliate voice

### DIFF
--- a/components/TTSSamplesSection.vue
+++ b/components/TTSSamplesSection.vue
@@ -43,6 +43,28 @@
           </Transition>
         </div>
       </UCard>
+
+      <ul
+        v-if="attributedSamples.length"
+        class="text-xs text-muted text-center space-y-1"
+      >
+        <li
+          v-for="sample in attributedSamples"
+          :key="sample.id"
+        >
+          <NuxtLink
+            v-if="sample.attribution.nftClassId"
+            :to="localeRoute({ name: 'store-nftClassId', params: { nftClassId: sample.attribution.nftClassId } })"
+            class="underline hover:text-highlighted"
+          >
+            <span v-text="sample.attribution.text" />
+          </NuxtLink>
+          <span
+            v-else
+            v-text="sample.attribution.text"
+          />
+        </li>
+      </ul>
     </div>
 
     <footer
@@ -61,6 +83,7 @@ const props = defineProps<{
   affiliateExclusiveBadgeText?: string
 }>()
 
+const localeRoute = useLocaleRoute()
 const { handleError } = useErrorHandler()
 
 const {
@@ -81,6 +104,11 @@ const {
   affiliateLikerId: () => props.affiliateLikerId,
   affiliateExclusiveBadgeText: () => props.affiliateExclusiveBadgeText,
 })
+
+type AttributedSample = TTSSample & { attribution: TTSSampleAttribution }
+const attributedSamples = computed(
+  () => ttsSamples.value.filter((s): s is AttributedSample => !!s.attribution),
+)
 
 function getPlayButtonIcon(sampleId: string | null) {
   return sampleId && activeTTSSampleId.value === sampleId && isPlayingSample.value

--- a/components/TTSSamplesSection.vue
+++ b/components/TTSSamplesSection.vue
@@ -44,27 +44,22 @@
         </div>
       </UCard>
 
-      <ul
-        v-if="attributedSamples.length"
-        class="text-xs text-muted text-center space-y-1"
+      <div
+        v-if="activeAttribution"
+        class="text-xs text-muted text-center"
       >
-        <li
-          v-for="sample in attributedSamples"
-          :key="sample.id"
+        <NuxtLink
+          v-if="activeAttribution.nftClassId"
+          :to="localeRoute({ name: 'store-nftClassId', params: { nftClassId: activeAttribution.nftClassId } })"
+          class="underline hover:text-highlighted"
         >
-          <NuxtLink
-            v-if="sample.attribution.nftClassId"
-            :to="localeRoute({ name: 'store-nftClassId', params: { nftClassId: sample.attribution.nftClassId } })"
-            class="underline hover:text-highlighted"
-          >
-            <span v-text="sample.attribution.text" />
-          </NuxtLink>
-          <span
-            v-else
-            v-text="sample.attribution.text"
-          />
-        </li>
-      </ul>
+          <span v-text="activeAttribution.text" />
+        </NuxtLink>
+        <span
+          v-else
+          v-text="activeAttribution.text"
+        />
+      </div>
     </div>
 
     <footer
@@ -88,6 +83,7 @@ const { handleError } = useErrorHandler()
 
 const {
   samples: ttsSamples,
+  activeSample,
   activeSampleId: activeTTSSampleId,
   currentSegmentText,
   currentSegmentIndex,
@@ -105,10 +101,7 @@ const {
   affiliateExclusiveBadgeText: () => props.affiliateExclusiveBadgeText,
 })
 
-type AttributedSample = TTSSample & { attribution: TTSSampleAttribution }
-const attributedSamples = computed(
-  () => ttsSamples.value.filter((s): s is AttributedSample => !!s.attribution),
-)
+const activeAttribution = computed(() => activeSample.value?.attribution ?? null)
 
 function getPlayButtonIcon(sampleId: string | null) {
   return sampleId && activeTTSSampleId.value === sampleId && isPlayingSample.value

--- a/composables/use-tts-samples-player.ts
+++ b/composables/use-tts-samples-player.ts
@@ -125,13 +125,12 @@ export function useTTSSamplesPlayer(options: TTSSamplesPlayerOptions = {}) {
 
   const audio = ref<HTMLAudioElement | null>(null)
 
-  const segments = computed(() => {
-    if (!activeSampleId.value) return []
-    const activeSample = samples.value.find(
-      sample => sample.id === activeSampleId.value,
-    )
-    return activeSample?.segments || []
+  const activeSample = computed(() => {
+    if (!activeSampleId.value) return null
+    return samples.value.find(sample => sample.id === activeSampleId.value) ?? null
   })
+
+  const segments = computed(() => activeSample.value?.segments ?? [])
 
   const currentSegment = computed(() => {
     return segments.value[currentSegmentIndex.value]
@@ -235,6 +234,7 @@ export function useTTSSamplesPlayer(options: TTSSamplesPlayerOptions = {}) {
   return {
     samples,
 
+    activeSample,
     activeSampleId: readonly(activeSampleId),
     isPlaying: readonly(isPlaying),
     currentSegmentIndex: readonly(currentSegmentIndex),

--- a/composables/use-tts-samples-player.ts
+++ b/composables/use-tts-samples-player.ts
@@ -1,6 +1,6 @@
 import type { AffiliateVoiceData } from '~/shared/types/custom-voice'
 import { encodeAffiliateVoiceId } from '~/shared/utils/tts-sig'
-import { getTTSSampleText } from '~/shared/utils/tts-sample'
+import { getAffiliateSampleScript, getTTSSampleText } from '~/shared/utils/tts-sample'
 
 interface TTSSamplesPlayerOptions {
   onError?: (error: unknown) => void
@@ -23,33 +23,39 @@ export function useTTSSamplesPlayer(options: TTSSamplesPlayerOptions = {}) {
     const exclusiveBadgeText = toValue(affiliateExclusiveBadgeText)
     return voices.map((voice) => {
       const encodedVoiceId = encodeAffiliateVoiceId(voice.id)
-      const language = voice.language?.toLowerCase().startsWith('zh-tw') ? 'zh-TW' : 'zh-HK'
+      const script = getAffiliateSampleScript(likerId, voice.id)
+      const language = script?.language
+        ?? (voice.language?.toLowerCase().startsWith('zh-tw') ? 'zh-TW' : 'zh-HK')
       const sampleId = `affiliate-${voice.id}`
-      const text = getTTSSampleText(language)
-      const params = new URLSearchParams({
-        voice_id: encodedVoiceId,
-        language,
-        from: likerId,
-      })
       const description = language === 'zh-TW'
         ? $t('tts_sample_mandarin')
         : $t('tts_sample_cantonese')
+      const segmentTexts = script?.segments ?? [getTTSSampleText(language)]
+      const baseQuery = new URLSearchParams({
+        voice_id: encodedVoiceId,
+        language,
+        from: likerId,
+      }).toString()
+      const segments = segmentTexts.map((text, index) => ({
+        id: `${sampleId}-segment-${index}`,
+        text,
+        sectionIndex: 0,
+        cfi: undefined,
+        audioSrc: script
+          ? `/api/tts/sample?${baseQuery}&seg=${index}`
+          : `/api/tts/sample?${baseQuery}`,
+      }))
       return {
         id: sampleId,
         title: voice.name,
         description,
-        segments: [{
-          id: `${sampleId}-segment-0`,
-          text,
-          sectionIndex: 0,
-          cfi: undefined,
-          audioSrc: `/api/tts/sample?${params.toString()}`,
-        }],
+        segments,
         language,
         languageVoice: encodedVoiceId,
         avatarSrc: getVoiceAvatar(encodedVoiceId),
         isAffiliateExclusive: true,
         affiliateExclusiveBadgeText: exclusiveBadgeText,
+        attribution: script?.attribution,
       }
     })
   })

--- a/server/api/tts/sample.get.ts
+++ b/server/api/tts/sample.get.ts
@@ -2,7 +2,7 @@ import { createHash } from 'node:crypto'
 import type { H3Event } from 'h3'
 import { TTSSampleQuerySchema } from '~/server/schemas/tts'
 import { decodeAffiliateVoiceId, isAffiliateVoiceId } from '~/shared/utils/tts-sig'
-import { getTTSSampleText } from '~/shared/utils/tts-sample'
+import { getAffiliateSampleScript, getTTSSampleText } from '~/shared/utils/tts-sample'
 
 // Public endpoint with deterministic URLs, so a cold cache can produce a
 // thundering herd of identical Minimax synthesis requests. The map collapses
@@ -55,16 +55,17 @@ async function serveCachedSample(
 }
 
 export default defineEventHandler(async (event) => {
-  const { language, voice_id: voiceId, from } = await getValidatedQuery(
+  const { language: requestedLanguage, voice_id: voiceId, from, seg } = await getValidatedQuery(
     event,
     createValidator(TTSSampleQuerySchema),
   )
 
-  const text = getTTSSampleText(language)
   const isAffiliate = isAffiliateVoiceId(voiceId)
 
   let customMiniMaxVoiceId: string | undefined
   let voiceDisplayName: string | undefined
+  let language = requestedLanguage
+  let text: string | undefined
 
   if (isAffiliate) {
     if (!from) {
@@ -84,6 +85,20 @@ export default defineEventHandler(async (event) => {
     }
     customMiniMaxVoiceId = affiliateVoice.providerVoiceId
     voiceDisplayName = affiliateVoice.name
+
+    const script = getAffiliateSampleScript(from, slot)
+    if (script) {
+      const segmentIndex = seg ?? 0
+      const segmentText = script.segments[segmentIndex]
+      if (!segmentText) {
+        throw createError({ status: 400, message: 'INVALID_SEG' })
+      }
+      language = script.language
+      text = segmentText
+    }
+    else if (seg !== undefined) {
+      throw createError({ status: 400, message: 'INVALID_SEG' })
+    }
   }
   else {
     if (!KNOWN_VOICE_IDS.has(voiceId)) {
@@ -91,6 +106,8 @@ export default defineEventHandler(async (event) => {
     }
     voiceDisplayName = getVoiceDisplayName(voiceId)
   }
+
+  text ??= getTTSSampleText(language)
 
   const provider = new MinimaxTTSProvider()
   const ttsModel = getMinimaxModel({ voiceId, customVoiceId: customMiniMaxVoiceId, language })

--- a/server/api/tts/sample.get.ts
+++ b/server/api/tts/sample.get.ts
@@ -104,6 +104,9 @@ export default defineEventHandler(async (event) => {
     if (!KNOWN_VOICE_IDS.has(voiceId)) {
       throw createError({ status: 400, message: 'INVALID_VOICE_ID' })
     }
+    if (seg !== undefined) {
+      throw createError({ status: 400, message: 'INVALID_SEG' })
+    }
     voiceDisplayName = getVoiceDisplayName(voiceId)
   }
 

--- a/server/schemas/tts.ts
+++ b/server/schemas/tts.ts
@@ -30,4 +30,11 @@ export const TTSSampleQuerySchema = v.object({
     v.nonEmpty('INVALID_VOICE_ID'),
   ),
   from: v.optional(v.string()),
+  seg: v.optional(v.pipe(
+    v.string(),
+    v.transform(Number),
+    v.number('INVALID_SEG'),
+    v.integer('INVALID_SEG'),
+    v.minValue(0, 'INVALID_SEG'),
+  )),
 })

--- a/server/schemas/tts.ts
+++ b/server/schemas/tts.ts
@@ -32,6 +32,7 @@ export const TTSSampleQuerySchema = v.object({
   from: v.optional(v.string()),
   seg: v.optional(v.pipe(
     v.string(),
+    v.nonEmpty('INVALID_SEG'),
     v.transform(Number),
     v.number('INVALID_SEG'),
     v.integer('INVALID_SEG'),

--- a/shared/utils/tts-sample.ts
+++ b/shared/utils/tts-sample.ts
@@ -1,3 +1,5 @@
+import { normalizeLikerId } from '~/shared/utils/liker-id'
+
 // Static example text for the public TTS sample endpoint. Hardcoding the text
 // per language closes the abuse vector: without auth + sig, an arbitrary
 // `text=` param would let anyone burn Minimax tokens against our cache. With
@@ -12,4 +14,49 @@ export const TTS_SAMPLE_TEXT_BY_LANGUAGE: Record<TTSSampleLanguage, string> = {
 
 export function getTTSSampleText(language: TTSSampleLanguage): string {
   return TTS_SAMPLE_TEXT_BY_LANGUAGE[language]
+}
+
+// Per-affiliate-voice curated demo scripts. The text is server-controlled and
+// looked up by (likerId, voiceSlot); the client only sends the segment index,
+// preserving the abuse-vector closure of the public sample endpoint.
+export interface AffiliateSampleScript {
+  language: TTSSampleLanguage
+  segments: string[]
+  attribution?: TTSSampleAttribution
+}
+
+// Pre-chunked to match the reader's runtime segmentation
+// (splitTextIntoSegments + mergeShortTTSSegments in utils/tts.ts, ~100 char cap).
+// Regenerate if the source text changes.
+const KAIMING_CHIMING_SCRIPT: AffiliateSampleScript = {
+  language: 'zh-TW',
+  segments: [
+    '整個世界，整個真實世界，在三隻飛蟲逃跑後，進入了我的房間。就在這裡重新包圍我，和我融在一起。',
+    '此刻，我聽著所有聲響，不由自主地捕捉它們在這個空間的位置：我的呼吸彷彿造風箱輕柔的聲音；我的身體不經意的動作壓得床鋪嘎吱響；那兒傳來一隻蟑螂搔著壁紙起縐部分的聲音；',
+    '外面，人們正在內院裡說話，他們講話的同時，幾扇窗戶亮起，整棟大樓變幻成不同面貌，聖壇社宅的燈光灑在通往四面八方的街道上，那兒同時響起各種聲音：',
+    '一輛汽車、一輛電車，整座城市所有居民不斷的低語；我的太太在隔壁，她有一頭栗子色秀髮，睜著一雙惺忪睡眼；隔壁的房間是完美的正方形；我有兩個桃花心木家具；',
+    '爸爸住在聖心街；我伸出指腹觸摸床單；今天就快落幕，前一天過去了，明天緊接著而來，然後再一個明天，然後再一個，然後再一個，我會移動雙腳繼續前進，以免往前撲一跤。',
+    '我聽到，我看到，我感覺到一切。一陣幽微的山茶花香飄來。',
+    '我聽到，我看到，我感覺到，我活著。何必懷疑？我的大腦已經排空，頓悟從連通管流向低處的現實。再會，廁所和所有一切！我知道，每當我額頭抵著右手，任由自然之力流淌過我，我就能靈光一閃，豁然開朗。',
+    '而現在我躺在床上，接著明天早上會起床，然後再回到床上過夜。吃飯、寒暄、評論、做夢、打呵欠、愛人，最後睡覺，為了能夠醒來，能夠開始一天又一天，和我的同類、空氣、土地，和生活肩並肩，身體挨著身體。',
+  ],
+  attribution: {
+    text: '出自《懸停日日》',
+    nftClassId: '0x4d69ecb8da3b16d5828ec0dcd17b1310cb96d3a0',
+  },
+}
+
+// Duplicate prod+testnet liker IDs so sepolia QA matches prod — mirrors the
+// pattern in AFFILIATE_DEFINITIONS (composables/use-pricing-page-campaign.ts).
+const AFFILIATE_SAMPLE_SCRIPTS: Record<string, Record<string, AffiliateSampleScript>> = {
+  bsymfp: { chiming: KAIMING_CHIMING_SCRIPT },
+  gpzauz: { chiming: KAIMING_CHIMING_SCRIPT },
+}
+
+export function getAffiliateSampleScript(
+  likerId: string | undefined,
+  voiceSlot: string | undefined,
+): AffiliateSampleScript | undefined {
+  if (!likerId || !voiceSlot) return undefined
+  return AFFILIATE_SAMPLE_SCRIPTS[normalizeLikerId(likerId)]?.[voiceSlot]
 }

--- a/types/tts.d.ts
+++ b/types/tts.d.ts
@@ -7,6 +7,11 @@ declare interface TTSSegment {
   audioSrc?: string
 }
 
+declare interface TTSSampleAttribution {
+  text: string
+  nftClassId?: string
+}
+
 declare interface TTSSample {
   id: string
   title: string
@@ -17,4 +22,5 @@ declare interface TTSSample {
   avatarSrc: string
   isAffiliateExclusive?: boolean
   affiliateExclusiveBadgeText?: string
+  attribution?: TTSSampleAttribution
 }


### PR DESCRIPTION
Adds an in-repo (likerId, voiceSlot) → script map so an affiliate voice on /member can play a multi-segment passage instead of the generic one-liner sample. The /api/tts/sample endpoint now accepts a `seg` index when a script exists; text is still resolved server-side from the static map, so the public no-auth endpoint's abuse vector stays closed. First curated entry is 啟明's 聖修 voice reading《懸停日日》, with attribution surfaced on the sample row linking to the book's store page.
<img width="447" height="401" alt="image" src="https://github.com/user-attachments/assets/9f0c6b3a-cbbe-41e7-89d3-0618294b68af" />
