### PR TITLE
📱 Hide overflow tab skeletons on phone

### DIFF
--- a/components/PillButtonGroup.vue
+++ b/components/PillButtonGroup.vue
@@ -15,6 +15,7 @@
             'rounded-full',
             'border-2',
             'border-muted',
+            { 'max-phone:hidden': i >= 2 },
           ]"
         />
         <USkeleton


### PR DESCRIPTION
Before
<img width="342" height="99" alt="before" src="https://github.com/user-attachments/assets/0e4651ce-7885-4e34-bfec-a45c81ab8de6" />

After
<img width="321" height="71" alt="after" src="https://github.com/user-attachments/assets/76c56066-93b7-4b24-adb7-29a4b4240bab" />
