### PR TITLE
🔥 Skip web Intercom SDK in app and drop pre-bridge hacks

### DIFF
--- a/composables/use-intercom.ts
+++ b/composables/use-intercom.ts
@@ -1,9 +1,6 @@
 // Single entry point for Intercom on web. Picks among the native RN SDK
 // bridge, the window.Intercom JS SDK, and a mailto fallback so call sites
-// don't have to branch on bridge / SDK availability themselves. The web
-// SDK branch is gated on !isApp because plugins/intercom.client.ts hides
-// the messenger via CSS in app mode (real app or ?app=1) — calling
-// Intercom('show') there opens an invisible UI.
+// don't have to branch on bridge / SDK availability themselves.
 
 const SUPPORT_EMAIL = 'cs@3ook.com'
 
@@ -19,8 +16,6 @@ function openMailto(subject?: string, body?: string): void {
 }
 
 export function useIntercom() {
-  const { isApp } = useAppDetection()
-
   function dispatch(
     native: () => void,
     web: () => void,
@@ -30,7 +25,7 @@ export function useIntercom() {
       native()
       return { method: 'chat' }
     }
-    if (!isApp.value && isWebIntercomReady()) {
+    if (isWebIntercomReady()) {
       web()
       return { method: 'chat' }
     }

--- a/composables/use-logger.ts
+++ b/composables/use-logger.ts
@@ -152,9 +152,6 @@ export function useLogEvent(eventName: string, eventParams: EventParams = {}) {
       if (items) {
         params.items = JSON.stringify(items)
       }
-      // Forward via the native bridge when supported; otherwise use the
-      // web SDK. Older app builds without the bridge keep the web SDK
-      // active so events still reach Intercom for CS context.
       if (isNativeIntercomAvailable()) {
         postToNative({ type: 'intercomTrackEvent', name: eventName, metaData: params })
       }
@@ -247,10 +244,8 @@ export function useSetLogUser(user: User | null, locale: string) {
     }
   }
 
-  // When the native Intercom bridge is supported, the native SDK owns
-  // identity (driven by the identifyUser/resetUser bridge below). Browser
-  // sessions and older app builds without the bridge sync via the web SDK
-  // so CS still has user context.
+  // In app, the native SDK owns identity (driven by identifyUser/resetUser
+  // below). In the browser, sync identity via the web SDK.
   if (import.meta.client && !isNativeIntercomAvailable()) {
     try {
       if (!user) {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -226,9 +226,6 @@ export default defineNuxtConfig({
         bundle: false,
         proxy: false,
       },
-      intercom: {
-        trigger: { idleTimeout: 3000 },
-      },
       metaPixel: {
         bundle: false,
         proxy: false,

--- a/pages/account/index.vue
+++ b/pages/account/index.vue
@@ -517,7 +517,7 @@
           variant="link"
           class="cursor-pointer"
           leading-icon="i-material-symbols-contact-support"
-          :trailing-icon="isApp ? 'i-material-symbols-mail-outline' : 'i-material-symbols-chat-bubble-outline-rounded'"
+          trailing-icon="i-material-symbols-chat-bubble-outline-rounded"
           color="neutral"
           size="lg"
           block

--- a/plugins/intercom.client.ts
+++ b/plugins/intercom.client.ts
@@ -1,39 +1,17 @@
+// Skip the web Intercom SDK in app — the native shell owns the chat surface
+// via the WebView bridge (see useIntercom). Loading both stacks risks a
+// duplicate messenger on top of the native one in builds where the bridge
+// feature flag isn't yet present.
 export default defineNuxtPlugin(() => {
   const { isApp } = useAppDetection()
 
-  if (!isApp.value) {
+  if (isApp.value) {
     return
   }
 
-  // When the native Intercom bridge is supported, defang the web SDK so
-  // any stray window.Intercom(...) call becomes a no-op and can't open a
-  // duplicate web messenger on top of the native one — useIntercom()
-  // routes through the WebView bridge instead. Older app builds without
-  // the bridge keep the web SDK active (identity + events still flow);
-  // the CSS hide below keeps the launcher invisible.
-  if (isNativeIntercomAvailable()) {
-    const noop = () => {}
-    ;(window as unknown as { Intercom: (...args: unknown[]) => void }).Intercom = noop
-  }
-
-  // Hide certain Intercom UI elements via CSS in case it loads later
-  const styleId = 'intercom-visibility-overrides'
-  if (document.getElementById(styleId)) {
-    return
-  }
-
-  const style = document.createElement('style')
-  style.id = styleId
-  style.textContent = `
-    .intercom-launcher-frame,
-    .intercom-launcher-badge-frame,
-    .intercom-lightweight-app,
-    .intercom-lightweight-app-launcher,
-    .intercom-messenger-frame,
-    [name="intercom-notification-stack-frame"],
-    [class^="intercom-with-namespace-"]:not([name="intercom-banner-frame"]) {
-      display: none !important;
-    }
-  `
-  document.head.appendChild(style)
+  useScriptIntercom({
+    scriptOptions: {
+      trigger: useScriptTriggerIdleTimeout({ timeout: 3000 }),
+    },
+  })
 })


### PR DESCRIPTION
The native bridge owns the chat surface in app, so the web SDK no longer needs to load there. Move the registry trigger into a client plugin gated on !isApp (mirrors plugins/stripe.client.ts), which makes the CSS launcher-hide, the window.Intercom defang, the per- call-site !isApp gate in useIntercom, and the conditional mailto icon in account redundant.