### PR TITLE
🐛 Prompt relogin when Magic session expired mid-write

### DIFF
--- a/composables/use-error-handler.ts
+++ b/composables/use-error-handler.ts
@@ -57,6 +57,12 @@ export default function () {
           }
           break
 
+        case 'MAGIC_SESSION_EXPIRED':
+          handler = {
+            description: $t('error_wallet_session_expired'),
+          }
+          break
+
         default:
           break
       }

--- a/composables/use-magic-session.ts
+++ b/composables/use-magic-session.ts
@@ -1,12 +1,9 @@
-import { useConnect, useDisconnect } from '@wagmi/vue'
 import type { Magic } from 'magic-sdk'
 
 let pendingSessionCheck: Promise<void> | null = null
 
 export function useMagicSession() {
   const { $wagmiConfig } = useNuxtApp()
-  const { connectAsync } = useConnect()
-  const { disconnectAsync } = useDisconnect()
 
   async function doEnsureMagicSession() {
     const currentKey = $wagmiConfig.state.current
@@ -24,9 +21,23 @@ export function useMagicSession() {
       needsReauth = true
     }
 
-    if (needsReauth) {
-      await disconnectAsync()
-      await connectAsync({ connector, chainId: $wagmiConfig.chains[0].id })
+    if (!needsReauth) return
+
+    const accountStore = useAccountStore()
+    const { user } = useUserSession()
+    await accountStore.login({
+      connectorId: 'magic',
+      email: user.value?.email,
+    })
+
+    // accountStore.login() silently returns when the user dismisses Magic's UI,
+    // so confirm wagmi actually reconnected before letting the caller proceed.
+    const newKey = $wagmiConfig.state.current
+    if (!newKey || !$wagmiConfig.state.connections.get(newKey)) {
+      throw createError({
+        statusCode: 401,
+        message: 'MAGIC_SESSION_EXPIRED',
+      })
     }
   }
 

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -416,6 +416,7 @@
   "error_unknown": "Unknown error.",
   "error_unstake_amount_exceeded": "Amount exceeds your stake",
   "error_unstake_amount_exceeded_description": "You can only unstake up to {amount} LIKE.",
+  "error_wallet_session_expired": "Your wallet session has expired. Please log in again to continue.",
   "expandable_content_show_less_button_label": "Show Less",
   "expandable_content_show_more_button_label": "Show More",
   "footer_about": "About Us",

--- a/i18n/locales/zh-Hant.json
+++ b/i18n/locales/zh-Hant.json
@@ -416,6 +416,7 @@
   "error_unknown": "未知錯誤",
   "error_unstake_amount_exceeded": "超過可解除質押的數量",
   "error_unstake_amount_exceeded_description": "你只能解除 {amount} LIKE 的質押數量。",
+  "error_wallet_session_expired": "錢包連線已過期，請重新登入再繼續。",
   "expandable_content_show_less_button_label": "收起內容",
   "expandable_content_show_more_button_label": "查看更多",
   "footer_about": "關於我們",


### PR DESCRIPTION
ensureMagicSession previously did a bare connect without email when the Magic Link session had expired, leaving unstake (and every other contract write) failing silently. Route through accountStore.login() so the user gets the real re-auth flow, and surface a clear wallet-session-expired error if they dismiss it.