### PR TITLE
🐛 Reduce v-gsap entrance flash on About page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@farcaster/miniapp-sdk": "^0.2.1",
         "@google-cloud/pubsub": "^5.3.0",
         "@likecoin/epub-ts": "^0.6.3",
-        "@likecoin/v-gsap-nuxt": "1.5.12-like.0",
+        "@likecoin/v-gsap-nuxt": "1.5.12-like.2",
         "@likecoin/wagmi-connector": "2.4.1-like.0",
         "@nuxt/icon": "^1.11.0",
         "@nuxt/scripts": "^1.0.2",
@@ -5375,9 +5375,9 @@
       }
     },
     "node_modules/@likecoin/v-gsap-nuxt": {
-      "version": "1.5.12-like.0",
-      "resolved": "https://registry.npmjs.org/@likecoin/v-gsap-nuxt/-/v-gsap-nuxt-1.5.12-like.0.tgz",
-      "integrity": "sha512-hsbQxDqODGd4sNAK4LKdr3hN+VHg4swPSXPMg6dq1l1LmJp5k8qDfq62rfSdakXyLSyPQnnostrrxEtH0bWxiQ==",
+      "version": "1.5.12-like.2",
+      "resolved": "https://registry.npmjs.org/@likecoin/v-gsap-nuxt/-/v-gsap-nuxt-1.5.12-like.2.tgz",
+      "integrity": "sha512-xDzyZ8GftW4S5SOC4+fAMd1J9I+s732ySfZ7RinFG2XPlgYKqWR79/Zznj1QWhGH7eZBT4UOlzXsjrBGO16ngQ==",
       "license": "MIT",
       "dependencies": {
         "@nuxt/kit": "^3.14.1592",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@farcaster/miniapp-sdk": "^0.2.1",
     "@google-cloud/pubsub": "^5.3.0",
     "@likecoin/epub-ts": "^0.6.3",
-    "@likecoin/v-gsap-nuxt": "1.5.12-like.0",
+    "@likecoin/v-gsap-nuxt": "1.5.12-like.2",
     "@likecoin/wagmi-connector": "2.4.1-like.0",
     "@nuxt/icon": "^1.11.0",
     "@nuxt/scripts": "^1.0.2",

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -830,6 +830,14 @@ import glassesOnLogo from '~/assets/images/about/media/glasses-on.png'
 import scmpLogo from '~/assets/images/about/media/scmp.png'
 import unwireLogo from '~/assets/images/about/media/unwire.png'
 
+// Preload gsap chunks at module-eval time so the hero's above-the-fold
+// v-gsap entrance animation doesn't flash before the directive's lazy
+// loader fetches them on beforeMount.
+if (import.meta.client) {
+  void import('gsap')
+  void import('gsap/ScrollTrigger')
+}
+
 definePageMeta({
   layout: false,
   colorMode: 'light',


### PR DESCRIPTION
Bumps @likecoin/v-gsap-nuxt to 1.5.12-like.1 so the SSR hider covers .from / .fromTo with an explicit opacity:0 value, not only the .fromInvisible modifier — closes the FOUC gap for non-entrance-preset directives like the stats bar and feature grids.

Also eagerly imports gsap + ScrollTrigger from pages/about.vue so the chunks start fetching at page module eval rather than waiting for the directive's beforeMount — meaningfully shortens the dark-hero window above the fold after the lazy-load switch in 10c6b669.