### PR TITLE
🔧 Raise mainnet Cloud Run memory to 4 GiB

### DIFF
--- a/apphosting.mainnet.yaml
+++ b/apphosting.mainnet.yaml
@@ -5,7 +5,7 @@ runConfig:
   # maxInstances: 100
   # concurrency: 80
   cpu: 1
-  memoryMiB: 2048
+  memoryMiB: 4000
 
 # Environment variables and secrets.
 env:


### PR DESCRIPTION
Cloud Run memory p99 hit 88% and p95 85% on the 2 GiB instance, leaving little headroom before OOM. Bump to 4 GiB (the ceiling at cpu: 1) to absorb SSR + EPUB/TTS spikes.