### PR TITLE
[TAS-4439] 🐛 Force PWA refresh to recover iOS users stuck on chunk errors

### DIFF
--- a/plugins/chunk-error.client.ts
+++ b/plugins/chunk-error.client.ts
@@ -11,30 +11,76 @@ const RELOAD_FLUSH_DELAY_MS = 200
 
 export default defineNuxtPlugin((nuxtApp) => {
   const lastReloadAt = useSessionStorage<number>('chunk_error_reload', 0)
+  const hasEscalated = useSessionStorage<boolean>('chunk_error_escalated', false)
+  const pwa = usePWA()
   let hasHandled = false
 
-  const handle = (error: unknown) => {
+  const handle = async (error: unknown) => {
     const message = getErrorMessage(error)
     if (!CHUNK_ERROR_PATTERNS.some(pattern => message.includes(pattern))) return
     if (hasHandled) return
     hasHandled = true
 
     const isLooping = Date.now() - lastReloadAt.value < RELOAD_COOLDOWN_MS
+    let hadSW = false
+    try {
+      hadSW = !!(await navigator.serviceWorker?.getRegistration())
+    }
+    catch {
+      // Telemetry only — fall back to false on browsers that reject the call.
+    }
 
-    useLogEvent('chunk_error', {
-      error_message: message,
-      url: window.location.pathname,
-      reloaded: !isLooping,
-    })
+    const logChunkError = (reloaded: boolean, escalated: boolean) =>
+      useLogEvent('chunk_error', {
+        error_message: message,
+        url: window.location.pathname,
+        reloaded,
+        escalated,
+        had_sw: hadSW,
+      })
+
+    if (isLooping && hasEscalated.value) {
+      logChunkError(false, true)
+      console.error('[chunk-error] already escalated, surfacing error', error)
+      return
+    }
 
     if (isLooping) {
-      console.error('[chunk-error] reload already attempted recently, surfacing error', error)
+      // Cooperative reload didn't fix it — purge SW + caches and force a clean
+      // fetch. Targets iOS WebKit where the cached "/" shell keeps re-serving
+      // references to deleted chunk hashes after deploy.
+      hasEscalated.value = true
+      logChunkError(true, true)
+      try {
+        const regs = (await navigator.serviceWorker?.getRegistrations()) ?? []
+        await Promise.all(regs.map(r => r.unregister()))
+        const keys = (await caches?.keys()) ?? []
+        await Promise.all(keys.map(k => caches.delete(k)))
+      }
+      catch (e) {
+        console.warn('[chunk-error] cache purge failed', e)
+      }
+      setTimeout(() => {
+        const url = new URL(window.location.href)
+        url.searchParams.set('_swrefresh', String(Date.now()))
+        window.location.replace(url.toString())
+      }, RELOAD_FLUSH_DELAY_MS)
       return
     }
 
     lastReloadAt.value = Date.now()
+    logChunkError(true, false)
     // Give PostHog/GA a window to flush the event before navigating away
-    setTimeout(() => {
+    setTimeout(async () => {
+      try {
+        if (pwa?.updateServiceWorker) {
+          await pwa.updateServiceWorker(true)
+          return
+        }
+      }
+      catch (e) {
+        console.warn('[chunk-error] updateServiceWorker failed', e)
+      }
       window.location.reload()
     }, RELOAD_FLUSH_DELAY_MS)
   }


### PR DESCRIPTION
PostHog showed ~22% of chunk_error events hit the 10s cooldown without reloading, concentrated on iOS WebKit (37% block rate vs 3% on desktop Chrome). After one reload the cached "/" shell keeps re-serving deleted chunk hashes, so the second failure surfaces the error to users.

Escalate on the second chunk error inside the cooldown: unregister all service workers, purge Cache Storage, then window.location.replace with a cache-bust query to defeat iOS bfcache. Use vite-pwa's updateServiceWorker(true) for the first attempt so a waiting SW gets a chance to swap cooperatively before the nuclear path.

Adds escalated and had_sw to the chunk_error event so we can verify the escalation rate in PostHog after deploy.