### PR TITLE
⬆️ Upgrade minimax-speech-ts to v0.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "firebase-admin": "^13.4.0",
         "jwt-decode": "^4.0.0",
         "markdown-it": "^14.1.1",
-        "minimax-speech-ts": "^0.1.0",
+        "minimax-speech-ts": "^0.3.0",
         "nuxt": "^3.20.1",
         "nuxt-auth-utils": "^0.5.17",
         "nuxt-security": "^2.2.0",
@@ -25215,9 +25215,9 @@
       }
     },
     "node_modules/minimax-speech-ts": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/minimax-speech-ts/-/minimax-speech-ts-0.1.0.tgz",
-      "integrity": "sha512-GUy9ySfvsF9YqmT5jN05N37iYKtF5W9GWgnscdJyQ9540SlNyYk9mWQ8gYRZ6fdAjME2FOJ3/dPuCTYKPWMLFQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/minimax-speech-ts/-/minimax-speech-ts-0.3.0.tgz",
+      "integrity": "sha512-eiwbKKml8ussRgmF1AukkLYccEQsubHYCOuNpqXp+UGPj+9tclsGIPVF3TwMdVXh6c4hSrq0PD71Ncl1tZeEDQ==",
       "license": "MIT",
       "dependencies": {
         "eventsource-parser": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "firebase-admin": "^13.4.0",
     "jwt-decode": "^4.0.0",
     "markdown-it": "^14.1.1",
-    "minimax-speech-ts": "^0.1.0",
+    "minimax-speech-ts": "^0.3.0",
     "nuxt": "^3.20.1",
     "nuxt-auth-utils": "^0.5.17",
     "nuxt-security": "^2.2.0",

--- a/server/utils/tts-minimax.ts
+++ b/server/utils/tts-minimax.ts
@@ -90,7 +90,7 @@ export class MinimaxTTSProvider implements BaseTTSProvider {
       voiceSetting: {
         voiceId: resolvedVoiceId,
         speed: 1,
-        emotion: 'neutral',
+        emotion: 'calm',
         textNormalization: true,
       },
       pronunciationDict: getTTSPronunciationDictionary(language),
@@ -114,18 +114,19 @@ export class MinimaxTTSProvider implements BaseTTSProvider {
     const resolvedVoiceId = (customMiniMaxVoiceId || VOICE_CONFIG[voiceId]!.minimaxVoiceId) as string
     const model = getMinimaxModel({ voiceId, customVoiceId: customMiniMaxVoiceId, language })
 
-    return await client.synthesizeStream({
+    const { audio } = await client.synthesizeStream({
       text,
       model,
       voiceSetting: {
         voiceId: resolvedVoiceId,
         speed: 1,
-        emotion: 'neutral',
+        emotion: 'calm',
         textNormalization: true,
       },
       pronunciationDict: getTTSPronunciationDictionary(language),
       languageBoost: LANG_MAPPING[language as keyof typeof LANG_MAPPING],
       streamOptions: { excludeAggregatedAudio: true },
     })
+    return audio
   }
 }


### PR DESCRIPTION
v0.3.0 drops the 'neutral' emotion (replaced with 'calm') and reshapes synthesizeStream's return to { audio, subtitle }; destructure audio at the call site. Default apiHost also moves to api.minimax.io.