### PR TITLE
🐛 Restore payment currency before logging Plus success events

### DIFF
--- a/pages/plus/success.vue
+++ b/pages/plus/success.vue
@@ -37,6 +37,7 @@ const localeRoute = useLocaleRoute()
 const accountStore = useAccountStore()
 const { handleError } = useErrorHandler()
 const { currency, yearlyPrice, monthlyPrice } = useSubscription()
+const { initializePaymentCurrency } = usePaymentCurrency()
 const { convertPrice } = useCurrency()
 const { user } = useUserSession()
 const likeCoinSessionAPI = useLikeCoinSessionAPI()
@@ -104,6 +105,10 @@ onMounted(async () => {
       giftClaimToken,
     } = await fetchPlusGiftStatus()
     if (isRedirected.value) {
+      // Restore the persisted currency before logging: post-Stripe-redirect the
+      // payment-currency state is fresh 'auto' and resolves to USD until
+      // geolocation lands, which would mislabel the analytics value/currency.
+      await initializePaymentCurrency()
       const isTrial = getRouteQuery('trial') !== '0'
 
       const PREDICTED_LTV_USD = 100


### PR DESCRIPTION
The success page is reached via Stripe redirect, so payment-currency state is a fresh 'auto' and resolves to USD until geolocation lands — the subscribe/start_trial events were logging value/currency decoupled from the actual charge. Initialize the persisted currency first.