### PR TITLE
[TAS-5901] ♻️ Read session JWT via secure-or-user shim

### DIFF
--- a/server/api/account/refresh.post.ts
+++ b/server/api/account/refresh.post.ts
@@ -10,7 +10,8 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  if (!session.user.token) {
+  const token = session.secure?.token ?? session.user.token
+  if (!token) {
     throw createError({
       statusCode: 401,
       message: 'TOKEN_NOT_FOUND',
@@ -18,7 +19,7 @@ export default defineEventHandler(async (event) => {
   }
   let userInfoRes: LikerProfileResponseData | undefined = undefined
   try {
-    userInfoRes = await fetchLikerProfileInfo(session.user.token)
+    userInfoRes = await fetchLikerProfileInfo(token)
   }
   catch (error) {
     console.warn(`Failed to fetch user info for wallet ${walletAddress} in account refresh`, error)
@@ -50,7 +51,7 @@ export default defineEventHandler(async (event) => {
       // sessions that already have one.
       ttsKey: session.user.ttsKey ?? generateTTSKey(),
     },
-    secure: { token: session.user.token },
+    secure: { token },
   })
 
   const userDocRef = getUserCollection().doc(walletAddress)
@@ -58,9 +59,9 @@ export default defineEventHandler(async (event) => {
     userDocRef.set({
       accessTimestamp: FieldValue.serverTimestamp(),
     }, { merge: true }),
-    hasIntercomTokenRotated && session.user.evmWallet && session.user.token && session.user.jwtId
+    hasIntercomTokenRotated && session.user.evmWallet && session.user.jwtId
       ? refreshSessionTokens(session.user.evmWallet, session.user.jwtId, {
-          token: session.user.token,
+          token,
           intercomToken,
           loginMethod: session.user.loginMethod,
         })

--- a/server/api/user/settings.post.ts
+++ b/server/api/user/settings.post.ts
@@ -33,15 +33,16 @@ export default defineEventHandler(async (event) => {
   }
 
   // Sync locale to like.co user preferences API
-  if ('locale' in body && session.user.token) {
+  const token = session.secure?.token ?? session.user.token
+  if ('locale' in body && token) {
     try {
-      const decoded = jwtDecode<{ permissions?: string[] }>(session.user.token)
+      const decoded = jwtDecode<{ permissions?: string[] }>(token)
       const hasWritePreferences = decoded.permissions?.includes('write:preferences')
       if (hasWritePreferences) {
         await getLikeCoinAPIFetch()('/users/preferences', {
           method: 'POST',
           headers: {
-            Authorization: `Bearer ${session.user.token}`,
+            Authorization: `Bearer ${token}`,
           },
           body: {
             locale: body.locale?.startsWith('zh') ? 'zh' : 'en',


### PR DESCRIPTION
Step 2 of moving the JWT out of the cookie. Server reads now prefer session.secure?.token, falling back to session.user.token so sessions issued before Step 1 keep working. Step 1 already dual-writes both locations; Steps 4 and 6 stop emitting the legacy ones.

The token-presence early-return in refresh.post.ts already proves truthiness, so the redundant `&& session.user.token` guard in the intercom-rotation Promise.all is dropped.

Reapplied after the original commit (fd86cbce) was orphaned by a rebase onto deploy/main.