### PR TITLE
🐛 Retry idempotent API requests on transient network drops

### DIFF
--- a/composables/use-annotations.ts
+++ b/composables/use-annotations.ts
@@ -24,7 +24,7 @@ export default function useAnnotations(params: {
     }
 
     isLoading.value = true
-    fetchPromise.value = $fetch<{ annotations: Annotation[] }>(`/api/books/${nftClassId.value}/annotations`)
+    fetchPromise.value = apiFetch<{ annotations: Annotation[] }>(`/books/${nftClassId.value}/annotations`)
       .then((response) => {
         annotations.value = response.annotations
         hasFetched.value = true
@@ -104,8 +104,9 @@ export default function useAnnotations(params: {
     })
 
     try {
-      const response = await $fetch<{ annotation: Annotation }>(`/api/books/${nftClassId.value}/annotations/${annotationId}`, {
+      const response = await apiFetch<{ annotation: Annotation }>(`/books/${nftClassId.value}/annotations/${annotationId}`, {
         method: 'POST',
+        retry: API_MAX_RETRIES,
         body: {
           ...data,
           ...(data.note !== undefined ? { note: data.note || '' } : {}),

--- a/composables/use-book-owner-affiliate.ts
+++ b/composables/use-book-owner-affiliate.ts
@@ -33,7 +33,7 @@ export function useBookOwnerAffiliate(
       await metadataStore.lazyFetchLikerInfoByWalletAddress(wallet)
       const likerId = ownerLikerId.value
       if (!likerId || loadedLikerId.value === likerId) return
-      const data = await $fetch<AffiliatePublicConfig>(`/api/affiliate/${encodeURIComponent(likerId)}`)
+      const data = await apiFetch<AffiliatePublicConfig>(`/affiliate/${encodeURIComponent(likerId)}`)
       loadedConfig.value = data?.active ? data : null
       loadedLikerId.value = likerId
     }

--- a/composables/use-custom-voice.ts
+++ b/composables/use-custom-voice.ts
@@ -18,7 +18,7 @@ export function useCustomVoice() {
     if (inflightFetch) return inflightFetch
     const task = (async () => {
       try {
-        const data = await $fetch<CustomVoiceData | null>('/api/user/custom-voice')
+        const data = await apiFetch<CustomVoiceData | null>('/user/custom-voice')
         if (!hasLoggedIn.value) return
         customVoice.value = data
         isLoaded.value = true

--- a/composables/use-plus-affiliate.ts
+++ b/composables/use-plus-affiliate.ts
@@ -31,7 +31,7 @@ export function usePlusAffiliate() {
     if (loadedFrom.value === from || isLoading.value) return
     isLoading.value = true
     try {
-      const data = await $fetch<AffiliatePublicConfig>(`/api/affiliate/${encodeURIComponent(from)}`)
+      const data = await apiFetch<AffiliatePublicConfig>(`/affiliate/${encodeURIComponent(from)}`)
       loadedConfig.value = data?.active ? data : null
       loadedFrom.value = from
     }

--- a/composables/use-tts-trial-usage.ts
+++ b/composables/use-tts-trial-usage.ts
@@ -20,7 +20,7 @@ async function fetchServerUsage(wallet: string): Promise<ServerUsage | null> {
   if (pending) return pending
   const task = (async (): Promise<ServerUsage | null> => {
     try {
-      return await $fetch<ServerUsage>('/api/reader/tts/usage')
+      return await apiFetch<ServerUsage>('/reader/tts/usage')
     }
     catch (error) {
       console.warn('[TTSTrialUsage] Failed to fetch server usage:', error)

--- a/pages/member.vue
+++ b/pages/member.vue
@@ -154,7 +154,7 @@ async function fetchAffiliateInfo() {
     return
   }
   try {
-    affiliateInfo.value = await $fetch<AffiliatePublicConfig>(`/api/affiliate/${encodeURIComponent(affiliateLikerId.value)}`)
+    affiliateInfo.value = await apiFetch<AffiliatePublicConfig>(`/affiliate/${encodeURIComponent(affiliateLikerId.value)}`)
   }
   catch { /* ignore */ }
 }

--- a/shared/utils/api.ts
+++ b/shared/utils/api.ts
@@ -1,6 +1,6 @@
 export function getLikeCoinAPIFetch() {
   const config = useRuntimeConfig()
-  return $fetch.create({ baseURL: config.public.likeCoinAPIEndpoint })
+  return createRetryingFetch({ baseURL: config.public.likeCoinAPIEndpoint })
 }
 
 export function fetchLikerProfileInfo(

--- a/shared/utils/collective-indexer.ts
+++ b/shared/utils/collective-indexer.ts
@@ -106,7 +106,7 @@ export interface CollectiveEventQueryResponse<T> {
 
 function getCollectiveIndexerAPIFetch() {
   const config = useRuntimeConfig()
-  return $fetch.create({ baseURL: config.public.likeCoinEVMChainCollectiveAPIEndpoint })
+  return createRetryingFetch({ baseURL: config.public.likeCoinEVMChainCollectiveAPIEndpoint })
 }
 
 export interface CollectiveQueryOptions {

--- a/shared/utils/fetch-retry.ts
+++ b/shared/utils/fetch-retry.ts
@@ -1,0 +1,40 @@
+import type { FetchOptions } from 'ofetch'
+
+/**
+ * Retry count for idempotent requests. The backoff curve in
+ * `createRetryingFetch` assumes every retrying request starts here, so a
+ * call site opting a POST into retry MUST pass exactly this value.
+ */
+export const API_MAX_RETRIES = 2
+
+/**
+ * Wraps `$fetch.create` with a method-aware retry policy.
+ *
+ * A transient network drop surfaces in ofetch as a `<no response>`
+ * error, which it treats as HTTP 500 and so retries when `retry > 0`.
+ * ofetch's defaults are conservative (GET/HEAD retry once, payload
+ * methods never), so an idempotent request on a flaky connection fails
+ * hard instead of recovering.
+ *
+ * Do NOT use for clients that perform financial / on-chain mutations
+ * (e.g. the LikeCoin session API) — a replayed purchase after a
+ * `<no response>` double-charges.
+ */
+export function createRetryingFetch(options: FetchOptions = {}) {
+  return $fetch.create({
+    ...options,
+    retryDelay({ options }) {
+      // Jittered exponential backoff; ofetch decrements `retry` per
+      // attempt, so (max - remaining) is the 0-indexed attempt.
+      const remaining = typeof options.retry === 'number' ? options.retry : 0
+      const attempt = Math.max(0, API_MAX_RETRIES - remaining)
+      return Math.min(300 * 2 ** attempt, 1500) + Math.floor(Math.random() * 150)
+    },
+    onRequest({ options }) {
+      if (options.retry === undefined) {
+        const method = (options.method ?? 'GET').toUpperCase()
+        options.retry = method === 'GET' || method === 'HEAD' ? API_MAX_RETRIES : 0
+      }
+    },
+  })
+}

--- a/shared/utils/indexer.ts
+++ b/shared/utils/indexer.ts
@@ -42,7 +42,7 @@ export interface FetchAccountByBookNFTResponseData {
 
 export function getIndexerAPIFetch() {
   const config = useRuntimeConfig()
-  return $fetch.create({ baseURL: config.public.likeCoinEVMChainAPIEndpoint })
+  return createRetryingFetch({ baseURL: config.public.likeCoinEVMChainAPIEndpoint })
 }
 
 export interface IndexerQueryOptions {

--- a/stores/account.ts
+++ b/stores/account.ts
@@ -508,8 +508,9 @@ export const useAccountStore = defineStore('account', () => {
       const signature = await signMessageAsync({ message })
 
       blockingModal.patch({ title: $t('account_logging_in') })
-      await $fetch('/api/login', {
+      await apiFetch('/login', {
         method: 'POST',
+        retry: API_MAX_RETRIES,
         body: {
           walletAddress,
           signature,
@@ -590,7 +591,7 @@ export const useAccountStore = defineStore('account', () => {
     blockingModal.open({ title: $t('account_logging_out') })
     try {
       await disconnectAsync()
-      await $fetch('/api/logout', { method: 'POST' })
+      await apiFetch('/logout', { method: 'POST', retry: API_MAX_RETRIES })
       await refreshSession()
       clearCaches()
       savePlusRedirectRoute(null)
@@ -610,7 +611,7 @@ export const useAccountStore = defineStore('account', () => {
     if (inFlightRefresh) return inFlightRefresh
     inFlightRefresh = (async () => {
       try {
-        await $fetch('/api/account/refresh', { method: 'POST' })
+        await apiFetch('/account/refresh', { method: 'POST', retry: API_MAX_RETRIES })
         await refreshSession()
         if (import.meta.client) {
           localStorage.setItem(SESSION_REFRESH_TIMESTAMP_KEY, String(Date.now()))

--- a/stores/book-list.ts
+++ b/stores/book-list.ts
@@ -8,7 +8,7 @@ export const useBookListStore = defineStore('book-list', () => {
   async function loadItems() {
     isLoading.value = true
     try {
-      const response = await $fetch<{ items: BookListItem[] }>('/api/book-list/all')
+      const response = await apiFetch<{ items: BookListItem[] }>('/book-list/all')
 
       itemsMap.value.clear()
       response.items.forEach((item: BookListItem) => {

--- a/stores/book-settings.ts
+++ b/stores/book-settings.ts
@@ -46,7 +46,7 @@ export const useBookSettingsStore = defineStore('book-settings', () => {
       return fetchPromisesMap.value[key]
     }
 
-    const fetchPromise = $fetch<BookSettingsData>('/api/books/settings', {
+    const fetchPromise = apiFetch<BookSettingsData>('/books/settings', {
       params: { nftClassId },
     }).then((settings) => {
       settingsMap.value[key] = {
@@ -94,7 +94,7 @@ export const useBookSettingsStore = defineStore('book-settings', () => {
         for (let i = 0; i < nftClassIdsToFetch.length; i += FIRESTORE_IN_OPERATOR_LIMIT) {
           if (isStale()) return
           const chunk = nftClassIdsToFetch.slice(i, i + FIRESTORE_IN_OPERATOR_LIMIT)
-          const settings = await $fetch<Record<string, BookSettingsData>>('/api/books/settings', {
+          const settings = await apiFetch<Record<string, BookSettingsData>>('/books/settings', {
             params: {
               nftClassIds: chunk,
             },
@@ -176,8 +176,9 @@ export const useBookSettingsStore = defineStore('book-settings', () => {
     queue.clear()
 
     try {
-      await $fetch(`/api/books/${nftClassId}/settings`, {
+      await apiFetch(`/books/${nftClassId}/settings`, {
         method: 'POST',
+        retry: API_MAX_RETRIES,
         body: updates,
       })
     }

--- a/stores/user-settings.ts
+++ b/stores/user-settings.ts
@@ -23,7 +23,7 @@ export const useUserSettingsStore = defineStore('user-settings', () => {
       return fetchPromise.value
     }
 
-    const promise = $fetch<UserSettingsData>('/api/user/settings')
+    const promise = apiFetch<UserSettingsData>('/user/settings')
       .then((settings) => {
         settingsEntry.value = {
           data: settings,
@@ -75,8 +75,9 @@ export const useUserSettingsStore = defineStore('user-settings', () => {
     const updates = Object.fromEntries(batchQueue.value.entries())
 
     try {
-      await $fetch('/api/user/settings', {
+      await apiFetch('/user/settings', {
         method: 'POST',
+        retry: API_MAX_RETRIES,
         body: updates,
       })
       batchQueue.value.clear()

--- a/utils/api.ts
+++ b/utils/api.ts
@@ -1,3 +1,11 @@
+/**
+ * Shared client for first-party `/api/*` Nitro routes, with the
+ * method-aware retry policy from `createRetryingFetch` (idempotent
+ * GET/HEAD retry twice on a `<no response>`; payload methods opt in
+ * via an explicit `retry`).
+ */
+export const apiFetch = createRetryingFetch({ baseURL: '/api' })
+
 export function fetchBookstoreCMSProductsByTagId(tagId: string, {
   offset,
   limit = 100,
@@ -7,7 +15,7 @@ export function fetchBookstoreCMSProductsByTagId(tagId: string, {
   limit?: number
   ts?: number
 } = {}) {
-  return $fetch<FetchBookstoreCMSProductsResponseData>('/api/store/products', {
+  return apiFetch<FetchBookstoreCMSProductsResponseData>('/store/products', {
     query: {
       tag: tagId,
       offset,
@@ -26,7 +34,7 @@ export function fetchBookstoreCMSPublicationsBySearchTerm(searchTerm: string, {
   limit?: number
   ts?: number
 } = {}) {
-  return $fetch<FetchBookstoreCMSProductsResponseData>('/api/store/search', {
+  return apiFetch<FetchBookstoreCMSProductsResponseData>('/store/search', {
     query: {
       q: searchTerm,
       offset,
@@ -45,7 +53,7 @@ export function fetchBookstoreCMSPublicationsByGenre(genre: string, {
   limit?: number
   ts?: number
 } = {}) {
-  return $fetch<FetchBookstoreCMSProductsResponseData>('/api/store/genre', {
+  return apiFetch<FetchBookstoreCMSProductsResponseData>('/store/genre', {
     query: {
       q: genre,
       offset,
@@ -64,7 +72,7 @@ export function fetchBookstoreCMSTagsForAll({
   limit?: number
   ts?: number
 } = {}) {
-  return $fetch<FetchBookstoreCMSTagsResponseData>('/api/store/tags', {
+  return apiFetch<FetchBookstoreCMSTagsResponseData>('/store/tags', {
     query: {
       offset,
       limit,
@@ -74,7 +82,7 @@ export function fetchBookstoreCMSTagsForAll({
 }
 
 export function fetchBookstoreCMSTagById(tagId: string) {
-  return $fetch<BookstoreCMSTag>(`/api/store/tags/${tagId}`)
+  return apiFetch<BookstoreCMSTag>(`/store/tags/${tagId}`)
 }
 
 export function getEncryptedArweaveLinkAPIEndpoint() {


### PR DESCRIPTION
ofetch surfaces a dropped connection as a <no response> error it treats as HTTP 500, but its defaults never retry payload methods — so a flaky network made login (and other idempotent POSTs) fail hard instead of recovering.

Add createRetryingFetch: a method-aware policy (GET/HEAD retry twice with jittered exponential backoff; payload methods opt in explicitly via API_MAX_RETRIES). Route first-party /api/* through apiFetch and the read-only LikeCoin clients through it too. The financial/on-chain session API is deliberately left untouched to avoid replayed purchases.