### PR TITLE
📈 Instrument TTS audio source to size cache vs Minimax

### DIFF
--- a/composables/use-text-to-speech.ts
+++ b/composables/use-text-to-speech.ts
@@ -223,6 +223,14 @@ export function useTextToSpeech(options: TTSOptions) {
     return classifyTTSCacheStatus(player.getCurrentURL())
   }
 
+  // Cost bucket for this segment load: browser_cache / cdn_or_storage are
+  // cheap, generated means a Minimax call. Native shell owns its own audio
+  // pipeline, so the source is opaque from the WebView.
+  function resolveAudioSource() {
+    if (isNativeBridge.value) return 'native' as const
+    return classifyTTSAudioSource(player.getCurrentURL())
+  }
+
   // Wire player events
   player.on('play', () => {
     isTextToSpeechPlaying.value = true
@@ -235,6 +243,7 @@ export function useTextToSpeech(options: TTSOptions) {
         had_buffering: timing.hadBuffering,
         is_first_segment: timing.index === 0,
         cache_status: resolveCacheStatus(),
+        audio_source: resolveAudioSource(),
       }))
     }
   })
@@ -312,6 +321,7 @@ export function useTextToSpeech(options: TTSOptions) {
         is_first_segment: timing.index === 0,
         error: formatTTSError(error),
         cache_status: resolveCacheStatus(),
+        audio_source: resolveAudioSource(),
       }))
     }
 

--- a/server/api/reader/tts.get.ts
+++ b/server/api/reader/tts.get.ts
@@ -3,10 +3,18 @@ import type { Writable } from 'node:stream'
 import type { H3Event } from 'h3'
 import { TTSQuerySchema } from '~/server/schemas/tts'
 import { computeLegacyTTSTextSig, computeTTSTextSig, decodeAffiliateVoiceId, isAffiliateVoiceId, TTS_PREVIEW_NFT_CLASS_ID } from '~/shared/utils/tts-sig'
+import { buildTTSServerTiming, TTS_SERVER_SOURCE, type TTSServerSource } from '~/shared/utils/tts-server-timing'
 
 // Coalesces concurrent identical TTS requests (e.g. browser range probes)
 const inFlightWrites = new Map<string, Promise<void>>()
 const IN_FLIGHT_TIMEOUT_MS = 120_000
+
+// Per-request source marker, read back client-side via
+// PerformanceResourceTiming.serverTiming on the tts_segment_loaded event to
+// size Cloud Storage cache hits vs expensive Minimax generations.
+function setTTSSourceHeader(event: H3Event, source: TTSServerSource) {
+  setHeader(event, 'server-timing', buildTTSServerTiming(source))
+}
 
 function getTTSProvider(voiceId: string): MinimaxTTSProvider {
   if (!KNOWN_VOICE_IDS.has(voiceId)) {
@@ -45,6 +53,7 @@ async function serveCachedTTS(
   setHeader(event, 'accept-ranges', 'bytes')
   setHeader(event, 'vary', 'Range')
   setHeader(event, 'etag', etag)
+  setTTSSourceHeader(event, TTS_SERVER_SOURCE.STORED)
 
   console.log(`[Speech] Cache hit for user ${wallet}: ${cacheKey}`)
 
@@ -310,6 +319,7 @@ export default defineEventHandler(async (event) => {
       setHeader(event, 'accept-ranges', 'bytes')
       setHeader(event, 'vary', 'Range')
       setHeader(event, 'etag', etag)
+      setTTSSourceHeader(event, TTS_SERVER_SOURCE.GENERATED)
 
       if (isCacheEnabled) {
         const cacheFile = bucket.file(cacheKey!)
@@ -351,6 +361,7 @@ export default defineEventHandler(async (event) => {
     }
     setHeader(event, 'content-type', provider.format)
     setHeader(event, 'cache-control', 'public, max-age=604800')
+    setTTSSourceHeader(event, TTS_SERVER_SOURCE.GENERATED)
 
     let cacheWriteStream: Writable | null = null
     if (isCacheEnabled) {

--- a/shared/utils/tts-server-timing.ts
+++ b/shared/utils/tts-server-timing.ts
@@ -1,0 +1,17 @@
+// Wire contract for the per-request TTS source marker. The server emits it as
+// a Server-Timing header on /api/reader/tts; the client reads it back via
+// PerformanceResourceTiming.serverTiming on the tts_segment_loaded event. Both
+// sides MUST go through these symbols — a mismatch degrades silently to an
+// 'unknown' classification with no error.
+export const TTS_SERVER_TIMING_METRIC = 'tts'
+
+export const TTS_SERVER_SOURCE = {
+  GENERATED: 'gen',
+  STORED: 'store',
+} as const
+
+export type TTSServerSource = typeof TTS_SERVER_SOURCE[keyof typeof TTS_SERVER_SOURCE]
+
+export function buildTTSServerTiming(source: TTSServerSource): string {
+  return `${TTS_SERVER_TIMING_METRIC};desc="${source}"`
+}

--- a/test/unit/tts.test.ts
+++ b/test/unit/tts.test.ts
@@ -12,6 +12,11 @@ import {
   computeLegacyTTSTextSig,
   computeTTSTextSig,
 } from '~/shared/utils/tts-sig'
+import {
+  buildTTSServerTiming,
+  TTS_SERVER_SOURCE,
+  TTS_SERVER_TIMING_METRIC,
+} from '~/shared/utils/tts-server-timing'
 
 describe('sanitizeTTSText', () => {
   it('returns empty string for falsy input', () => {
@@ -353,6 +358,44 @@ describe('computeTTSTextSig', () => {
     expect(computeTTSTextSig({ ...baseParams, ...overrides })).not.toBe(
       computeTTSTextSig(baseParams),
     )
+  })
+})
+
+describe('TTS Server-Timing wire contract', () => {
+  // The server (server/api/reader/tts.get.ts) and the client classifier
+  // (utils/resource-timing.ts) never share an import of each other's expected
+  // strings — they only agree via these symbols. A typo degrades silently to
+  // an 'unknown' classification with no error, so lock the literals here.
+  it('builds the exact wire format the client parses', () => {
+    expect(buildTTSServerTiming(TTS_SERVER_SOURCE.GENERATED)).toBe('tts;desc="gen"')
+    expect(buildTTSServerTiming(TTS_SERVER_SOURCE.STORED)).toBe('tts;desc="store"')
+  })
+
+  it('pins the metric name and source descriptors', () => {
+    expect(TTS_SERVER_TIMING_METRIC).toBe('tts')
+    expect(TTS_SERVER_SOURCE.GENERATED).toBe('gen')
+    expect(TTS_SERVER_SOURCE.STORED).toBe('store')
+  })
+
+  // Round-trip: parse the built header the way the browser exposes it via
+  // PerformanceResourceTiming.serverTiming, then run the client classifier's
+  // own comparison (utils/resource-timing.ts:69-71). This fails if either
+  // side drifts, before it can silently fall through to 'unknown'.
+  it('survives a server-build → browser-parse → client-classify round trip', () => {
+    function parseServerTiming(header: string) {
+      const [name, descPart] = header.split(';')
+      const description = descPart?.replace(/^desc="?|"?$/g, '') ?? ''
+      return { name, description }
+    }
+    function classify(header: string) {
+      const entry = parseServerTiming(header)
+      const desc = entry.name === TTS_SERVER_TIMING_METRIC ? entry.description : undefined
+      if (desc === TTS_SERVER_SOURCE.GENERATED) return 'generated'
+      if (desc === TTS_SERVER_SOURCE.STORED) return 'cdn_or_storage'
+      return 'unknown'
+    }
+    expect(classify(buildTTSServerTiming(TTS_SERVER_SOURCE.GENERATED))).toBe('generated')
+    expect(classify(buildTTSServerTiming(TTS_SERVER_SOURCE.STORED))).toBe('cdn_or_storage')
   })
 })
 

--- a/utils/resource-timing.ts
+++ b/utils/resource-timing.ts
@@ -1,4 +1,14 @@
+import { TTS_SERVER_SOURCE, TTS_SERVER_TIMING_METRIC } from '~~/shared/utils/tts-server-timing'
+
 export type TTSCacheStatus = 'hit' | 'miss' | 'unknown'
+
+// Where the audio bytes came from, in ascending cost order:
+// browser_cache (free) < cdn_or_storage (cheap) < generated (Minimax, $$$).
+// "cdn_or_storage" collapses the Cloudflare edge and Cloud Storage layers:
+// both serve a previously-stored file with Server-Timing desc="store", and a
+// media-element load cannot read cf-cache-status to tell them apart.
+// "native" is reported by the WebView shell, whose audio pipeline is opaque.
+export type TTSAudioSource = 'browser_cache' | 'cdn_or_storage' | 'generated' | 'native' | 'unknown'
 
 const TTS_URL_PATTERN = /\/api\/reader\/tts(?:\?|$)/
 const MAX_TRACKED_URLS = 200
@@ -30,14 +40,34 @@ function ensureObserver() {
   }
 }
 
-export function classifyTTSCacheStatus(audioURL: string): TTSCacheStatus {
-  if (!audioURL || typeof PerformanceObserver === 'undefined') return 'unknown'
+function getTTSResourceEntry(audioURL: string): PerformanceResourceTiming | undefined {
+  if (!audioURL || typeof PerformanceObserver === 'undefined') return undefined
   ensureObserver()
   // Buffered observer entries flush asynchronously, so on the first call
   // fall back to a synchronous query against the browser's resource buffer.
-  const entry = latestByURL.get(audioURL)
+  return latestByURL.get(audioURL)
     ?? (performance.getEntriesByName(audioURL, 'resource').at(-1) as PerformanceResourceTiming | undefined)
+}
+
+export function classifyTTSCacheStatus(audioURL: string): TTSCacheStatus {
+  const entry = getTTSResourceEntry(audioURL)
   // decodedBodySize === 0 means cross-origin without Timing-Allow-Origin
   if (!entry || entry.decodedBodySize === 0) return 'unknown'
   return entry.transferSize === 0 ? 'hit' : 'miss'
+}
+
+// Sizes the "expensive Minimax generation" slice of tts_segment_loaded.
+// transferSize === 0 wins first: a browser-cache replay has no fresh response
+// (and no Server-Timing), so it must be classified before reading the header.
+// Otherwise the origin's per-request Server-Timing desc decides: "gen" means a
+// Minimax call happened, "store" means a stored file (Cloud Storage, or a
+// Cloudflare edge HIT replaying the stored header) — see TTSAudioSource.
+export function classifyTTSAudioSource(audioURL: string): TTSAudioSource {
+  const entry = getTTSResourceEntry(audioURL)
+  if (!entry || entry.decodedBodySize === 0) return 'unknown'
+  if (entry.transferSize === 0) return 'browser_cache'
+  const desc = entry.serverTiming?.find(metric => metric.name === TTS_SERVER_TIMING_METRIC)?.description
+  if (desc === TTS_SERVER_SOURCE.GENERATED) return 'generated'
+  if (desc === TTS_SERVER_SOURCE.STORED) return 'cdn_or_storage'
+  return 'unknown'
 }


### PR DESCRIPTION
tts_segment_loaded carried no signal for whether a segment was a cheap cache hit or an expensive Minimax generation, so the prize for splitting TTS work was unknown. Origin now emits a per-request Server-Timing marker; the client reads it back via PerformanceResourceTiming and tags the event with audio_source (browser_cache / cdn_or_storage / generated / native). The gen/store contract lives in shared/utils so a server or client typo fails the build instead of degrading silently to 'unknown'.