### PR TITLE
🚀 Cache NFT metadata server-side to collapse blocking SSR fetch

### DIFF
--- a/server/api/nft/[nftClassId]/metadata.get.ts
+++ b/server/api/nft/[nftClassId]/metadata.get.ts
@@ -1,0 +1,50 @@
+import { FetchError } from 'ofetch'
+
+import type { LikeCoinNFTClassAggregatedMetadataOptionKey } from '~~/shared/utils/api'
+import { fetchLikeCoinNFTClassAggregatedMetadataById, likeCoinNFTClassAggregatedMetadataOptions, resolveLikeCoinNFTMetadataDataOptions } from '~~/shared/utils/api'
+import { NFTClassIdParamsSchema } from '~~/server/schemas/params'
+import { NFTMetadataQuerySchema } from '~~/server/schemas/nft'
+
+export default defineEventHandler(async (event) => {
+  const { nftClassId } = await getValidatedRouterParams(event, createValidator(NFTClassIdParamsSchema))
+  const query = await getValidatedQuery(event, createValidator(NFTMetadataQuerySchema))
+
+  const toArray = (value?: string | string[]) => (Array.isArray(value) ? value : value ? [value] : [])
+
+  const validOptionSet = new Set<string>(likeCoinNFTClassAggregatedMetadataOptions)
+  const requestedData = toArray(query.data)
+    .filter(option => validOptionSet.has(option)) as LikeCoinNFTClassAggregatedMetadataOptionKey[]
+  const dataOptions = resolveLikeCoinNFTMetadataDataOptions({
+    include: requestedData.length ? requestedData : undefined,
+  })
+  const isCacheDisabled = toArray(query.nocache)[0] === '1'
+
+  const fetcher = () => fetchLikeCoinNFTClassAggregatedMetadataById(nftClassId, {
+    include: dataOptions,
+    nocache: isCacheDisabled,
+  })
+
+  try {
+    if (isCacheDisabled) {
+      setHeader(event, 'cache-control', 'no-store')
+      return await fetcher()
+    }
+
+    const result = await fetchCachedNFTClassAggregatedMetadata(nftClassId, dataOptions)
+    setHeader(event, 'cache-control', 'public, max-age=60, stale-while-revalidate=600')
+    return result
+  }
+  catch (error) {
+    if (error instanceof FetchError && error.statusCode) {
+      throw createError({
+        statusCode: error.statusCode,
+        message: error.data?.error || 'NFT_METADATA_FETCH_FAILED',
+      })
+    }
+    console.error(error)
+    throw createError({
+      statusCode: 500,
+      statusMessage: 'UNEXPECTED_ERROR',
+    })
+  }
+})

--- a/server/api/nft/[nftClassId]/metadata.get.ts
+++ b/server/api/nft/[nftClassId]/metadata.get.ts
@@ -12,8 +12,16 @@ export default defineEventHandler(async (event) => {
   const toArray = (value?: string | string[]) => (Array.isArray(value) ? value : value ? [value] : [])
 
   const validOptionSet = new Set<string>(likeCoinNFTClassAggregatedMetadataOptions)
-  const requestedData = toArray(query.data)
-    .filter(option => validOptionSet.has(option)) as LikeCoinNFTClassAggregatedMetadataOptionKey[]
+  const requestedDataRaw = toArray(query.data)
+  const invalidRequestedData = requestedDataRaw.filter(option => !validOptionSet.has(option))
+  if (invalidRequestedData.length) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'INVALID_DATA_QUERY',
+      message: `Unsupported data option(s): ${invalidRequestedData.join(', ')}`,
+    })
+  }
+  const requestedData = requestedDataRaw as LikeCoinNFTClassAggregatedMetadataOptionKey[]
   const dataOptions = resolveLikeCoinNFTMetadataDataOptions({
     include: requestedData.length ? requestedData : undefined,
   })

--- a/server/schemas/nft.ts
+++ b/server/schemas/nft.ts
@@ -1,0 +1,6 @@
+import * as v from 'valibot'
+
+export const NFTMetadataQuerySchema = v.object({
+  data: v.optional(v.union([v.string(), v.array(v.string())])),
+  nocache: v.optional(v.union([v.string(), v.array(v.string())])),
+})

--- a/server/utils/likecoin-nft.ts
+++ b/server/utils/likecoin-nft.ts
@@ -1,0 +1,21 @@
+import type { LikeCoinNFTClassAggregatedMetadataOptionKey } from '~~/shared/utils/api'
+import { fetchLikeCoinNFTClassAggregatedMetadataById } from '~~/shared/utils/api'
+
+// Aggregated NFT metadata is book-level, not session-scoped, so a shared cache
+// is safe and does not affect per-user rendering. Stale-while-revalidate keeps
+// the upstream call off the SSR render path: past maxAge a render serves the
+// cached payload and revalidates in the background (a cold key still blocks
+// once). With the default in-memory cache driver this is per-instance — a
+// shared driver would be needed for global collapsing under scale-out.
+export const fetchCachedNFTClassAggregatedMetadata = defineCachedFunction(
+  (nftClassId: string, dataOptions: LikeCoinNFTClassAggregatedMetadataOptionKey[]) =>
+    fetchLikeCoinNFTClassAggregatedMetadataById(nftClassId, { include: dataOptions }),
+  {
+    name: 'likecoin-nft',
+    group: 'likecoin-nft',
+    swr: true,
+    maxAge: 60, // seconds
+    getKey: (nftClassId, dataOptions) =>
+      `${nftClassId.toLowerCase()}:${[...dataOptions].sort().join(',')}`,
+  },
+)

--- a/shared/utils/api.ts
+++ b/shared/utils/api.ts
@@ -74,19 +74,50 @@ export interface FetchLikeCoinNFTClassAggregatedMetadataResponseData {
   bookstoreInfo: BookstoreInfo | null
 }
 
+export function resolveLikeCoinNFTMetadataDataOptions(
+  options: FetchLikeCoinNFTClassAggregatedMetadataOptions = {},
+): LikeCoinNFTClassAggregatedMetadataOptionKey[] {
+  const included = new Set(options.include || likeCoinNFTClassAggregatedMetadataOptions)
+  const excluded = new Set(options.exclude || [])
+  return [...included].filter(option => !excluded.has(option))
+}
+
 export function fetchLikeCoinNFTClassAggregatedMetadataById(
   nftClassId: string,
   options: FetchLikeCoinNFTClassAggregatedMetadataOptions = { exclude: [], nocache: false },
 ) {
   const fetch = getLikeCoinAPIFetch()
-  const includedOptionSet = new Set(options.include || likeCoinNFTClassAggregatedMetadataOptions)
-  const excludedOptionSet = new Set(options.exclude || [])
   const query: Record<string, string | string[]> = {
     class_id: normalizeNFTClassId(nftClassId),
-    data: [...includedOptionSet].filter(option => !excludedOptionSet.has(option)),
+    data: resolveLikeCoinNFTMetadataDataOptions(options),
   }
   if (options.nocache) query.ts = `${Math.round(Date.now() / 1000)}`
   return fetch<FetchLikeCoinNFTClassAggregatedMetadataResponseData>('/likerland/nft/metadata', { query })
+}
+
+/**
+ * On the server, routes through our `/api/nft/:id/metadata` endpoint, which
+ * wraps the upstream call in a short shared cache to collapse the blocking SSR
+ * fetch (Cloud Run CPU). On the client it hits LikeCoin directly: the upstream
+ * is already Cloudflare-cached, so an extra hop through our server would only
+ * add latency. The payload is book-level (not session-scoped), so caching is
+ * safe and does not affect per-user rendering.
+ */
+export function fetchCachedLikeCoinNFTClassAggregatedMetadataById(
+  nftClassId: string,
+  options: FetchLikeCoinNFTClassAggregatedMetadataOptions = { exclude: [], nocache: false },
+) {
+  if (import.meta.client) {
+    return fetchLikeCoinNFTClassAggregatedMetadataById(nftClassId, options)
+  }
+  const query: Record<string, string | string[]> = {
+    data: resolveLikeCoinNFTMetadataDataOptions(options),
+  }
+  if (options.nocache) query.nocache = '1'
+  return $fetch<FetchLikeCoinNFTClassAggregatedMetadataResponseData>(
+    `/api/nft/${normalizeNFTClassId(nftClassId)}/metadata`,
+    { query },
+  )
 }
 
 export interface FetchBuyerMessageResponseData {

--- a/stores/nft.ts
+++ b/stores/nft.ts
@@ -40,7 +40,7 @@ export const useNFTStore = defineStore('nft', () => {
   }
 
   async function fetchNFTClassAggregatedMetadataById(nftClassId: string, options?: FetchLikeCoinNFTClassAggregatedMetadataOptions) {
-    const data = await fetchLikeCoinNFTClassAggregatedMetadataById(nftClassId, options)
+    const data = await fetchCachedLikeCoinNFTClassAggregatedMetadataById(nftClassId, options)
     if (data.classData) {
       addNFTClassMetadata(nftClassId, data.classData as NFTClassMetadata)
     }


### PR DESCRIPTION
Book/store SSR fetched aggregated NFT metadata fresh on every render, making the upstream LikeCoin call a CPU-bound stall on the dominant traffic class. Route the SSR fetch through /api/nft/:id/metadata, which wraps the upstream call in a short shared Nitro storage cache.

The payload is book-level (not session-scoped), so a shared cache is safe and per-user rendering is unaffected. The client keeps hitting LikeCoin directly — that endpoint is already Cloudflare-cached, so an extra hop through our server would only add latency. callOnce render mode + Pinia payload transfer mean no duplicate fetch or hydration mismatch from the server/client split.