### PR TITLE
[TAS-5561] 🐛 Retry idempotent cart claim on transient network drops

### DIFF
--- a/app/composables/use-likecoin-session-api.ts
+++ b/app/composables/use-likecoin-session-api.ts
@@ -112,7 +112,11 @@ export function useLikeCoinSessionAPI() {
     if (hasLoggedIn && user.value?.token) {
       fetchOptions.headers = { Authorization: `Bearer ${user.value?.token}` }
     }
-    return $fetch.create(fetchOptions)
+    // Method-aware retry: GET/HEAD recover from a transient `<no response>`,
+    // while payload methods stay no-retry by default so a dropped checkout
+    // POST (`purchase/cart/new`) is never replayed into a second payment.
+    // Idempotent POSTs opt in explicitly per call (see `claimCartById`).
+    return createRetryingFetch(fetchOptions)
   })
 
   function createNFTBookPurchase({
@@ -293,6 +297,10 @@ export function useLikeCoinSessionAPI() {
   function claimCartById({ cartId, token, paymentId, wallet }: { cartId: string, token: string, paymentId: string, wallet: string }) {
     return fetch.value<ClaimCartByIdResponseData>(`/likernft/book/purchase/cart/${cartId}/claim`, {
       method: 'POST',
+      // Idempotent: keyed on cartId/paymentId so a replay can't double-mint,
+      // and re-claiming returns CART_ALREADY_CLAIMED* which the claim page
+      // normalizes back into success.
+      retry: API_MAX_RETRIES,
       query: { token },
       body: { wallet, paymentId },
     })


### PR DESCRIPTION
0dbbf9ce deliberately left the LikeCoin session API no-retry to avoid replayed purchases. The post-payment cart claim is the safe exception: it is keyed on cartId/paymentId so a replay can't double-mint, and a re-claim returns CART_ALREADY_CLAIMED* which the claim page already normalizes into success — so a dropped <no response> now recovers instead of stranding a paid-but-unclaimed cart.

Route the session fetch through createRetryingFetch (GET/HEAD recover; payload methods stay no-retry by default, so purchase/cart/new is untouched) and opt claimCartById in explicitly via API_MAX_RETRIES.