### PR TITLE
[TAS-5820] ✨ Let yearly Plus subscribers pick their affiliate gift book

### DIFF
--- a/app/pages/member.vue
+++ b/app/pages/member.vue
@@ -53,9 +53,9 @@
             : 'pricing_page_affiliate_gift_label')"
         />
         <div
-          class="flex gap-3 py-6 -mx-2 px-2"
+          class="flex gap-3 py-3 -mx-3 px-3"
           :class="giftBooks.length > 2
-            ? 'overflow-x-auto snap-x'
+            ? 'overflow-x-auto snap-x scroll-px-3'
             : 'justify-center'"
           role="radiogroup"
           aria-labelledby="affiliate-gift-picker-label"
@@ -77,7 +77,6 @@
               class="w-16"
               :src="getGiftBookCover(book.cover)"
               :alt="book.name || `${$t('pricing_page_affiliate_gift_label')} ${index + 1}`"
-              has-shadow
             />
             <span
               v-if="book.classId === selectedGiftClassId"

--- a/app/pages/member.vue
+++ b/app/pages/member.vue
@@ -52,16 +52,16 @@
             : 'pricing_page_affiliate_gift_label')"
         />
         <div
-          class="flex gap-3 py-2 -mx-1 px-1"
+          class="flex gap-3 py-6 -mx-2 px-2"
           :class="giftBooks.length > 2
             ? 'overflow-x-auto snap-x'
             : 'justify-center'"
         >
           <button
-            v-for="book in giftBooks"
+            v-for="(book, index) in giftBooks"
             :key="book.classId"
             type="button"
-            class="relative shrink-0 snap-start rounded-md transition-all duration-150 cursor-pointer"
+            class="relative shrink-0 snap-start rounded-md transition-all duration-150 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
             :class="book.classId === selectedGiftClassId
               ? 'ring-2 ring-primary scale-105'
               : 'opacity-50 hover:opacity-90'"
@@ -70,8 +70,8 @@
           >
             <BookCover
               class="w-16"
-              :src="giftBookCover(book.cover)"
-              :alt="book.name || $t('pricing_page_affiliate_gift_label')"
+              :src="getGiftBookCover(book.cover)"
+              :alt="book.name || `${$t('pricing_page_affiliate_gift_label')} ${index + 1}`"
               has-shadow
             />
             <span
@@ -183,7 +183,7 @@ watch(giftBooks, (books) => {
 const selectedGiftBook = computed(() =>
   giftBooks.value.find(b => b.classId === selectedGiftClassId.value),
 )
-function giftBookCover(src?: string) {
+function getGiftBookCover(src?: string) {
   return src ? getResizedNormalizedImageURL(src, { size: 300 }) : ''
 }
 

--- a/app/pages/member.vue
+++ b/app/pages/member.vue
@@ -47,27 +47,55 @@
       >
         <p
           class="text-sm font-medium text-toned mb-3"
-          v-text="$t('pricing_page_affiliate_gift_label')"
+          v-text="$t(giftBooks.length > 1
+            ? 'pricing_page_affiliate_gift_select_label'
+            : 'pricing_page_affiliate_gift_label')"
         />
-        <div class="flex items-center justify-center gap-3">
-          <BookCover
-            class="w-12 shrink-0"
-            :src="giftBookCoverSrc"
-            :alt="activeAffiliate.giftBookName || $t('pricing_page_affiliate_gift_label')"
-            has-shadow
+        <div
+          class="flex gap-3 py-2 -mx-1 px-1"
+          :class="giftBooks.length > 2
+            ? 'overflow-x-auto snap-x'
+            : 'justify-center'"
+        >
+          <button
+            v-for="book in giftBooks"
+            :key="book.classId"
+            type="button"
+            class="relative shrink-0 snap-start rounded-md transition-all duration-150 cursor-pointer"
+            :class="book.classId === selectedGiftClassId
+              ? 'ring-2 ring-primary scale-105'
+              : 'opacity-50 hover:opacity-90'"
+            :aria-pressed="book.classId === selectedGiftClassId"
+            @click="selectedGiftClassId = book.classId"
+          >
+            <BookCover
+              class="w-16"
+              :src="giftBookCover(book.cover)"
+              :alt="book.name || $t('pricing_page_affiliate_gift_label')"
+              has-shadow
+            />
+            <span
+              v-if="book.classId === selectedGiftClassId"
+              class="absolute -top-1.5 -right-1.5 flex items-center justify-center w-5 h-5 rounded-full bg-primary text-inverted"
+            >
+              <UIcon
+                name="i-material-symbols-check-rounded"
+                class="w-3.5 h-3.5"
+              />
+            </span>
+          </button>
+        </div>
+        <div class="mt-3 text-center">
+          <p
+            v-if="selectedGiftBook?.name"
+            class="text-sm font-bold text-highlighted"
+            v-text="selectedGiftBook.name"
           />
-          <div class="text-left">
-            <p
-              v-if="activeAffiliate.giftBookName"
-              class="text-sm font-bold text-highlighted"
-              v-text="activeAffiliate.giftBookName"
-            />
-            <p
-              v-if="affiliateVoiceNames"
-              class="text-xs text-muted"
-              v-text="$t('pricing_page_affiliate_voice_label', { name: affiliateVoiceNames })"
-            />
-          </div>
+          <p
+            v-if="affiliateVoiceNames"
+            class="text-xs text-muted"
+            v-text="$t('pricing_page_affiliate_voice_label', { name: affiliateVoiceNames })"
+          />
         </div>
       </UCard>
     </template>
@@ -143,10 +171,21 @@ const affiliateVoiceNames = computed(() => {
 const affiliateSampleVoices = computed(() => activeAffiliate.value?.customVoices ?? [])
 
 const { getResizedNormalizedImageURL } = useImageResize()
-const giftBookCoverSrc = computed(() => {
-  const src = activeAffiliate.value?.giftBookCover
+const giftBooks = computed(() => activeAffiliate.value?.giftBooks ?? [])
+const selectedGiftClassId = ref<string | undefined>(undefined)
+// Default to the first book and keep the pick valid as the list changes
+// (e.g. when the affiliate link / config loads asynchronously).
+watch(giftBooks, (books) => {
+  if (!books.some(b => b.classId === selectedGiftClassId.value)) {
+    selectedGiftClassId.value = books[0]?.classId
+  }
+}, { immediate: true })
+const selectedGiftBook = computed(() =>
+  giftBooks.value.find(b => b.classId === selectedGiftClassId.value),
+)
+function giftBookCover(src?: string) {
   return src ? getResizedNormalizedImageURL(src, { size: 300 }) : ''
-})
+}
 
 async function fetchAffiliateInfo() {
   if (!affiliateLikerId.value) {
@@ -299,7 +338,7 @@ const trialPeriodDays = computed(() => {
 
 const isAffiliateGiftRedeemable = computed(() => {
   const info = activeAffiliate.value
-  if (!info?.giftClassId) return false
+  if (!info?.giftBooks?.length) return false
   if (selectedPlan.value !== 'yearly') return false
   if (info.giftOnTrial === false && trialPeriodDays.value !== 0) return false
   return true
@@ -365,6 +404,11 @@ async function handleSubscribe(payload: {
   await checkout.startSubscription({
     ...payload,
     coupon: coupon.value,
+    // Carry the subscriber's chosen gift book; the API validates it against
+    // the affiliate's gift list and resolves the (free) price index itself.
+    nftClassId: isAffiliateGiftRedeemable.value
+      ? selectedGiftClassId.value
+      : undefined,
   })
 }
 

--- a/app/pages/member.vue
+++ b/app/pages/member.vue
@@ -46,6 +46,7 @@
         variant="subtle"
       >
         <p
+          id="affiliate-gift-picker-label"
           class="text-sm font-medium text-toned mb-3"
           v-text="$t(giftBooks.length > 1
             ? 'pricing_page_affiliate_gift_select_label'
@@ -56,16 +57,20 @@
           :class="giftBooks.length > 2
             ? 'overflow-x-auto snap-x'
             : 'justify-center'"
+          role="radiogroup"
+          aria-labelledby="affiliate-gift-picker-label"
         >
           <button
             v-for="(book, index) in giftBooks"
             :key="book.classId"
             type="button"
+            role="radio"
             class="relative shrink-0 snap-start rounded-md transition-all duration-150 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
             :class="book.classId === selectedGiftClassId
               ? 'ring-2 ring-primary scale-105'
               : 'opacity-50 hover:opacity-90'"
-            :aria-pressed="book.classId === selectedGiftClassId"
+            :aria-checked="book.classId === selectedGiftClassId"
+            :tabindex="(selectedGiftClassId ? book.classId === selectedGiftClassId : index === 0) ? 0 : -1"
             @click="selectedGiftClassId = book.classId"
           >
             <BookCover

--- a/app/pages/member.vue
+++ b/app/pages/member.vue
@@ -54,43 +54,70 @@
             : 'pricing_page_affiliate_gift_label')"
         />
 
-        <div
-          class="flex items-end gap-3 px-4 sm:px-6 pt-6 pb-12 scroll-px-4 sm:scroll-px-6 scrollbar-none"
-          :class="giftBooks.length > 2
-            ? 'overflow-x-auto snap-x'
-            : 'justify-center'"
-          role="radiogroup"
-          aria-labelledby="affiliate-gift-picker-label"
-        >
-          <button
-            v-for="(book, index) in giftBooks"
-            :key="book.classId"
-            type="button"
-            role="radio"
-            class="relative block shrink-0 snap-start rounded-lg transition-all duration-150 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
-            :class="book.classId === selectedGiftClassId
-              ? 'ring-2 ring-primary scale-105'
-              : 'opacity-50 hover:opacity-90'"
-            :aria-checked="book.classId === selectedGiftClassId"
-            :tabindex="(selectedGiftClassId ? book.classId === selectedGiftClassId : index === 0) ? 0 : -1"
-            @click="selectedGiftClassId = book.classId"
+        <div class="relative">
+          <UButton
+            v-if="isGiftsListScrollable && hasMoreGiftsLeft"
+            class="absolute left-1 top-1/2 -translate-y-1/2 z-10 cursor-pointer rounded-full bg-default/90 shadow-md hover:bg-default"
+            icon="i-material-symbols-chevron-left-rounded"
+            color="neutral"
+            variant="ghost"
+            size="sm"
+            square
+            :aria-label="$t('pricing_page_affiliate_gift_scroll_prev')"
+            @click="scrollGiftsList(-1)"
+          />
+
+          <div
+            ref="giftsListEl"
+            class="flex items-end gap-3 px-4 sm:px-6 pt-6 pb-12 scroll-px-4 sm:scroll-px-6 scrollbar-none"
+            :class="isGiftsListScrollable
+              ? 'overflow-x-auto snap-x'
+              : 'justify-center'"
+            role="radiogroup"
+            aria-labelledby="affiliate-gift-picker-label"
           >
-            <BookCover
-              class="w-16 aspect-auto"
-              :src="getGiftBookCover(book.cover)"
-              :alt="book.name || `${$t('pricing_page_affiliate_gift_label')} ${index + 1}`"
-              has-shadow
-            />
-            <span
-              v-if="book.classId === selectedGiftClassId"
-              class="absolute top-0 right-0 flex items-center justify-center w-5 h-5 rounded-full bg-primary text-inverted translate-x-1/2 -translate-y-1/2"
+            <button
+              v-for="(book, index) in giftBooks"
+              :key="book.classId"
+              type="button"
+              role="radio"
+              class="relative block shrink-0 snap-start rounded-lg transition-all duration-150 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+              :class="book.classId === selectedGiftClassId
+                ? 'ring-2 ring-primary scale-105'
+                : 'opacity-50 hover:opacity-90'"
+              :aria-checked="book.classId === selectedGiftClassId"
+              :tabindex="(selectedGiftClassId ? book.classId === selectedGiftClassId : index === 0) ? 0 : -1"
+              @click="selectedGiftClassId = book.classId"
             >
-              <UIcon
-                name="i-material-symbols-check-rounded"
-                class="w-3.5 h-3.5"
+              <BookCover
+                class="w-16 aspect-auto"
+                :src="getGiftBookCover(book.cover)"
+                :alt="book.name || `${$t('pricing_page_affiliate_gift_label')} ${index + 1}`"
+                has-shadow
               />
-            </span>
-          </button>
+              <span
+                v-if="book.classId === selectedGiftClassId"
+                class="absolute top-0 right-0 flex items-center justify-center w-5 h-5 rounded-full bg-primary text-inverted translate-x-1/2 -translate-y-1/2"
+              >
+                <UIcon
+                  name="i-material-symbols-check-rounded"
+                  class="w-3.5 h-3.5 text-theme-cyan"
+                />
+              </span>
+            </button>
+          </div>
+
+          <UButton
+            v-if="isGiftsListScrollable && hasMoreGiftsRight"
+            class="absolute right-1 top-1/2 -translate-y-1/2 z-10 cursor-pointer rounded-full bg-default/90 shadow-md hover:bg-default"
+            icon="i-material-symbols-chevron-right-rounded"
+            color="neutral"
+            variant="ghost"
+            size="sm"
+            square
+            :aria-label="$t('pricing_page_affiliate_gift_scroll_next')"
+            @click="scrollGiftsList(1)"
+          />
         </div>
 
         <div class="-mt-3 px-4 sm:px-6 text-center">
@@ -193,6 +220,24 @@ const selectedGiftBook = computed(() =>
 )
 function getGiftBookCover(src?: string) {
   return src ? getResizedNormalizedImageURL(src, { size: 300 }) : ''
+}
+
+const isGiftsListScrollable = computed(() => giftBooks.value.length > 2)
+const giftsListEl = useTemplateRef<HTMLElement>('giftsListEl')
+const { arrivedState: giftsListArrivedState, measure: measureGiftsListScroll } = useScroll(giftsListEl)
+const hasMoreGiftsLeft = computed(() => !giftsListArrivedState.left)
+const hasMoreGiftsRight = computed(() => !giftsListArrivedState.right)
+
+useResizeObserver(giftsListEl, () => measureGiftsListScroll())
+watch(giftBooks, async () => {
+  await nextTick()
+  measureGiftsListScroll()
+})
+
+function scrollGiftsList(direction: -1 | 1) {
+  const el = giftsListEl.value
+  if (!el) return
+  el.scrollBy({ left: el.clientWidth * 0.7 * direction, behavior: 'smooth' })
 }
 
 async function fetchAffiliateInfo() {

--- a/app/pages/member.vue
+++ b/app/pages/member.vue
@@ -44,18 +44,20 @@
       <UCard
         class="mt-4"
         variant="subtle"
+        :ui="{ body: 'px-0 sm:px-0' }"
       >
-        <p
+        <h3
           id="affiliate-gift-picker-label"
-          class="text-sm font-medium text-toned mb-3"
+          class="px-4 sm:px-6 text-sm font-medium text-toned mb-3"
           v-text="$t(giftBooks.length > 1
             ? 'pricing_page_affiliate_gift_select_label'
             : 'pricing_page_affiliate_gift_label')"
         />
+
         <div
-          class="flex gap-3 py-3 -mx-3 px-3"
+          class="flex items-end gap-3 px-4 sm:px-6 pt-6 pb-12 scroll-px-4 sm:scroll-px-6 scrollbar-none"
           :class="giftBooks.length > 2
-            ? 'overflow-x-auto snap-x scroll-px-3'
+            ? 'overflow-x-auto snap-x'
             : 'justify-center'"
           role="radiogroup"
           aria-labelledby="affiliate-gift-picker-label"
@@ -65,7 +67,7 @@
             :key="book.classId"
             type="button"
             role="radio"
-            class="relative shrink-0 snap-start rounded-md transition-all duration-150 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+            class="relative block shrink-0 snap-start rounded-lg transition-all duration-150 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
             :class="book.classId === selectedGiftClassId
               ? 'ring-2 ring-primary scale-105'
               : 'opacity-50 hover:opacity-90'"
@@ -74,13 +76,14 @@
             @click="selectedGiftClassId = book.classId"
           >
             <BookCover
-              class="w-16"
+              class="w-16 aspect-auto"
               :src="getGiftBookCover(book.cover)"
               :alt="book.name || `${$t('pricing_page_affiliate_gift_label')} ${index + 1}`"
+              has-shadow
             />
             <span
               v-if="book.classId === selectedGiftClassId"
-              class="absolute -top-1.5 -right-1.5 flex items-center justify-center w-5 h-5 rounded-full bg-primary text-inverted"
+              class="absolute top-0 right-0 flex items-center justify-center w-5 h-5 rounded-full bg-primary text-inverted translate-x-1/2 -translate-y-1/2"
             >
               <UIcon
                 name="i-material-symbols-check-rounded"
@@ -89,7 +92,8 @@
             </span>
           </button>
         </div>
-        <div class="mt-3 text-center">
+
+        <div class="-mt-3 px-4 sm:px-6 text-center">
           <p
             v-if="selectedGiftBook?.name"
             class="text-sm font-bold text-highlighted"

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -625,6 +625,7 @@
   "plus_subscribe_cta_yearly_gift": "Subscribe yearly — this book is free",
   "price_free": "Free",
   "pricing_page_affiliate_gift_label": "Subscribe yearly and get a free book",
+  "pricing_page_affiliate_gift_select_label": "Choose your free book",
   "pricing_page_affiliate_voice_label": "Includes exclusive {name} narration",
   "pricing_page_coupon_applied_description": "The final discount will be calculated and shown at checkout.",
   "pricing_page_coupon_applied_title": "Coupon {code} has been applied",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -625,6 +625,8 @@
   "plus_subscribe_cta_yearly_gift": "Subscribe yearly — this book is free",
   "price_free": "Free",
   "pricing_page_affiliate_gift_label": "Subscribe yearly and get a free book",
+  "pricing_page_affiliate_gift_scroll_next": "See more books",
+  "pricing_page_affiliate_gift_scroll_prev": "See previous books",
   "pricing_page_affiliate_gift_select_label": "Choose your free book",
   "pricing_page_affiliate_voice_label": "Includes exclusive {name} narration",
   "pricing_page_coupon_applied_description": "The final discount will be calculated and shown at checkout.",

--- a/i18n/locales/zh-Hant.json
+++ b/i18n/locales/zh-Hant.json
@@ -625,6 +625,7 @@
   "plus_subscribe_cta_yearly_gift": "年費訂閱，免費獲得本書",
   "price_free": "免費",
   "pricing_page_affiliate_gift_label": "訂閱年費即可免費獲得書籍",
+  "pricing_page_affiliate_gift_select_label": "選擇你的免費書籍",
   "pricing_page_affiliate_voice_label": "附帶 {name} 專屬語音朗讀",
   "pricing_page_coupon_applied_description": "最終折扣將在結帳時計算並顯示。",
   "pricing_page_coupon_applied_title": "已套用優惠碼 {code}",

--- a/i18n/locales/zh-Hant.json
+++ b/i18n/locales/zh-Hant.json
@@ -625,6 +625,8 @@
   "plus_subscribe_cta_yearly_gift": "年費訂閱，免費獲得本書",
   "price_free": "免費",
   "pricing_page_affiliate_gift_label": "訂閱年費即可免費獲得書籍",
+  "pricing_page_affiliate_gift_scroll_next": "查看更多書籍",
+  "pricing_page_affiliate_gift_scroll_prev": "查看前面書籍",
   "pricing_page_affiliate_gift_select_label": "選擇你的免費書籍",
   "pricing_page_affiliate_voice_label": "附帶 {name} 專屬語音朗讀",
   "pricing_page_coupon_applied_description": "最終折扣將在結帳時計算並顯示。",

--- a/server/api/affiliate/[likerId].get.ts
+++ b/server/api/affiliate/[likerId].get.ts
@@ -1,6 +1,6 @@
 import type { AffiliatePublicConfig } from '~~/shared/types/affiliate'
 import { getAffiliateConfig, getAffiliatePlusDiscountAllowed } from '~~/server/utils/affiliate'
-import { fetchLikeCoinNFTClassAggregatedMetadataById } from '~~/shared/utils/api'
+import { fetchCachedNFTClassAggregatedMetadata } from '~~/server/utils/likecoin-nft'
 
 export default defineEventHandler(async (event): Promise<AffiliatePublicConfig> => {
   const likerId = getRouterParam(event, 'likerId')
@@ -16,26 +16,31 @@ export default defineEventHandler(async (event): Promise<AffiliatePublicConfig> 
     return { active: false, isPlusDiscountAllowed }
   }
 
-  let giftBookName: string | undefined
-  let giftBookCover: string | undefined
-
-  if (config.giftClassId) {
-    try {
-      const metadata = await fetchLikeCoinNFTClassAggregatedMetadataById(
-        config.giftClassId,
-        { include: ['bookstore'] },
-      )
-      giftBookName = metadata?.bookstoreInfo?.name
-      giftBookCover = metadata?.bookstoreInfo?.thumbnailUrl
-    }
-    catch { /* ignore */ }
-  }
+  const giftBooks = await Promise.all(
+    (config.giftBooks ?? []).map(async (book) => {
+      let name: string | undefined
+      let cover: string | undefined
+      try {
+        const metadata = await fetchCachedNFTClassAggregatedMetadata(
+          book.classId,
+          ['bookstore'],
+        )
+        name = metadata?.bookstoreInfo?.name
+        cover = metadata?.bookstoreInfo?.thumbnailUrl
+      }
+      catch { /* ignore */ }
+      return {
+        classId: book.classId,
+        priceIndex: book.priceIndex,
+        name,
+        cover,
+      }
+    }),
+  )
 
   return {
     active: true,
-    giftClassId: config.giftClassId,
-    giftBookName,
-    giftBookCover,
+    giftBooks,
     giftOnTrial: config.giftOnTrial,
     isPlusDiscountAllowed,
     affiliateClassIds: config.affiliateClassIds,

--- a/server/types/affiliate.d.ts
+++ b/server/types/affiliate.d.ts
@@ -7,11 +7,15 @@ export interface AffiliateCustomVoice {
   providerVoiceId: string
 }
 
+export interface AffiliateGiftBook {
+  classId: string
+  priceIndex: number
+}
+
 export interface AffiliateConfig {
   active: boolean
   affiliateClassIds: string[]
-  giftClassId?: string
-  giftPriceIndex?: number
+  giftBooks?: AffiliateGiftBook[]
   giftOnTrial?: boolean
   customVoices: AffiliateCustomVoice[]
 }

--- a/server/utils/affiliate.ts
+++ b/server/utils/affiliate.ts
@@ -1,4 +1,5 @@
 import type { AffiliateConfig, AffiliateCustomVoice } from '~~/server/types/affiliate'
+import { normalizeNFTClassId } from '~~/shared/utils'
 import { getLikeCoinAPIFetch } from '~~/shared/utils/api'
 import { normalizeLikerId } from '~~/shared/utils/liker-id'
 
@@ -43,7 +44,13 @@ async function getAffiliateEntry(likerId: string): Promise<AffiliateEntry | null
               affiliateClassIds: (upstream.affiliateClassIds ?? []).map(id => id.toLowerCase()),
               giftBooks: (upstream.giftBooks ?? [])
                 .filter(b => typeof b?.classId === 'string' && !!b.classId)
-                .map(b => ({ classId: b.classId, priceIndex: b.priceIndex || 0 })),
+                .map((b) => {
+                  const priceIndex = Number(b.priceIndex)
+                  return {
+                    classId: normalizeNFTClassId(b.classId),
+                    priceIndex: Number.isInteger(priceIndex) && priceIndex >= 0 ? priceIndex : 0,
+                  }
+                }),
               giftOnTrial: upstream.giftOnTrial,
               customVoices: (upstream.customVoices ?? []).filter(isValidCustomVoice),
             }

--- a/server/utils/affiliate.ts
+++ b/server/utils/affiliate.ts
@@ -41,8 +41,9 @@ async function getAffiliateEntry(likerId: string): Promise<AffiliateEntry | null
           ? {
               active: true,
               affiliateClassIds: (upstream.affiliateClassIds ?? []).map(id => id.toLowerCase()),
-              giftClassId: upstream.giftClassId,
-              giftPriceIndex: upstream.giftPriceIndex,
+              giftBooks: (upstream.giftBooks ?? [])
+                .filter(b => typeof b?.classId === 'string' && !!b.classId)
+                .map(b => ({ classId: b.classId, priceIndex: b.priceIndex || 0 })),
               giftOnTrial: upstream.giftOnTrial,
               customVoices: (upstream.customVoices ?? []).filter(isValidCustomVoice),
             }

--- a/shared/types/affiliate.d.ts
+++ b/shared/types/affiliate.d.ts
@@ -1,5 +1,12 @@
 import type { AffiliateVoiceData } from '~~/shared/types/custom-voice'
 
+export interface AffiliatePublicGiftBook {
+  classId: string
+  priceIndex: number
+  name?: string
+  cover?: string
+}
+
 export type AffiliatePublicConfig =
   | {
     active: false
@@ -7,9 +14,7 @@ export type AffiliatePublicConfig =
   }
   | {
     active: true
-    giftClassId?: string
-    giftBookName?: string
-    giftBookCover?: string
+    giftBooks?: AffiliatePublicGiftBook[]
     giftOnTrial?: boolean
     isPlusDiscountAllowed?: boolean
     affiliateClassIds: string[]


### PR DESCRIPTION
The affiliate config now carries a giftBooks list instead of a single gift; the member pricing page shows the books as a horizontal scrollable cover list with an obvious selected-state highlight, defaulting to the first book. The chosen classId is passed to checkout. Per-book bookstore metadata now goes through the cached SWR fetcher so a multi-book list doesn't fan out uncached upstream calls on every affiliate page load.
<img width="472" height="309" alt="image" src="https://github.com/user-attachments/assets/c0299e55-a9e2-41dc-9091-b838f80ae0f0" />

Requires: https://github.com/likecoin/likecoin-api-public/pull/1262