### PR TITLE
🐛 Fix TTS opening at the wrong section in the EPUB reader

### DIFF
--- a/app/composables/use-tts-player-modal.ts
+++ b/app/composables/use-tts-player-modal.ts
@@ -88,38 +88,66 @@ export function useTTSPlayerModal(options: TTSPlayerOptions) {
       }
     }
 
+    // First TTS segment of the reader's current section (0 when there's no
+    // section or it has no segments). Used by the cfi fallbacks and the
+    // no-page-cfi path.
+    const firstSegmentOfSection = () => sectionIndex !== undefined
+      ? Math.max(ttsSegments.value.findIndex(segment => segment.sectionIndex >= sectionIndex), 0)
+      : 0
+
     if (ttsIndex !== undefined && !isStoredIndexStale) {
       startIndex.value = ttsIndex
     }
-    else if (sectionIndex !== undefined || cfi) {
+    else if (cfi) {
+      const segments = ttsSegments.value
       let segmentIndex = 0
-      if (sectionIndex !== undefined) {
-        segmentIndex = ttsSegments.value.findIndex(
-          segment => segment.sectionIndex >= sectionIndex,
-        )
-        segmentIndex = Math.max(segmentIndex, 0)
-      }
-      if (cfi) {
-        // Constrain the cfi search to the current section. Without this,
-        // when the user's section has few or no matching segments, the
-        // search would silently resolve into the next chapter.
-        const sectionToStayIn = ttsSegments.value[segmentIndex]?.sectionIndex
-        let foundIndex = -1
-        for (let i = segmentIndex; i < ttsSegments.value.length; i++) {
-          const segment = ttsSegments.value[i]
-          if (!segment) continue
-          if (sectionToStayIn !== undefined && segment.sectionIndex > sectionToStayIn) break
-          if (segment.cfi && epubCFI.compare(segment.cfi, cfi) >= 0) {
-            foundIndex = i
-            break
+      try {
+        // epub.js can report an inconsistent page range — start cfi *after*
+        // end cfi — for a reflowable chapter wedged between fixed-layout
+        // image spreads. The page cfi is then garbage, so anchor on the
+        // section the reader actually opened.
+        if (pageEndCFI && epubCFI.compare(cfi, pageEndCFI) > 0) {
+          segmentIndex = firstSegmentOfSection()
+        }
+        else {
+          // Anchor on the page-start cfi across ALL segments, not a
+          // `sectionIndex >= currentSection` seed: a cfi embeds its spine
+          // position so it still resolves when the current spine item has no
+          // segments (full-page image spreads between text pages), whereas
+          // the seed could only skip forward to the next text section
+          // ("read → listen jumps to next section" bug).
+          const pageCFI = new EpubCFI(cfi)
+          let lastAtOrBefore = -1
+          let firstAfter = -1
+          for (let i = 0; i < segments.length; i++) {
+            const segmentCFI = segments[i]?.cfi
+            if (!segmentCFI) continue // cfi is optional on TTSSegment
+            if (epubCFI.compare(segmentCFI, pageCFI) <= 0) {
+              lastAtOrBefore = i
+            }
+            else {
+              firstAfter = i
+              break
+            }
+          }
+          segmentIndex = lastAtOrBefore >= 0 ? lastAtOrBefore : Math.max(firstAfter, 0)
+          // A block split into multiple segments shares one element cfi; rewind
+          // to the first so playback starts at the block top, not mid-way.
+          const anchorCFI = segments[segmentIndex]?.cfi
+          while (segmentIndex > 0 && segments[segmentIndex - 1]?.cfi === anchorCFI) {
+            segmentIndex--
           }
         }
-        if (foundIndex > segmentIndex) {
-          // Retrieve the previous segment for better UX, as the segment might span multiple pages
-          segmentIndex = foundIndex - 1
-        }
+      }
+      catch {
+        // Malformed/unsupported cfi — fall back to the section start.
+        segmentIndex = firstSegmentOfSection()
       }
       startIndex.value = segmentIndex
+    }
+    else if (sectionIndex !== undefined) {
+      // No rendered page cfi to anchor on — fall back to the section start.
+      startIndex.value = firstSegmentOfSection()
     }
     else {
       startIndex.value = 0

--- a/app/composables/use-tts-player-modal.ts
+++ b/app/composables/use-tts-player-modal.ts
@@ -78,8 +78,7 @@ export function useTTSPlayerModal(options: TTSPlayerOptions) {
     let isStoredIndexStale = false
     if (storedSegmentCFI && cfi && pageEndCFI) {
       try {
-        isStoredIndexStale = epubCFI.compare(storedSegmentCFI, cfi) < 0
-          || epubCFI.compare(storedSegmentCFI, pageEndCFI) > 0
+        isStoredIndexStale = !isCFIWithinPageRange(epubCFI, storedSegmentCFI, cfi, pageEndCFI)
       }
       catch {
         // Treat malformed/unsupported CFIs as stale so we fall back to the
@@ -88,12 +87,19 @@ export function useTTSPlayerModal(options: TTSPlayerOptions) {
       }
     }
 
-    // First TTS segment of the reader's current section (0 when there's no
-    // section or it has no segments). Used by the cfi fallbacks and the
-    // no-page-cfi path.
-    const firstSegmentOfSection = () => sectionIndex !== undefined
-      ? Math.max(ttsSegments.value.findIndex(segment => segment.sectionIndex >= sectionIndex), 0)
-      : 0
+    // First TTS segment at or after the reader's current section (so an
+    // image-only section with no segments resolves to the next section that
+    // has them). 0 when there's no section index; when the section is past
+    // every segment (e.g. trailing image-only pages) fall back to the last
+    // segment rather than restarting from the book's start. Used by the cfi
+    // fallbacks and the no-page-cfi path.
+    const firstSegmentOfSection = () => {
+      if (sectionIndex === undefined || ttsSegments.value.length === 0) return 0
+      const index = ttsSegments.value.findIndex(
+        segment => segment.sectionIndex >= sectionIndex,
+      )
+      return index === -1 ? ttsSegments.value.length - 1 : index
+    }
 
     if (ttsIndex !== undefined && !isStoredIndexStale) {
       startIndex.value = ttsIndex

--- a/app/pages/reader/epub.vue
+++ b/app/pages/reader/epub.vue
@@ -938,8 +938,10 @@ async function loadEPub() {
   // Clear stale TTS index from previous session so it doesn't override current page position
   activeTTSElementIndex.value = undefined
 
-  rendition.value.on('rendered', (section: Section, view: EpubView) => {
-    currentSectionIndex.value = section.index ?? 0
+  rendition.value.on('rendered', (_section: Section, view: EpubView) => {
+    // `rendered` fires for sections epub.js pre-renders into its paging
+    // buffer, so this can be a neighbour, not the visible page — the section
+    // index comes from the authoritative `relocated` handler instead.
     renditionViewWindow.value = view.window
     isPageLoading.value = false
     isWrittenFromRightToLeft.value = view.settings.direction === 'rtl'
@@ -1090,6 +1092,8 @@ async function loadEPub() {
     isPageLoading.value = false
     currentPageStartCfi.value = location.start.cfi
     currentPageEndCfi.value = location.end.cfi
+    // Authoritative section of the visible page (see the `rendered` handler).
+    currentSectionIndex.value = location.start.index
     const href = location.start.href
     currentPageHref.value = href
     activeNavItemHref.value = resolveActiveNavItemHref(href)
@@ -1097,6 +1101,11 @@ async function loadEPub() {
     // segment-accurate position, while `relocated` only sees the page start
     // (and stale data while the modal covers the reader on native).
     if (isTTSQueryParam.value) return
+    // Any read-mode page change invalidates a persisted TTS index: the user
+    // has read past where playback last was, so the next listen resumes from
+    // this page via the cfi lookup. relocated is the single choke point that
+    // also covers swipe, reflow and native-shell turns.
+    activeTTSElementIndex.value = undefined
     percentage.value = book.locations!.percentageFromCfi(location.start.cfi) ?? 0
     currentCfi.value = location.start.cfi
     readingProgress.value = percentage.value

--- a/app/pages/reader/epub.vue
+++ b/app/pages/reader/epub.vue
@@ -1093,6 +1093,10 @@ async function loadEPub() {
     const href = location.start.href
     currentPageHref.value = href
     activeNavItemHref.value = resolveActiveNavItemHref(href)
+    // During listen mode `onSegmentChange` owns progress: it writes the
+    // segment-accurate position, while `relocated` only sees the page start
+    // (and stale data while the modal covers the reader on native).
+    if (isTTSQueryParam.value) return
     percentage.value = book.locations!.percentageFromCfi(location.start.cfi) ?? 0
     currentCfi.value = location.start.cfi
     readingProgress.value = percentage.value

--- a/app/pages/reader/epub.vue
+++ b/app/pages/reader/epub.vue
@@ -538,10 +538,11 @@ let pendingTTSDisplayCfi: string | null = null
 const epubCFI = new EpubCFI()
 
 function isSegmentOnCurrentPage(segmentCfi: string): boolean {
-  if (!currentPageStartCfi.value || !currentPageEndCfi.value) return false
+  const start = currentPageStartCfi.value
+  const end = currentPageEndCfi.value
+  if (!start || !end) return false
   try {
-    return epubCFI.compare(segmentCfi, currentPageStartCfi.value) >= 0
-      && epubCFI.compare(segmentCfi, currentPageEndCfi.value) <= 0
+    return isCFIWithinPageRange(epubCFI, segmentCfi, start, end)
   }
   catch {
     return false

--- a/app/utils/epub.ts
+++ b/app/utils/epub.ts
@@ -1,6 +1,25 @@
 import { EpubCFI } from '@likecoin/epub-ts'
 
 /**
+ * Whether `cfi` lies within the page span bounded by `pageBoundA` and
+ * `pageBoundB` (inclusive), without assuming which bound is the lower one.
+ * epub.js can report a page's start cfi *after* its end cfi for a reflowable
+ * chapter wedged between fixed-layout image spreads, so the membership test
+ * must be order-agnostic. May throw on a malformed cfi (via `compare`);
+ * callers guard with try/catch.
+ */
+export function isCFIWithinPageRange(
+  epubCFI: EpubCFI,
+  cfi: string,
+  pageBoundA: string,
+  pageBoundB: string,
+): boolean {
+  const a = epubCFI.compare(cfi, pageBoundA)
+  const b = epubCFI.compare(cfi, pageBoundB)
+  return (a >= 0 && b <= 0) || (a <= 0 && b >= 0)
+}
+
+/**
  * Resolve the first text node at or after the DOM position (container, offset).
  * For element containers, `offset` indexes into childNodes per the DOM Range spec,
  * so we advance to the child at that index (or past the container entirely).


### PR DESCRIPTION
Fixes a family of bugs where Text-to-Speech started or resumed at the wrong place in the EPUB reader — most visibly in **fixed-layout / illustrated books**, where epub.js mis-reports section indices and page CFIs

### Commits

1. **🐛 Stop stale relocations from rewinding listen-mode progress** (`fc1cceef`)
   During playback the `relocated` handler raced `onSegmentChange`, overwriting the segment-accurate position with the page-start CFI (or stale data while the modal covers the reader fullscreen on native). Guards the progress writes on `isTTSQueryParam` so `onSegmentChange` owns progress during listen mode, while keeping page-bound refs fresh for TTS page navigation.

2. **🐛 Source reader section index from relocated, not rendered** (`c3d3ea04`)
   `currentSectionIndex` came from the `rendered` event, which also fires for epub.js's pre-rendered neighbour sections — on mobile it could sit a chapter ahead, so Listen opened TTS in a later chapter. Source it from `relocated`'s `location.start.index` (same event as the page CFIs), and clear the persisted TTS index on read-mode relocation so a later Listen resumes from the current page.

3. **🐛 Resolve TTS start by page cfi, fall back to section** (`43936dfe`)
   `openPlayer` seeded the start segment with `findIndex(sectionIndex >= current)`, which can only resolve forward. Fixed-layout / illustrated EPUBs interleave full-page image spine items (zero TTS segments) with text items, so reading text → swiping to the facing image → Listen skipped a section ahead. Now anchors on the page-start CFI across all segments (a CFI embeds its spine position, so it resolves through empty image sections), falling back to the section start when the page range is unusable.

4. **🐛 Order-agnostic page-range cfi test for inverted epub.js spans** (`14615eb4`)
   epub.js can report a page's start CFI *after* its end CFI for a reflowable chapter wedged between fixed-layout image spreads. Two range checks (`isSegmentOnCurrentPage`, the `openPlayer` staleness check) assumed `start <= end` and silently broke (TTS needlessly re-navigating every segment; a still-visible stored index judged stale). Extracted a shared `isCFIWithinPageRange` that tests membership without assuming bound order — no behavior change for normal pages.

### Verification

- Typecheck, lint, and the unit suite (52 tests) pass.
- Commits 3 & 4 verified with `@likecoin/epub-ts` in happy-dom against the real problem EPUB and the captured on-device diagnostic CFIs — image-page, inverted-range, valid mid-chapter, chapter-top, and malformed-cfi cases all resolve correctly.

### Note

The root cause of the inverted / incorrect spans is upstream in epub.js's `location` computation for mixed fixed-layout + reflowable books. Commits 3–4 are robust consumer-side guards; worth filing upstream against `@likecoin/epub-ts` so these eventually become pure defense-in-depth.
