### PR TITLE
[TAS-5900] 🐛 Drop iOS preconnect that poisons WKWebView connection pool

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -32,7 +32,7 @@ const { memberProgramData } = useMemberProgramStructuredData()
 const { initializeServerGeolocation, initializeClientGeolocation } = useDetectedGeolocation()
 const { initializePaymentCurrency } = usePaymentCurrency()
 const { initializeLocale } = useAutoLocale()
-const { isApp } = useAppDetection()
+const { isApp, isIOS } = useAppDetection()
 
 callOnce(() => {
   initializeServerGeolocation()
@@ -193,7 +193,11 @@ useHead({
       rel: 'me',
       href: 'https://www.threads.com/@3ookcom',
     },
-    ...(likeCoinAPIEndpoint
+    // Skip on iOS: priming WKWebView's app-level NSURLSession pool with a
+    // cross-origin CORS preconnect can wedge a poisoned connection that fails
+    // every later $fetch with "Load failed: <no response>" until the app is
+    // killed — reload alone doesn't recover it.
+    ...(likeCoinAPIEndpoint && !isIOS.value
       ? [{ rel: 'preconnect', href: likeCoinAPIEndpoint, crossorigin: '', key: 'preconnect-like-api' }]
       : []),
     ...(likeCoinStaticEndpoint

--- a/app/pages/store/index.vue
+++ b/app/pages/store/index.vue
@@ -782,17 +782,10 @@ useHead(() => {
       crossorigin: 'anonymous' as const,
       key: 'preload-store-tags',
     },
-    // Skip cross-origin `<link rel="preload" as="fetch" crossorigin>` on iOS:
-    // WebKit fails to match it to the subsequent $fetch and the request errors
-    // out with "Load failed: <no response>". Preconnect warms TLS without the bug.
-    ...(isStakingTagId.value && isIOS.value && collectiveEndpoint
-      ? [{
-          rel: 'preconnect' as const,
-          href: new URL(collectiveEndpoint).origin,
-          crossorigin: '' as const,
-          key: 'preconnect-collective-indexer',
-        }]
-      : []),
+    // No resource hint for the cross-origin indexer on iOS: priming WKWebView's
+    // app-level NSURLSession pool (preload OR preconnect) can wedge a poisoned
+    // connection that fails every later fetch with "Load failed: <no response>"
+    // until the app is killed — reload alone doesn't recover it.
     ...(isStakingTagId.value && !isIOS.value
       ? [{
           rel: 'preload',


### PR DESCRIPTION
The earlier preload→preconnect swap still wedges the popular tab on iOS: WKWebView holds connections in an app-level NSURLSession pool that survives page reloads, so priming it (preload OR preconnect) can leave a poisoned connection failing every later indexer fetch with "Load failed: <no response>" until the app is killed — which is why a reload doesn't recover it.

Emit no resource hint for the cross-origin indexer on iOS; let the $fetch open its own connection cold. Non-iOS keeps the preload.