### PR TITLE
♻️ Bound book-file cache growth with LRU eviction

### DIFF
--- a/app/composables/use-book-file-loader.ts
+++ b/app/composables/use-book-file-loader.ts
@@ -1,6 +1,7 @@
 export default function () {
   const { t: $t } = useI18n()
   const { user } = useUserSession()
+  const config = useRuntimeConfig()
 
   const loadingFilesize = ref(0)
   const loadedFilesize = ref(0)
@@ -28,11 +29,18 @@ export default function () {
     loadedFilesize.value = 0
 
     let res
+    let cachePutPromise: Promise<boolean> | undefined
     const req = new Request(url)
     if (cacheKey && window.caches) {
       try {
         const cache = await caches.open(cacheKey)
         res = await cache.match(req)
+        if (res) {
+          touchBookFileCacheEntry({
+            cacheKeyPrefix: config.public.cacheKeyPrefix,
+            cacheKey,
+          })
+        }
       }
       catch (error) {
         console.error(error)
@@ -61,12 +69,42 @@ export default function () {
       if (cacheKey && window.caches) {
         try {
           const cache = await caches.open(cacheKey)
-          cache.put(req, res.clone())
+          // Fire-and-forget: awaiting would drain the clone before our own
+          // stream loop starts, forcing the tee to buffer the whole response.
+          // On failure we delete the now-empty cache that caches.open() just
+          // created; otherwise pruneBookFileCaches would treat it as live and
+          // keep the index entry, inflating the LRU total.
+          cachePutPromise = cache.put(req, res.clone())
+            .then(() => true)
+            .catch((error) => {
+              console.error(error)
+              return caches.delete(cacheKey).catch(console.error).then(() => false)
+            })
         }
         catch (error) {
           console.error(error)
         }
       }
+    }
+
+    // Deferred until the body has finished streaming, since the byte size is
+    // only known then. Prune reuses the index record() just wrote so opening
+    // a book parses the localStorage index once, not twice.
+    function registerCachedFile(size: number) {
+      if (!cacheKey || !cachePutPromise) return
+      void cachePutPromise.then((didCache) => {
+        if (!didCache) return
+        const index = recordBookFileCacheEntry({
+          cacheKeyPrefix: config.public.cacheKeyPrefix,
+          cacheKey,
+          size,
+        })
+        void pruneBookFileCaches({
+          cacheKeyPrefix: config.public.cacheKeyPrefix,
+          keepCacheKey: cacheKey,
+          index,
+        })
+      })
     }
 
     const streamReader = res?.body?.getReader()
@@ -103,6 +141,7 @@ export default function () {
         loadedFilesize.value = offset
       }
       if (!overflow) {
+        registerCachedFile(offset)
         return offset < buffer.length
           ? buffer.buffer.slice(0, offset)
           : buffer.buffer
@@ -114,6 +153,7 @@ export default function () {
         combined.set(chunk, pos)
         pos += chunk.length
       }
+      registerCachedFile(offset)
       return combined.buffer
     }
 
@@ -135,6 +175,7 @@ export default function () {
       position += chunk.length
     }
 
+    registerCachedFile(receivedLength)
     return combinedChunks.buffer
   }
 

--- a/app/stores/account.ts
+++ b/app/stores/account.ts
@@ -578,6 +578,8 @@ export const useAccountStore = defineStore('account', () => {
         })
       })
 
+      window.localStorage.removeItem(getBookFileCacheIndexKey(config.public.cacheKeyPrefix))
+
       getTTSConfigKeySuffixes().forEach((suffix) => {
         window.localStorage.removeItem(getTTSConfigKeyWithSuffix(TTS_CONFIG_KEY, suffix))
       })

--- a/app/utils/reader.ts
+++ b/app/utils/reader.ts
@@ -24,6 +24,172 @@ export function getReaderCacheKeyWithSuffix(key: string, suffix: ReaderCacheKeyS
 }
 
 /**
+ * Total byte budget for cached EPUB/PDF book files. The Cache API has no
+ * built-in quota eviction, so we run an LRU sweep to stay under this limit.
+ * 500 MB holds dozens of books while staying within typical browser/WebView
+ * storage quotas.
+ */
+export const BOOK_FILE_CACHE_MAX_BYTES = 500 * 1024 * 1024
+
+// Skip a recency write if the entry was already touched within this window —
+// re-reads during a session would otherwise rewrite the index repeatedly.
+const BOOK_FILE_CACHE_TOUCH_INTERVAL_MS = 60 * 1000
+
+type BookFileCacheIndex = Record<string, { size: number, lastOpened: number }>
+
+/**
+ * Recency lives in this localStorage sidecar, not in the Cache entry (which
+ * has no timestamp), so the LRU sweep never has to read or re-parse blobs.
+ */
+export function getBookFileCacheIndexKey(cacheKeyPrefix: string): string {
+  return [cacheKeyPrefix, READER_CACHE_KEY, 'cache-index'].join('-')
+}
+
+function readBookFileCacheIndex(cacheKeyPrefix: string): BookFileCacheIndex {
+  if (typeof window === 'undefined' || !window.localStorage) return {}
+  try {
+    const raw = window.localStorage.getItem(getBookFileCacheIndexKey(cacheKeyPrefix))
+    if (!raw) return {}
+    const parsed = JSON.parse(raw)
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {}
+    // Coerce each entry — a single NaN size would make the eviction total NaN
+    // and silently disable the LRU sweep that this index exists to support.
+    const sanitized: BookFileCacheIndex = {}
+    for (const [key, value] of Object.entries(parsed)) {
+      if (!value || typeof value !== 'object' || Array.isArray(value)) continue
+      const size = Number((value as { size?: unknown }).size)
+      const lastOpened = Number((value as { lastOpened?: unknown }).lastOpened)
+      if (!Number.isFinite(size) || !Number.isFinite(lastOpened)) continue
+      sanitized[key] = { size, lastOpened }
+    }
+    return sanitized
+  }
+  catch {
+    return {}
+  }
+}
+
+function writeBookFileCacheIndex(cacheKeyPrefix: string, index: BookFileCacheIndex) {
+  if (typeof window === 'undefined' || !window.localStorage) return
+  try {
+    window.localStorage.setItem(getBookFileCacheIndexKey(cacheKeyPrefix), JSON.stringify(index))
+  }
+  catch (error) {
+    console.error(error)
+  }
+}
+
+/**
+ * Record a freshly cached book file. Returns the updated index so the caller
+ * can hand it to pruneBookFileCaches without a second localStorage read.
+ */
+export function recordBookFileCacheEntry({
+  cacheKeyPrefix,
+  cacheKey,
+  size,
+}: {
+  cacheKeyPrefix: string
+  cacheKey: string
+  size: number
+}): BookFileCacheIndex {
+  const index = readBookFileCacheIndex(cacheKeyPrefix)
+  index[cacheKey] = { size, lastOpened: Date.now() }
+  writeBookFileCacheIndex(cacheKeyPrefix, index)
+  return index
+}
+
+/**
+ * Bump recency for a cache hit (no cache.put runs) so an actively re-read
+ * book is not evicted as "old". Upserts a zero-size entry if metadata was
+ * lost, mirroring pruneBookFileCaches' reconcile.
+ */
+export function touchBookFileCacheEntry({
+  cacheKeyPrefix,
+  cacheKey,
+}: {
+  cacheKeyPrefix: string
+  cacheKey: string
+}) {
+  const index = readBookFileCacheIndex(cacheKeyPrefix)
+  const entry = index[cacheKey]
+  const now = Date.now()
+  if (entry && now - entry.lastOpened < BOOK_FILE_CACHE_TOUCH_INTERVAL_MS) return
+  index[cacheKey] = { size: entry?.size ?? 0, lastOpened: now }
+  writeBookFileCacheIndex(cacheKeyPrefix, index)
+}
+
+/**
+ * LRU sweep over cached book files. Reconciles the index with the real
+ * CacheStorage, then — if the total exceeds BOOK_FILE_CACHE_MAX_BYTES —
+ * deletes the least-recently-opened book caches until back under budget.
+ * The currently-open book (keepCacheKey) is never evicted. Safe to call
+ * fire-and-forget; failures are swallowed.
+ */
+export async function pruneBookFileCaches({
+  cacheKeyPrefix,
+  keepCacheKey,
+  maxBytes = BOOK_FILE_CACHE_MAX_BYTES,
+  index: providedIndex,
+}: {
+  cacheKeyPrefix: string
+  keepCacheKey?: string
+  maxBytes?: number
+  index?: BookFileCacheIndex
+}) {
+  if (typeof window === 'undefined' || !window.caches) return
+  try {
+    const bookCachePrefix = [cacheKeyPrefix, READER_CACHE_KEY].join('-')
+    const liveNames = new Set(
+      (await window.caches.keys()).filter(name => name.startsWith(bookCachePrefix)),
+    )
+
+    const stored = providedIndex ?? readBookFileCacheIndex(cacheKeyPrefix)
+
+    // Keep only entries whose cache still exists; synthesize entries for
+    // caches with lost metadata as just-opened so a valid book is never
+    // evicted on a guess (the next fresh download records its real size).
+    let didChange = false
+    const index: BookFileCacheIndex = {}
+    for (const name of liveNames) {
+      const entry = stored[name]
+      if (entry) index[name] = entry
+      else {
+        index[name] = { size: 0, lastOpened: Date.now() }
+        didChange = true
+      }
+    }
+    if (!didChange) {
+      didChange = Object.keys(stored).some(name => !liveNames.has(name))
+    }
+
+    let total = Object.values(index).reduce((sum, entry) => sum + entry.size, 0)
+    const evicted = new Set<string>()
+    if (total > maxBytes) {
+      const evictable = Object.entries(index)
+        .filter(([name]) => name !== keepCacheKey)
+        .sort((a, b) => a[1].lastOpened - b[1].lastOpened)
+
+      for (const [name, entry] of evictable) {
+        if (total <= maxBytes) break
+        await window.caches.delete(name)
+        evicted.add(name)
+        total -= entry.size
+      }
+    }
+
+    if (!didChange && evicted.size === 0) return
+
+    const next = evicted.size
+      ? Object.fromEntries(Object.entries(index).filter(([name]) => !evicted.has(name)))
+      : index
+    writeBookFileCacheIndex(cacheKeyPrefix, next)
+  }
+  catch (error) {
+    console.error(error)
+  }
+}
+
+/**
  * Get localStorage key prefix for book progress/config (per NFT class, not per NFT ID)
  * Progress is tracked at the book level, not individual NFT level
  */


### PR DESCRIPTION
The manual Cache API for EPUB/PDF files had no quota eviction, so storage grew unbounded until a user manually cleared it. Add a localStorage sidecar index (size + last-opened per book cache) and an LRU sweep that runs after each fresh download, evicting the least-recently-opened books past a 500 MB budget. Recency lives in the sidecar since Cache entries have no timestamp; the sweep reconciles against real CacheStorage so externally cleared caches self-heal and a valid book is never evicted on a guess.