### PR TITLE
🔥 Retire tts-try-modal-cantonese-voice A/B test

### DIFF
--- a/app/components/TTSTryModal.vue
+++ b/app/components/TTSTryModal.vue
@@ -72,11 +72,6 @@ const { t: $t } = useI18n()
 const { setTTSLanguageVoice } = useTTSVoice()
 const { samples: ttsSamples } = useTTSSamplesPlayer()
 
-const cantoneseVoiceABTest = useABTest({
-  experimentKey: 'tts-try-modal-cantonese-voice',
-})
-const isPhoebeVariant = computed(() => cantoneseVoiceABTest.isVariant('test'))
-
 function handleRemindMeLater() {
   emit('snooze')
 }
@@ -86,17 +81,13 @@ function handleDismiss() {
 }
 
 function handleVoiceClick(sample: { id: string, languageVoice: string }) {
-  const { id: sampleId, languageVoice: sampleLanguageVoice } = sample
-  const languageVoice = sampleLanguageVoice === 'zh-HK_pazu' && isPhoebeVariant.value
-    ? 'zh-HK_phoebe'
-    : sampleLanguageVoice
+  const { id: sampleId, languageVoice } = sample
 
   setTTSLanguageVoice(languageVoice)
   useLogEvent('tts_try_voice_selected', {
     nft_class_id: props.nftClassId,
     sample: sampleId,
     languageVoice,
-    ab_variant: cantoneseVoiceABTest.variant.value,
   })
   emit('voiceSelected', languageVoice)
 }
@@ -105,7 +96,6 @@ onMounted(() => {
   emit('open')
   useLogEvent('tts_try_modal_open', {
     nft_class_id: props.nftClassId,
-    ab_variant: cantoneseVoiceABTest.variant.value,
   })
 })
 

--- a/app/composables/use-tts-try-modal.ts
+++ b/app/composables/use-tts-try-modal.ts
@@ -11,9 +11,6 @@ interface TTSTryModalState {
 export function useTTSTryModal() {
   const { user } = useUserSession()
   const overlay = useOverlay()
-  const cantoneseVoiceABTest = useABTest({
-    experimentKey: 'tts-try-modal-cantonese-voice',
-  })
 
   const state = useStorage<TTSTryModalState>(TTS_TRY_MODAL_KEY, {
     shouldOffer: true,
@@ -64,7 +61,6 @@ export function useTTSTryModal() {
           snoozeTTSTryModal()
           useLogEvent('tts_try_snoozed', {
             nft_class_id: options.nftClassId,
-            ab_variant: cantoneseVoiceABTest.variant.value,
           })
           modal.close()
           options.onSnooze?.()
@@ -73,7 +69,6 @@ export function useTTSTryModal() {
           dismissTTSTryModal()
           useLogEvent('tts_try_dismissed', {
             nft_class_id: options.nftClassId,
-            ab_variant: cantoneseVoiceABTest.variant.value,
           })
           modal.close()
           options.onDismiss?.()


### PR DESCRIPTION
Experiment 367584 ended in PostHog; drop the useABTest wiring and revert to the control behaviour (selected sample's own voice, no zh-HK_pazu → zh-HK_phoebe swap). Also strip the now-meaningless ab_variant property from the TTS-try analytics events.