### PR TITLE
🐛 Keep fullwidth CJK punctuation through the TTS pipeline

### DIFF
--- a/app/utils/tts.ts
+++ b/app/utils/tts.ts
@@ -1,14 +1,22 @@
+// Fullwidth letters/digits/symbols (ＡＢＣ, １２３, ＊, （）) trip up Minimax,
+// so the fullwidth sweep normalizes them to basic ASCII. Fullwidth CJK
+// punctuation is excluded: ，；：！？ are the correct, prosody-bearing
+// forms for a Chinese-first engine — flattening them to ASCII flattens
+// intonation, and for ，；： also drops the clause boundary that server-side
+// injectTTSPauseMarkers depends on. 。、 are not in the fullwidth block,
+// so they are untouched.
+const FULLWIDTH_PUNCT_KEEP = new Set(['！', '，', '：', '；', '？'])
+
 export function sanitizeTTSText(text: string): string {
   if (!text) return ''
   return text
-    // Normalize fullwidth ASCII (U+FF01–U+FF5E) to basic ASCII
     .replace(/[\uFF01-\uFF5E]/g, c =>
-      String.fromCharCode(c.charCodeAt(0) - 0xFEE0))
+      FULLWIDTH_PUNCT_KEEP.has(c) ? c : String.fromCharCode(c.charCodeAt(0) - 0xFEE0))
     .replace(/^\s*-{2,}\s*$/gm, '')
     .replace(/^\s*\.+\s*$/gm, '')
     .replace(/[*]/g, '')
     .replace(/[⋯︙…]+/g, '。')
-    .replace(/[—─―︱⸺]+/g, ',')
+    .replace(/[—─―︱⸺]+/g, '，')
     .replace(/﹁/g, '「')
     .replace(/﹂/g, '」')
     .replace(/﹃/g, '『')

--- a/server/utils/tts-minimax.ts
+++ b/server/utils/tts-minimax.ts
@@ -69,18 +69,21 @@ export function getMinimaxModel(options: {
 // Minimax inline-pause syntax: <#seconds#>. 0.01s is imperceptible.
 const TTS_PAUSE_MARKER = '<#0.01#>'
 
-// Minimax speech-2.x degrades the rest of a synthesis call into garbled,
-// unintelligible noise when it hits an unpronounceable glyph; a pause marker
-// bounds that corruption to the clause between markers. Minimax also rejects
-// consecutive and trailing markers, so
-// we collapse punctuation runs and require a speakable char after. The
-// lookahead stays intentionally narrow: skipping a quote-opened clause only
-// weakens protection, but a looser test could emit a marker before a trailing
-// 」 with no speakable text after — the exact invalid input this avoids.
-// Segments arrive pre-split/speakable, so the run always has speakable text
-// before it.
-function injectTTSPauseMarkers(text: string): string {
-  return text.replace(/([，。]+)(?=\s*[\p{L}\p{N}])/gu, `$1${TTS_PAUSE_MARKER}`)
+// Minimax speech-2.x degrades the rest of a synthesis call into garbled noise
+// when it hits an unpronounceable glyph; a pause marker bounds that corruption
+// to the clause between markers. Minimax rejects consecutive and trailing
+// markers, so we collapse punctuation runs and require a speakable char after
+// (segments arrive pre-split/speakable, so there is a speakable char before
+// the run too). The narrow lookahead avoids emitting a marker before a
+// trailing 」 with no speakable text after — the exact invalid input Minimax
+// rejects. The class is the fullwidth/CJK clause set only: 。、 are CJK and
+// never normalized, and sanitizeTTSText keeps ，；： fullwidth (see its
+// comment for why). ASCII ,;: are excluded so Latin tokens like "12:30" or
+// "e.g.," don't get spurious markers.
+const TTS_PAUSE_BOUNDARY_RE = /([，。、；：]+)(?=\s*[\p{L}\p{N}])/gu
+
+export function injectTTSPauseMarkers(text: string): string {
+  return text.replace(TTS_PAUSE_BOUNDARY_RE, `$1${TTS_PAUSE_MARKER}`)
 }
 
 export class MinimaxTTSProvider implements BaseTTSProvider {

--- a/test/unit/tts-minimax.test.ts
+++ b/test/unit/tts-minimax.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { injectTTSPauseMarkers } from '~~/server/utils/tts-minimax'
+
+const MARKER = '<#0.01#>'
+
+describe('injectTTSPauseMarkers', () => {
+  it('inserts a pause marker after fullwidth/CJK clause punctuation', () => {
+    expect(injectTTSPauseMarkers('好，壞')).toBe(`好，${MARKER}壞`)
+    expect(injectTTSPauseMarkers('好。壞')).toBe(`好。${MARKER}壞`)
+    expect(injectTTSPauseMarkers('甲、乙')).toBe(`甲、${MARKER}乙`)
+    expect(injectTTSPauseMarkers('好；壞')).toBe(`好；${MARKER}壞`)
+    expect(injectTTSPauseMarkers('好：壞')).toBe(`好：${MARKER}壞`)
+  })
+
+  it('does not insert markers for ASCII , ; : (Latin tokens stay intact)', () => {
+    expect(injectTTSPauseMarkers('12:30')).toBe('12:30')
+    expect(injectTTSPauseMarkers('e.g., word')).toBe('e.g., word')
+    expect(injectTTSPauseMarkers('a, b; c')).toBe('a, b; c')
+  })
+
+  it('collapses punctuation runs into a single marker', () => {
+    expect(injectTTSPauseMarkers('好。。壞')).toBe(`好。。${MARKER}壞`)
+    expect(injectTTSPauseMarkers('好，。壞')).toBe(`好，。${MARKER}壞`)
+  })
+
+  it('does not emit a marker when no speakable char follows', () => {
+    expect(injectTTSPauseMarkers('好。')).toBe('好。')
+    expect(injectTTSPauseMarkers('好，」')).toBe('好，」')
+  })
+
+  it('skips intervening whitespace when checking for a speakable char', () => {
+    expect(injectTTSPauseMarkers('好。 壞')).toBe(`好。${MARKER} 壞`)
+  })
+})

--- a/test/unit/tts.test.ts
+++ b/test/unit/tts.test.ts
@@ -31,6 +31,14 @@ describe('sanitizeTTSText', () => {
     expect(sanitizeTTSText('＊')).toBe('')
   })
 
+  it('keeps fullwidth CJK punctuation for Minimax prosody', () => {
+    expect(sanitizeTTSText('好，壞；對：錯！嗎？')).toBe('好，壞；對：錯！嗎？')
+  })
+
+  it('normalizes fullwidth alphanumerics adjacent to kept punctuation', () => {
+    expect(sanitizeTTSText('Ａ，Ｂ；１２３')).toBe('A，B；123')
+  })
+
   it('removes asterisks including normalized fullwidth ones', () => {
     expect(sanitizeTTSText('**bold**')).toBe('bold')
     expect(sanitizeTTSText('＊重點＊')).toBe('重點')
@@ -62,12 +70,13 @@ describe('sanitizeTTSText', () => {
     expect(sanitizeTTSText('好⋯⋯⋯')).toBe('好。')
   })
 
-  // Regression: 3c114fd2 — em dashes had no pause, causing run-on speech
-  // Regression: 343dea3d — dashes now map to ASCII comma (not fullwidth ，)
-  it('replaces dash-like characters with comma', () => {
-    expect(sanitizeTTSText('好—壞')).toBe('好,壞')
-    expect(sanitizeTTSText('好──壞')).toBe('好,壞')
-    expect(sanitizeTTSText('好⸺壞')).toBe('好,壞')
+  // Regression: 3c114fd2 — em dashes had no pause, causing run-on speech.
+  // Dashes map to fullwidth ，(not ASCII): CJK punctuation is kept fullwidth
+  // for Minimax prosody, reverting the ASCII-comma mapping from 343dea3d.
+  it('replaces dash-like characters with a fullwidth comma', () => {
+    expect(sanitizeTTSText('好—壞')).toBe('好，壞')
+    expect(sanitizeTTSText('好──壞')).toBe('好，壞')
+    expect(sanitizeTTSText('好⸺壞')).toBe('好，壞')
   })
 
   // Regression: fbda87d9 — vertical quotation marks were only replaced once (no /g flag)
@@ -79,7 +88,7 @@ describe('sanitizeTTSText', () => {
   it('applies multiple sanitization rules together', () => {
     const input = '﹁好＊﹂\n---\n好⋯⋯好—壞'
     const result = sanitizeTTSText(input)
-    expect(result).toBe('「好」\n\n好。好,壞')
+    expect(result).toBe('「好」\n\n好。好，壞')
   })
 })
 


### PR DESCRIPTION
343dea3d's blanket U+FF01–FF5E → ASCII sweep in sanitizeTTSText was meant for fullwidth letters/digits/symbols (ＡＢＣ, １２３, ＊, （）) that trip up Minimax, but flattened fullwidth CJK punctuation ，；：！？ as collateral. Those are the correct prosody-bearing forms for a Chinese-first engine; flattening them dulls intonation and (for ，；：) drops the clause boundary the server-side pause-marker injection relies on.

- sanitizeTTSText: exclude ，；：！？ from the sweep and restore dash-like chars to fullwidth ，, reverting that half of 343dea3d. Fullwidth alphanumerics/symbols still normalize as before.
- injectTTSPauseMarkers (follow-up to 21899e9): the pause regex had been broadened to ASCII ,;: to absorb what sanitizeTTSText used to emit; with fullwidth now preserved upstream, that branch only fired inside Latin tokens (12:30, e.g.,) injecting spurious markers. Narrow to the fullwidth/CJK clause set, hoist the regex to a module constant, and add unit coverage (now an exported pure helper).