### PR TITLE
⬆️ Upgrade @likecoin/epub-ts to 0.6.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5422,9 +5422,9 @@
       "license": "MIT"
     },
     "node_modules/@likecoin/epub-ts": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/@likecoin/epub-ts/-/epub-ts-0.6.3.tgz",
-      "integrity": "sha512-xJozq38HTFY5QH2MoWf4sXx9Z/Wh4+OfrI/NTobnjSn/k0I/TRrc8lza6xRYDQvxtJNmZc1MR9R0Tv7n6aPQ5w==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@likecoin/epub-ts/-/epub-ts-0.6.4.tgz",
+      "integrity": "sha512-QjBK/7d6LkWPQkprTkJZSI1IYFDoWa7nfepMy22f5wCu9ru9mNe4+OE/MnqKtKamNEjTAJ+vXfL6nG9xGTNtZw==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "jszip": "^3.10.1"


### PR DESCRIPTION
0.6.4's Mapping.page() detects a fast-path-induced start/end range inversion and recomputes via the DOM walk, fixing at the source the inverted-CFI-span behaviour worked around in 5e37366a and the TTS-start fixes. Lockfile-only — package.json's ^0.6.3 already permits it. 5e37366a's order-agnostic guard stays as a downstream seatbelt (library recovery is gated on _measurer). TTS suite 59/59, typecheck clean.