### PR TITLE
[TAS-5837] 🐛 Sync reader-open status when a book is opened outside the shelf

### DIFF
--- a/app/composables/use-reader-progress.ts
+++ b/app/composables/use-reader-progress.ts
@@ -8,6 +8,7 @@ export function useReaderProgress({
   bookProgressKeyPrefix: string
 }) {
   const bookshelfStore = useBookshelfStore()
+  const bookSettingsStore = useBookSettingsStore()
 
   function getProgressKeyWithSuffix(suffix: ReaderCacheKeySuffix) {
     return getReaderCacheKeyWithSuffix(bookProgressKeyPrefix, suffix)
@@ -31,7 +32,7 @@ export function useReaderProgress({
   if (import.meta.client) {
     useEventListener(document, 'visibilitychange', () => {
       if (document.visibilityState === 'hidden') {
-        useBookSettingsStore().flushBatch(nftClassId)
+        bookSettingsStore.flushBatch(nftClassId)
       }
     })
   }
@@ -42,6 +43,11 @@ export function useReaderProgress({
       readingProgress.value,
       lastOpenedTime.value,
     )
+    // updateProgress only schedules a debounced (1s) flush. Force it out
+    // now so the final progress / lastOpenedTime reaches the server
+    // immediately on unmount, syncing to the shelf and other devices
+    // without a 1s lag.
+    bookSettingsStore.flushBatch(nftClassId)
   })
 
   return {

--- a/app/composables/use-synced-book-settings.ts
+++ b/app/composables/use-synced-book-settings.ts
@@ -34,6 +34,12 @@ export function useSyncedBookSettings<T>({
 
   const localState = ref<T>(defaultValue)
 
+  // Settings load lazily via the shelf batch-fetch. When the reader is opened
+  // directly (a bookstore link, bypassing the shelf) a write can land before
+  // init resolves; without deferring it `queueUpdate` is skipped and the value
+  // (e.g. the `lastOpenedTime` stamp) is silently lost, never syncing.
+  let pendingWrite: { value: T } | null = null
+
   const storeValue = computed(() => {
     const settings = bookSettingsStore.getSettings(nftClassId)
     return settings?.[dbKey as keyof BookSettingsData] as T | undefined
@@ -52,12 +58,24 @@ export function useSyncedBookSettings<T>({
       if (bookSettingsStore.isInitialized(nftClassId)) {
         bookSettingsStore.queueUpdate(nftClassId, dbKey, newValue)
       }
+      else if (hasLoggedIn.value) {
+        pendingWrite = { value: newValue }
+      }
     },
   })
 
   async function loadFromServer() {
     await bookSettingsStore.ensureInitialized(nftClassId)
-    syncFromStore()
+    if (pendingWrite) {
+      // A local write raced ahead of init — it wins over the fetched value
+      // (the user just acted on this book) and must still reach the server.
+      const { value } = pendingWrite
+      pendingWrite = null
+      bookSettingsStore.queueUpdate(nftClassId, dbKey, value)
+    }
+    else {
+      syncFromStore()
+    }
   }
 
   watch(storeValue, (newValue) => {


### PR DESCRIPTION
Opening the reader directly (e.g. a bookstore link, bypassing the shelf batch-fetch) left book settings uninitialized when the lastOpenedTime stamp was written, so queueUpdate was skipped and the open silently never synced to other devices. Defer the pre-init write and replay it once settings load.

Also flush immediately on reader unmount: updateProgress only schedules a debounced flush, which SPA navigation away cuts off before the final progress / lastOpenedTime write reaches the server.