### PR TITLE
📈 Surface Minimax extra_info on TTSComplete for noise detection

### DIFF
--- a/server/api/reader/tts.get.ts
+++ b/server/api/reader/tts.get.ts
@@ -308,7 +308,7 @@ export default defineEventHandler(async (event) => {
   try {
     if (isBlocking) {
       // Blocking path: full buffer with content-length (needed by native app)
-      const rawBuffer = await provider.processRequest(requestParams)
+      const { audio: rawBuffer, extraInfo, traceId } = await provider.processRequest(requestParams)
       const buffer = Buffer.concat([id3Tag, rawBuffer])
 
       const etag = cacheKey
@@ -334,7 +334,7 @@ export default defineEventHandler(async (event) => {
         resolveInFlight?.()
       }
 
-      publishEvent(event, 'TTSComplete', { ...ttsEventBase, audioSize: buffer.length, mode: 'blocking' })
+      publishEvent(event, 'TTSComplete', { ...ttsEventBase, audioSize: buffer.length, mode: 'blocking', ...getTTSExtraInfoEventProps(extraInfo, traceId) })
 
       const rangeHeader = getHeader(event, 'range')
       if (rangeHeader) {
@@ -353,7 +353,7 @@ export default defineEventHandler(async (event) => {
     }
 
     // Streaming path (default): pipe audio chunks as they arrive
-    const stream = await provider.processRequestStream(requestParams)
+    const { audio: stream, extraInfo: extraInfoPromise, traceId: traceIdPromise } = await provider.processRequestStream(requestParams)
 
     if (cacheKey) {
       const etag = `"${createHash('sha256').update(cacheKey).digest('hex').substring(0, 16)}"`
@@ -408,9 +408,14 @@ export default defineEventHandler(async (event) => {
         }
         controller.enqueue(chunk)
       },
-      flush() {
+      async flush() {
         cacheWriteStream?.end()
-        publishEvent(event, 'TTSComplete', { ...ttsEventBase, audioSize: streamedBytes, mode: 'streaming' })
+        // Safe to await here: flush() runs only after the source SSE stream is
+        // fully drained, so these resolve from the just-consumed final chunk —
+        // settled or imminent, never a hang, and never reject (they resolve
+        // undefined on early/aborted streams, where flush() isn't reached).
+        const [extraInfo, traceId] = await Promise.all([extraInfoPromise, traceIdPromise])
+        publishEvent(event, 'TTSComplete', { ...ttsEventBase, audioSize: streamedBytes, mode: 'streaming', ...getTTSExtraInfoEventProps(extraInfo, traceId) })
       },
     })
 

--- a/server/api/tts/sample.get.ts
+++ b/server/api/tts/sample.get.ts
@@ -170,7 +170,7 @@ export default defineEventHandler(async (event) => {
 
   let buffer: Buffer
   try {
-    const rawBuffer = await provider.processRequest({
+    const { audio: rawBuffer } = await provider.processRequest({
       text,
       language,
       voiceId,

--- a/server/utils/api-tts.ts
+++ b/server/utils/api-tts.ts
@@ -15,11 +15,52 @@ export interface TTSRequestParams {
   config?: ReturnType<typeof useRuntimeConfig>
 }
 
+// Provider-neutral generation metadata. MiniMax's richer `ExtraInfo`
+// structurally satisfies this, keeping the vendor type out of the generic
+// provider contract.
+export interface TTSExtraInfo {
+  audioLength?: number
+  wordCount?: number
+  invisibleCharacterRatio?: number
+  usageCharacters?: number
+  bitrate?: number
+}
+
+export interface TTSProviderResult {
+  audio: Buffer
+  extraInfo?: TTSExtraInfo
+  traceId?: string
+}
+
+export interface TTSProviderStreamResult {
+  audio: ReadableStream<Buffer>
+  // extraInfo/traceId ride the final aggregated SSE chunk and only settle once
+  // `audio` is fully drained — awaiting either before the stream is consumed
+  // hangs the underlying source. Resolve them in the cache TransformStream's
+  // flush(), where the source is guaranteed drained.
+  extraInfo: Promise<TTSExtraInfo | undefined>
+  traceId: Promise<string | undefined>
+}
+
 export interface BaseTTSProvider {
   provider: string
   format: string
-  processRequest(params: TTSRequestParams): Promise<Buffer>
-  processRequestStream(params: TTSRequestParams): Promise<ReadableStream<Buffer>>
+  processRequest(params: TTSRequestParams): Promise<TTSProviderResult>
+  processRequestStream(params: TTSRequestParams): Promise<TTSProviderStreamResult>
+}
+
+// Flattens generation metadata into analytics event props. audioLength is in
+// milliseconds; pairing it with textLength yields the speech-rate ratio used
+// (Phase 2) to flag noise-blast / truncation failures.
+export function getTTSExtraInfoEventProps(extraInfo?: TTSExtraInfo, traceId?: string) {
+  return {
+    traceId,
+    audioLengthMs: extraInfo?.audioLength,
+    wordCount: extraInfo?.wordCount,
+    invisibleCharacterRatio: extraInfo?.invisibleCharacterRatio,
+    usageCharacters: extraInfo?.usageCharacters,
+    bitrate: extraInfo?.bitrate,
+  }
 }
 
 export async function getUserTTSAvailable(event: H3Event): Promise<boolean> {

--- a/server/utils/tts-minimax.ts
+++ b/server/utils/tts-minimax.ts
@@ -1,4 +1,4 @@
-import type { BaseTTSProvider, TTSRequestParams } from './api-tts'
+import type { BaseTTSProvider, TTSProviderResult, TTSProviderStreamResult, TTSRequestParams } from './api-tts'
 
 export const LANG_MAPPING = {
   'en-US': 'English',
@@ -139,7 +139,7 @@ export class MinimaxTTSProvider implements BaseTTSProvider {
   provider = 'minimax'
   format = 'audio/mpeg'
 
-  async processRequest(params: TTSRequestParams): Promise<Buffer> {
+  async processRequest(params: TTSRequestParams): Promise<TTSProviderResult> {
     const { text, language, voiceId, customMiniMaxVoiceId } = params
 
     if (!customMiniMaxVoiceId && !VOICE_CONFIG[voiceId]) {
@@ -166,10 +166,10 @@ export class MinimaxTTSProvider implements BaseTTSProvider {
       languageBoost: LANG_MAPPING[language as keyof typeof LANG_MAPPING],
     })
 
-    return result.audio
+    return { audio: result.audio, extraInfo: result.extraInfo, traceId: result.traceId }
   }
 
-  async processRequestStream(params: TTSRequestParams): Promise<ReadableStream<Buffer>> {
+  async processRequestStream(params: TTSRequestParams): Promise<TTSProviderStreamResult> {
     const { text, language, voiceId, customMiniMaxVoiceId } = params
 
     if (!customMiniMaxVoiceId && !VOICE_CONFIG[voiceId]) {
@@ -183,7 +183,7 @@ export class MinimaxTTSProvider implements BaseTTSProvider {
     const resolvedVoiceId = (customMiniMaxVoiceId || VOICE_CONFIG[voiceId]!.minimaxVoiceId) as string
     const model = getMinimaxModel({ voiceId, customVoiceId: customMiniMaxVoiceId, language })
 
-    const { audio } = await client.synthesizeStream({
+    const { audio, extraInfo, traceId } = await client.synthesizeStream({
       text: injectTTSPauseMarkers(text),
       model,
       voiceSetting: {
@@ -196,6 +196,6 @@ export class MinimaxTTSProvider implements BaseTTSProvider {
       languageBoost: LANG_MAPPING[language as keyof typeof LANG_MAPPING],
       streamOptions: { excludeAggregatedAudio: true },
     })
-    return audio
+    return { audio, extraInfo, traceId }
   }
 }


### PR DESCRIPTION
Thread Minimax extra_info (audio length, word count, invisible-character ratio, billable chars) and trace id out of both the blocking and streaming TTS paths into the TTSComplete event. The audioLength-vs-textLength speech-rate signal is the basis for later auto-detecting garbled "static noise" generations and gating the cache write that would otherwise poison every subsequent listener.

Streaming resolves the deferred extra_info in the cache stream's flush(), the only point after the SSE source is drained. Keeps the provider contract vendor-neutral via a TTSExtraInfo interface that Minimax's richer ExtraInfo satisfies structurally.