### PR TITLE
🔒 Harden reading-session duration data for rev-share

### DIFF
--- a/app/composables/use-reading-session.ts
+++ b/app/composables/use-reading-session.ts
@@ -16,7 +16,7 @@ export function useReadingSession(options: ReadingSessionOptions) {
   const { readerType, progress, isTextToSpeechPlaying, chapterIndex, pageIndex } = options
   const nftClassId = toRef(options.nftClassId)
 
-  const { loggedIn } = useUserSession()
+  const { loggedIn, user: sessionUser } = useUserSession()
   let sessionId = ''
   let startProgress = 0
   let pagesViewed = new Set<number | string>()
@@ -159,6 +159,7 @@ export function useReadingSession(options: ReadingSessionOptions) {
       active_reading_time_ms: payload.activeReadingTimeMs,
       tts_active_time_ms: payload.ttsActiveTimeMs,
       pages_viewed: payload.pagesViewed,
+      is_liker_plus_at_event_time: !!sessionUser.value?.isLikerPlus,
     })
   }
 

--- a/server/api/analytics/heartbeat.post.ts
+++ b/server/api/analytics/heartbeat.post.ts
@@ -1,7 +1,7 @@
 import { HeartbeatSchema } from '~~/server/schemas/analytics'
 
 export default defineEventHandler(async (event) => {
-  const wallet = await requireUserWallet(event)
+  const { wallet, isLikerPlus } = await requireUserWalletWithStatus(event)
   const body = await readValidatedBody(event, createValidator(HeartbeatSchema))
 
   const {
@@ -10,13 +10,21 @@ export default defineEventHandler(async (event) => {
     ttsActiveTimeMsDelta,
   } = body
 
-  if (activeReadingTimeMsDelta > 0 || ttsActiveTimeMsDelta > 0) {
-    await incrementBookReadingTime(
-      wallet,
-      nftClassId,
-      activeReadingTimeMsDelta,
-      ttsActiveTimeMsDelta,
-    )
+  if (activeReadingTimeMsDelta <= 0 && ttsActiveTimeMsDelta <= 0) {
+    return { success: true }
+  }
+
+  const paced = await applyWallClockPacing(wallet, nftClassId, {
+    activeReadingTimeMsDelta,
+    ttsActiveTimeMsDelta,
+  })
+
+  if (paced.activeReadingTimeMsDelta > 0 || paced.ttsActiveTimeMsDelta > 0) {
+    await incrementBookReadingTime(wallet, nftClassId, {
+      activeReadingTimeMs: paced.activeReadingTimeMsDelta,
+      ttsActiveTimeMs: paced.ttsActiveTimeMsDelta,
+      isLikerPlus,
+    })
   }
 
   return { success: true }

--- a/server/api/analytics/session.post.ts
+++ b/server/api/analytics/session.post.ts
@@ -3,7 +3,7 @@ import { ReadingSessionSchema } from '~~/server/schemas/analytics'
 const COMPLETION_THRESHOLD = 95
 
 export default defineEventHandler(async (event) => {
-  const wallet = await requireUserWallet(event)
+  const { wallet, isLikerPlus } = await requireUserWalletWithStatus(event)
   const body = await readValidatedBody(event, createValidator(ReadingSessionSchema))
 
   const {
@@ -22,10 +22,23 @@ export default defineEventHandler(async (event) => {
   } = body
 
   const hasActivity = activeReadingTimeMs > 0 || ttsActiveTimeMs > 0
+  const hasDelta = activeReadingTimeMsDelta > 0 || ttsActiveTimeMsDelta > 0
+
+  const paced = hasDelta
+    ? await applyWallClockPacing(wallet, nftClassId, {
+      activeReadingTimeMsDelta,
+      ttsActiveTimeMsDelta,
+    })
+    : { activeReadingTimeMsDelta: 0, ttsActiveTimeMsDelta: 0 }
 
   const tasks: Promise<unknown>[] = []
   if (hasActivity) {
-    tasks.push(incrementBookReadingTime(wallet, nftClassId, activeReadingTimeMsDelta, ttsActiveTimeMsDelta, { countSession: true }))
+    tasks.push(incrementBookReadingTime(wallet, nftClassId, {
+      activeReadingTimeMs: paced.activeReadingTimeMsDelta,
+      ttsActiveTimeMs: paced.ttsActiveTimeMsDelta,
+      isLikerPlus,
+      countSession: true,
+    }))
     tasks.push(updateReadingStreak(wallet))
   }
 
@@ -41,10 +54,15 @@ export default defineEventHandler(async (event) => {
   try {
     publishEvent(event, 'ReadingSession', {
       evmWallet: wallet,
+      isLikerPlus,
       nftClassId,
       sessionId,
       activeReadingTimeMs,
       ttsActiveTimeMs,
+      activeReadingTimeMsDelta,
+      ttsActiveTimeMsDelta,
+      activeReadingTimeMsPacedDelta: paced.activeReadingTimeMsDelta,
+      ttsActiveTimeMsPacedDelta: paced.ttsActiveTimeMsDelta,
       pagesViewed,
       startProgress,
       endProgress,
@@ -56,6 +74,7 @@ export default defineEventHandler(async (event) => {
     if (isNewCompletion) {
       publishEvent(event, 'BookCompleted', {
         evmWallet: wallet,
+        isLikerPlus,
         nftClassId,
         completionProgress: endProgress,
       })

--- a/server/utils/analytics-pacing.ts
+++ b/server/utils/analytics-pacing.ts
@@ -1,0 +1,43 @@
+import { FieldValue, Timestamp } from 'firebase-admin/firestore'
+import { clampPacedDeltas, type PacedDeltas } from '~~/shared/utils/analytics-pacing'
+
+export async function applyWallClockPacing(
+  userWallet: string,
+  nftClassId: string,
+  requested: PacedDeltas,
+): Promise<PacedDeltas> {
+  const pacingRef = getUserCollection()
+    .doc(userWallet)
+    .collection('pacing')
+    .doc(nftClassId.toLowerCase())
+
+  return getFirestoreDb().runTransaction(async (transaction) => {
+    const doc = await transaction.get(pacingRef)
+    const data = doc.data()
+    const now = Date.now()
+    const today = toUTCDateString(new Date(now))
+
+    const isNewDay = !data || data.todayDate !== today
+    // Clamp against the stored heartbeat even across a UTC day boundary —
+    // otherwise the first beat after midnight is unpaced and a client could
+    // burst a max-delta beat on each side of the rollover.
+    const lastHeartbeatMs = data?.lastHeartbeatAt instanceof Timestamp
+      ? data.lastHeartbeatAt.toMillis()
+      : null
+
+    const paced = clampPacedDeltas(requested, lastHeartbeatMs, now)
+
+    transaction.set(pacingRef, {
+      todayDate: today,
+      lastHeartbeatAt: FieldValue.serverTimestamp(),
+      accumulatedActiveTodayMs: isNewDay
+        ? paced.activeReadingTimeMsDelta
+        : FieldValue.increment(paced.activeReadingTimeMsDelta),
+      accumulatedTTSTodayMs: isNewDay
+        ? paced.ttsActiveTimeMsDelta
+        : FieldValue.increment(paced.ttsActiveTimeMsDelta),
+    }, { merge: true })
+
+    return paced
+  })
+}

--- a/server/utils/api-user.ts
+++ b/server/utils/api-user.ts
@@ -5,7 +5,10 @@ import type { BookSettingsFirestoreData } from '~~/server/types/book-settings'
 import type { UserSettingsData } from '~~/shared/types/user-settings'
 import { FIRESTORE_IN_OPERATOR_LIMIT } from '~~/shared/constants/api'
 
-export async function requireUserWallet(event: H3Event): Promise<string> {
+export async function requireUserWalletWithStatus(event: H3Event): Promise<{
+  wallet: string
+  isLikerPlus: boolean
+}> {
   const session = await requireUserSession(event)
   const wallet = session.user.evmWallet
   if (!wallet) {
@@ -14,6 +17,11 @@ export async function requireUserWallet(event: H3Event): Promise<string> {
       message: 'WALLET_NOT_FOUND',
     })
   }
+  return { wallet, isLikerPlus: !!session.user.isLikerPlus }
+}
+
+export async function requireUserWallet(event: H3Event): Promise<string> {
+  const { wallet } = await requireUserWalletWithStatus(event)
   return wallet
 }
 
@@ -246,24 +254,32 @@ export async function deleteCustomVoice(
 export async function incrementBookReadingTime(
   userWallet: string,
   nftClassId: string,
-  activeReadingTimeMs: number,
-  ttsActiveTimeMs: number,
-  options?: { countSession?: boolean },
+  payload: {
+    activeReadingTimeMs: number
+    ttsActiveTimeMs: number
+    isLikerPlus: boolean
+    countSession?: boolean
+  },
 ): Promise<void> {
+  const { activeReadingTimeMs, ttsActiveTimeMs, isLikerPlus, countSession } = payload
   const userDocRef = getUserCollection().doc(userWallet)
   const bookDocRef = userDocRef.collection('books').doc(nftClassId.toLowerCase())
+
+  const plusTTSListeningTimeMs = isLikerPlus ? ttsActiveTimeMs : 0
 
   const batch = getFirestoreDb().batch()
 
   batch.set(userDocRef, {
     totalReadingTimeMs: FieldValue.increment(activeReadingTimeMs),
     totalTTSListeningTimeMs: FieldValue.increment(ttsActiveTimeMs),
+    totalPlusTTSListeningTimeMs: FieldValue.increment(plusTTSListeningTimeMs),
   }, { merge: true })
 
   batch.set(bookDocRef, {
     totalReadingTimeMs: FieldValue.increment(activeReadingTimeMs),
     totalTTSListeningTimeMs: FieldValue.increment(ttsActiveTimeMs),
-    ...(options?.countSession && { sessionCount: FieldValue.increment(1) }),
+    totalPlusTTSListeningTimeMs: FieldValue.increment(plusTTSListeningTimeMs),
+    ...(countSession && { sessionCount: FieldValue.increment(1) }),
     updatedAt: FieldValue.serverTimestamp(),
   }, { merge: true })
 
@@ -281,12 +297,12 @@ export async function updateReadingStreak(
     const streak = data?.readingStreak || { currentDays: 0, longestDays: 0, lastActiveDate: '' }
 
     const now = new Date()
-    const today = now.toISOString().split('T')[0]
+    const today = toUTCDateString(now)
     if (streak.lastActiveDate === today) return
 
     const yesterday = new Date(now)
     yesterday.setUTCDate(yesterday.getUTCDate() - 1)
-    const yesterdayStr = yesterday.toISOString().split('T')[0]
+    const yesterdayStr = toUTCDateString(yesterday)
 
     let newCurrentDays: number
     if (streak.lastActiveDate === yesterdayStr) {

--- a/server/utils/date.ts
+++ b/server/utils/date.ts
@@ -1,0 +1,3 @@
+export function toUTCDateString(date: Date = new Date()): string {
+  return date.toISOString().slice(0, 10)
+}

--- a/shared/constants/analytics.ts
+++ b/shared/constants/analytics.ts
@@ -1,3 +1,4 @@
 export const MAX_SESSION_DURATION_MS = 4 * 60 * 60 * 1000
 export const HEARTBEAT_INTERVAL_MS = 5 * 60 * 1000
 export const MAX_HEARTBEAT_DELTA_MS = 10 * 60 * 1000
+export const WALL_CLOCK_JITTER_MS = 30 * 1000

--- a/shared/utils/analytics-pacing.ts
+++ b/shared/utils/analytics-pacing.ts
@@ -1,0 +1,29 @@
+import { WALL_CLOCK_JITTER_MS } from '~~/shared/constants/analytics'
+
+export interface PacedDeltas {
+  activeReadingTimeMsDelta: number
+  ttsActiveTimeMsDelta: number
+}
+
+// The first-ever heartbeat for a user+book is unpaced — no prior reference to
+// clamp against, so the request schema cap is the only bound.
+export function clampPacedDeltas(
+  requested: PacedDeltas,
+  lastHeartbeatMs: number | null,
+  now: number,
+): PacedDeltas {
+  const active = Math.max(0, requested.activeReadingTimeMsDelta)
+  const tts = Math.max(0, requested.ttsActiveTimeMsDelta)
+  if (lastHeartbeatMs === null) {
+    return { activeReadingTimeMsDelta: active, ttsActiveTimeMsDelta: tts }
+  }
+  // Heartbeats aren't rate-limited, so a flat jitter allowance lets a scripted
+  // client farm ~30s of credit per back-to-back beat. Bounding jitter by the
+  // elapsed wall-clock caps total credit at ~2x the real elapsed time.
+  const elapsed = Math.max(0, now - lastHeartbeatMs)
+  const cap = elapsed + Math.min(WALL_CLOCK_JITTER_MS, elapsed)
+  return {
+    activeReadingTimeMsDelta: Math.min(active, cap),
+    ttsActiveTimeMsDelta: Math.min(tts, cap),
+  }
+}

--- a/test/unit/analytics-pacing.test.ts
+++ b/test/unit/analytics-pacing.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+import { clampPacedDeltas } from '~~/shared/utils/analytics-pacing'
+import { WALL_CLOCK_JITTER_MS } from '~~/shared/constants/analytics'
+
+const NOW = 1_700_000_000_000
+
+describe('clampPacedDeltas', () => {
+  it('returns inputs as-is when no prior heartbeat exists', () => {
+    expect(clampPacedDeltas(
+      { activeReadingTimeMsDelta: 600_000, ttsActiveTimeMsDelta: 300_000 },
+      null,
+      NOW,
+    )).toEqual({ activeReadingTimeMsDelta: 600_000, ttsActiveTimeMsDelta: 300_000 })
+  })
+
+  it('floors negative inputs at zero', () => {
+    expect(clampPacedDeltas(
+      { activeReadingTimeMsDelta: -5_000, ttsActiveTimeMsDelta: -1 },
+      null,
+      NOW,
+    )).toEqual({ activeReadingTimeMsDelta: 0, ttsActiveTimeMsDelta: 0 })
+  })
+
+  it('clamps deltas to wall-clock elapsed plus full jitter when elapsed exceeds the jitter', () => {
+    const elapsed = 60_000
+    const lastHeartbeatMs = NOW - elapsed
+    const result = clampPacedDeltas(
+      { activeReadingTimeMsDelta: 600_000, ttsActiveTimeMsDelta: 600_000 },
+      lastHeartbeatMs,
+      NOW,
+    )
+    expect(result.activeReadingTimeMsDelta).toBe(elapsed + WALL_CLOCK_JITTER_MS)
+    expect(result.ttsActiveTimeMsDelta).toBe(elapsed + WALL_CLOCK_JITTER_MS)
+  })
+
+  it('bounds jitter by the elapsed for near-instant beats so spam cannot farm credit', () => {
+    // A scripted client firing heartbeats back-to-back sees ~0 elapsed; the
+    // jitter must shrink with it rather than crediting a flat 30s per request.
+    const elapsed = 50
+    const result = clampPacedDeltas(
+      { activeReadingTimeMsDelta: 600_000, ttsActiveTimeMsDelta: 600_000 },
+      NOW - elapsed,
+      NOW,
+    )
+    expect(result.activeReadingTimeMsDelta).toBe(elapsed * 2)
+    expect(result.ttsActiveTimeMsDelta).toBe(elapsed * 2)
+  })
+
+  it('passes deltas through unchanged when they fit within the cap', () => {
+    const lastHeartbeatMs = NOW - 10 * 60 * 1000
+    expect(clampPacedDeltas(
+      { activeReadingTimeMsDelta: 60_000, ttsActiveTimeMsDelta: 5_000 },
+      lastHeartbeatMs,
+      NOW,
+    )).toEqual({ activeReadingTimeMsDelta: 60_000, ttsActiveTimeMsDelta: 5_000 })
+  })
+
+  it('clamps active and tts deltas independently', () => {
+    const elapsed = 60_000
+    const lastHeartbeatMs = NOW - elapsed
+    const cap = elapsed + WALL_CLOCK_JITTER_MS
+    const result = clampPacedDeltas(
+      { activeReadingTimeMsDelta: 999_999, ttsActiveTimeMsDelta: 100 },
+      lastHeartbeatMs,
+      NOW,
+    )
+    expect(result.activeReadingTimeMsDelta).toBe(cap)
+    expect(result.ttsActiveTimeMsDelta).toBe(100)
+  })
+
+  it('credits nothing for a future-dated lastHeartbeat (zero elapsed grants no jitter)', () => {
+    const lastHeartbeatMs = NOW + 5_000
+    const result = clampPacedDeltas(
+      { activeReadingTimeMsDelta: 600_000, ttsActiveTimeMsDelta: 600_000 },
+      lastHeartbeatMs,
+      NOW,
+    )
+    expect(result.activeReadingTimeMsDelta).toBe(0)
+    expect(result.ttsActiveTimeMsDelta).toBe(0)
+  })
+
+  it('returns zero deltas when both requested are zero', () => {
+    expect(clampPacedDeltas(
+      { activeReadingTimeMsDelta: 0, ttsActiveTimeMsDelta: 0 },
+      NOW - 1_000,
+      NOW,
+    )).toEqual({ activeReadingTimeMsDelta: 0, ttsActiveTimeMsDelta: 0 })
+  })
+})


### PR DESCRIPTION
Two changes preparing for a duration-based rev-share to publishers: Plus-attribution on TTS minutes (so the upcoming Plus-only TTS pool has a clean numerator without joining Stripe→PostHog by email), and wall-clock pacing on heartbeats (so a scripted client can't pump minutes against any book).

Plus status is read server-side on every flush from the existing session cookie — never trusted from the client — and written to a new totalPlusTTSListeningTimeMs counter on both the user and per-book Firestore docs alongside the existing total. The reading_session_end PostHog event also gains is_liker_plus_at_event_time for in-product modeling.

Pacing is keyed at (wallet, nftClassId) rather than per session: a sessionId is trivial for a script to rotate, but the (wallet, book) pair is what actually maps to a payout claim. Each subsequent heartbeat is clamped to wall-clock elapsed since the prior one (plus a 30s jitter). First heartbeat of a UTC day is unpaced — no prior reference exists, so the schema cap is the only bound. Daily accumulators are recorded but not enforced yet, leaving a one-line follow-up to add a per-day cap.

The PubSub ReadingSession event now carries both the raw client- reported durations and the paced ones, so anti-abuse forensics can later quantify how much got clipped per wallet without log replay.