### PR TITLE
📈 Tag TTS cache objects with originating nftClassId

### DIFF
--- a/server/api/reader/tts.get.ts
+++ b/server/api/reader/tts.get.ts
@@ -299,6 +299,7 @@ export default defineEventHandler(async (event) => {
       language,
       voiceId,
       provider: provider.provider,
+      nftClassId,
       text: text.length > 1800 ? text.substring(0, 1800) + '...' : text,
       textLength: text.length.toString(),
       createdAt: new Date().toISOString(),


### PR DESCRIPTION
GCS object metadata now records the book class id of the request that first generated the audio, giving us a traceback from a cached MP3 to its initial generator. The cache key stays content-addressed (text + voice + language) so identical text is still shared across books — the recorded id is best-effort "first generator," not exclusive ownership.