### PR TITLE
🐛 Resume store pagination after an expired-offset 422 stalls loading

### DIFF
--- a/app/pages/store/index.vue
+++ b/app/pages/store/index.vue
@@ -927,9 +927,12 @@ async function fetchTagItems({ isRefresh = false } = {}) {
   }
 }
 
-async function fetchItems({ lazy = false, isRefresh = false } = {}) {
+// Returns whether the fetch completed without surfacing an error, so callers
+// (e.g. the infinite-scroll watcher) can avoid chaining a follow-up fetch —
+// and a second error modal — after a genuine failure.
+async function fetchItems({ lazy = false, isRefresh = false } = {}): Promise<boolean> {
   if (lazy && products.value.items.length > 0) {
-    return
+    return true
   }
   if (isSearchMode.value) {
     try {
@@ -937,17 +940,19 @@ async function fetchItems({ lazy = false, isRefresh = false } = {}) {
       if (type && searchTerm) {
         await bookstoreStore.fetchSearchResults(type as 'q' | 'author' | 'publisher' | 'owner_wallet' | 'genre', searchTerm, { isRefresh })
       }
+      return true
     }
     catch (error) {
       await handleError(error, {
         title: isRefresh ? $t('store_fetch_items_error') : $t('store_fetch_more_items_error'),
       })
+      return false
     }
-    return
   }
 
   try {
     await fetchTagItems({ isRefresh })
+    return true
   }
   catch (error) {
     await handleError(error, {
@@ -966,6 +971,7 @@ async function fetchItems({ lazy = false, isRefresh = false } = {}) {
         },
       },
     })
+    return false
   }
 }
 
@@ -1010,11 +1016,36 @@ onBeforeRouteLeave((to) => {
   }
 })
 
+const isLoadingMore = ref(false)
 watch(
   shouldLoadMore,
-  async (shouldLoadMore) => {
-    if (shouldLoadMore) {
-      await fetchItems()
+  async (isSentinelVisible) => {
+    // Serialize: an async watch isn't re-entrancy-safe, so a sentinel
+    // visibility flip mid-fetch could otherwise stack overlapping runs (and
+    // duplicate error modals).
+    if (!isSentinelVisible || isLoadingMore.value) return
+    isLoadingMore.value = true
+    try {
+      const countBefore = products.value.items.length
+      const didFetch = await fetchItems()
+      // Recovering an expired offset (422) re-fetches page 1 in place to mint a
+      // fresh cursor without adding items. The IntersectionObserver won't
+      // re-fire because the sentinel hasn't moved, so the spinner would hang
+      // despite a usable cursor. If the fetch succeeded but the list didn't
+      // grow and a cursor remains, advance once more so pagination continues.
+      // Gating on success avoids re-firing (and re-erroring) after a failure.
+      if (
+        didFetch
+        && shouldLoadMore.value
+        && hasMoreItems.value
+        && !!products.value.nextItemsKey
+        && products.value.items.length <= countBefore
+      ) {
+        await fetchItems()
+      }
+    }
+    finally {
+      isLoadingMore.value = false
     }
   },
 )

--- a/app/stores/bookstore.ts
+++ b/app/stores/bookstore.ts
@@ -93,6 +93,10 @@ export const useBookstoreStore = defineStore('bookstore', () => {
       const result = await fetchBookstoreCMSProductsByTagId(tagId, {
         offset: fetchOffset,
         ts: bookstoreCMSProductsByTagIdMap.value[tagId].ts,
+        // The offset refresh must bypass the page-1 cache; the cached cursor
+        // has a shorter TTL than its records, so it may already be gone by
+        // the time we need to paginate.
+        live: shouldRefreshOffset,
       })
 
       if (isRefresh || shouldRefreshOffset) {

--- a/app/utils/api.ts
+++ b/app/utils/api.ts
@@ -10,10 +10,12 @@ export function fetchBookstoreCMSProductsByTagId(tagId: string, {
   offset,
   limit = 100,
   ts,
+  live,
 }: {
   offset?: string
   limit?: number
   ts?: number
+  live?: boolean
 } = {}) {
   return apiFetch<FetchBookstoreCMSProductsResponseData>('/store/products', {
     query: {
@@ -21,6 +23,7 @@ export function fetchBookstoreCMSProductsByTagId(tagId: string, {
       offset,
       limit,
       ts,
+      live: live ? 1 : undefined,
     },
   })
 }

--- a/server/api/store/products.get.ts
+++ b/server/api/store/products.get.ts
@@ -8,11 +8,25 @@ export default defineEventHandler(async (event) => {
     const tagId = (Array.isArray(query.tag) ? query.tag[0] : query.tag) || 'latest'
     const pageSize = Math.min(Math.max(1, Number((Array.isArray(query.limit) ? query.limit[0] : query.limit)) || 100), 100)
     const offset = (Array.isArray(query.offset) ? query.offset[0] : query.offset) || undefined
+    const isLive = (Array.isArray(query.live) ? query.live[0] : query.live) === '1'
 
     // Paginated requests always go live
     if (offset) {
       setHeader(event, 'cache-control', 'no-store')
       return await fetchAirtableCMSProductsByTagId(tagId, { pageSize, offset })
+    }
+
+    // A `live` page-1 fetch bypasses the cache to mint a *fresh* pagination
+    // cursor. The cached page-1 offset has a short TTL (AIRTABLE_OFFSET_TTL,
+    // 2 min) and is dropped well before its records (1 day), so a cached
+    // page 1 can come back without a usable cursor; the client requests this
+    // only when it needs one (see fetchCMSProductsByTagId's offset refresh).
+    // Concurrent live fetches for the same tag are coalesced to protect
+    // Airtable's per-base rate limit.
+    if (isLive) {
+      setHeader(event, 'cache-control', 'no-store')
+      const result = await fetchLiveAirtableCMSProductsByTagId(tagId, { pageSize })
+      return { ...result, hasMore: !!result.offset }
     }
 
     const result = await fetchWithAirtableCache(

--- a/server/schemas/store.ts
+++ b/server/schemas/store.ts
@@ -7,6 +7,8 @@ const PaginationFields = {
 
 export const StoreProductsQuerySchema = v.object({
   tag: v.optional(v.union([v.string(), v.array(v.string())])),
+  // Bypass the page-1 cache to mint a fresh Airtable pagination cursor.
+  live: v.optional(v.union([v.string(), v.array(v.string())])),
   ...PaginationFields,
 })
 

--- a/server/utils/airtable.ts
+++ b/server/utils/airtable.ts
@@ -232,6 +232,26 @@ export async function fetchAirtableCMSProductsByTagId(
   }
 }
 
+const inflightLiveTagFetches = new Map<string, Promise<FetchBookstoreCMSProductsResponseData>>()
+
+// Coalesce concurrent uncached "live" page-1 fetches for the same tag into a
+// single upstream call. The live path (used to mint a fresh pagination cursor)
+// bypasses the cache, so without this a burst of clients paginating the same
+// tag at once would each hit Airtable and trip its per-base rate limit.
+export function fetchLiveAirtableCMSProductsByTagId(
+  tagId: string,
+  { pageSize = 100 }: { pageSize?: number } = {},
+): Promise<FetchBookstoreCMSProductsResponseData> {
+  const key = `${tagId}:${pageSize}`
+  let inflight = inflightLiveTagFetches.get(key)
+  if (!inflight) {
+    inflight = fetchAirtableCMSProductsByTagId(tagId, { pageSize })
+      .finally(() => inflightLiveTagFetches.delete(key))
+    inflightLiveTagFetches.set(key, inflight)
+  }
+  return inflight
+}
+
 export interface FetchAirtableCMSTagRecord {
   id: string
   createdTime: string


### PR DESCRIPTION
After a 422 OFFSET_EXPIRED, the store re-fetches page 1 in place to mint a fresh cursor but adds no items, so the IntersectionObserver sentinel never moves and the load-more watch never re-fires — leaving the spinner stuck despite a usable cursor. When a cursor remains but the list didn't grow, advance once more so pagination continues.