### PR TITLE
[TAS-5899] ✨ Show per-currency book price overrides in store listing

### DIFF
--- a/app/components/BookstoreItem.vue
+++ b/app/components/BookstoreItem.vue
@@ -78,6 +78,10 @@ const props = defineProps({
     type: Number,
     default: 0,
   },
+  priceOverride: {
+    type: Object as PropType<BookPriceInDecimalByCurrency>,
+    default: undefined,
+  },
   lazy: {
     type: Boolean,
     default: false,
@@ -132,10 +136,10 @@ const bookName = computed(() => bookInfo.name.value || props.bookName)
 const authorName = computed(() => bookInfo.authorName.value)
 
 const price = computed(() => props.price || bookInfo.minPrice.value)
-// Only the catalog's own min-tier carries an override; a price passed in via
-// props has no currency override context, so fall back to ladder conversion.
+// A prop price carries its own per-currency override (the catalog's Airtable min);
+// without one we use the catalog's min-tier override. Unmigrated records pass none.
 const priceCurrencyOverride = computed(() => (
-  props.price ? undefined : bookInfo.minPricingItem.value?.priceInDecimalByCurrency
+  props.price ? props.priceOverride : bookInfo.minPricingItem.value?.priceInDecimalByCurrency
 ))
 const formattedPrice = computed(() => formatPrice(price.value, priceCurrencyOverride.value))
 

--- a/app/pages/store/index.vue
+++ b/app/pages/store/index.vue
@@ -256,6 +256,7 @@
           :book-name="item.title"
           :book-cover-src="item.imageUrl"
           :price="item.minPrice"
+          :price-override="item.minPriceInDecimalByCurrency"
           :like-rank="item.likeRank ?? 0"
           :lazy="index >= columnMax"
           :priority="index < columnMax"

--- a/app/stores/bookstore.ts
+++ b/app/stores/bookstore.ts
@@ -15,6 +15,7 @@ interface BookstoreSearchResults {
     title: string
     imageUrl: string
     minPrice?: number
+    minPriceInDecimalByCurrency?: BookPriceInDecimalByCurrency
   }>
   isFetching: boolean
   hasFetched: boolean
@@ -242,6 +243,7 @@ export const useBookstoreStore = defineStore('bookstore', () => {
         title: item.title!,
         imageUrl: item.imageUrl!,
         minPrice: item.minPrice,
+        minPriceInDecimalByCurrency: item.minPriceInDecimalByCurrency,
       }))
 
     updateSearchResults(queryKey, mappedItems, result.offset, isRefresh)
@@ -261,6 +263,7 @@ export const useBookstoreStore = defineStore('bookstore', () => {
         title: item.title!,
         imageUrl: item.imageUrl!,
         minPrice: item.minPrice,
+        minPriceInDecimalByCurrency: item.minPriceInDecimalByCurrency,
       }))
 
     updateSearchResults(queryKey, mappedItems, result.offset, isRefresh)

--- a/server/utils/airtable.ts
+++ b/server/utils/airtable.ts
@@ -101,6 +101,8 @@ export interface FetchAirtableCMSProductsByTagIdResponseData {
       'Image URL'?: string
       'Name'?: string
       'Min Price'?: number
+      'Min Price HKD'?: number
+      'Min Price TWD'?: number
       'Listing Date'?: string[]
       'Timestamp'?: number
       'DRM-free'?: boolean | number // boolean in Publications table, number (0 = false, 1 = true) in Products table
@@ -132,6 +134,20 @@ function getFormulaForSearchTerm(searchTerm: string) {
   return formula
 }
 
+// Airtable stores per-currency "Min Price <CODE>" columns in major units
+// (e.g. HKD/TWD dollars). Convert to the minor-unit override shape the client
+// price resolver expects.
+function normalizeMinPriceInDecimalByCurrency(
+  fields: FetchAirtableCMSProductsByTagIdResponseData['records'][number]['fields'],
+): BookPriceInDecimalByCurrency | undefined {
+  const result: BookPriceInDecimalByCurrency = {}
+  const hkd = fields['Min Price HKD']
+  const twd = fields['Min Price TWD']
+  if (typeof hkd === 'number' && hkd > 0) result.hkd = Math.round(hkd * 100)
+  if (typeof twd === 'number' && twd > 0) result.twd = Math.round(twd * 100)
+  return Object.keys(result).length ? result : undefined
+}
+
 function normalizeProductRecord({ id, fields }: FetchAirtableCMSProductsByTagIdResponseData['records'][number]): BookstoreCMSProduct {
   const classIds = fields.IDs
   const isMultiple = classIds && classIds.length > 1
@@ -148,6 +164,7 @@ function normalizeProductRecord({ id, fields }: FetchAirtableCMSProductsByTagIdR
     isAdultOnly: !!fields['Adult Only'] || undefined,
     isMultiple: isMultiple ? true : undefined,
     minPrice: fields['Min Price'],
+    minPriceInDecimalByCurrency: normalizeMinPriceInDecimalByCurrency(fields),
     timestamp: fields.Timestamp,
   }
 }

--- a/shared/types/bookstore.d.ts
+++ b/shared/types/bookstore.d.ts
@@ -11,6 +11,7 @@ export interface BookstoreCMSProduct {
   isAdultOnly?: boolean
   isMultiple?: boolean
   minPrice?: number
+  minPriceInDecimalByCurrency?: BookPriceInDecimalByCurrency
   timestamp?: number
   totalStaked?: bigint
   stakerCount?: number
@@ -63,6 +64,7 @@ declare global {
     isAdultOnly?: boolean
     isMultiple?: boolean
     minPrice?: number
+    minPriceInDecimalByCurrency?: BookPriceInDecimalByCurrency
     timestamp?: number
   }
 


### PR DESCRIPTION
The store grid derived HKD/TWD prices by ladder-converting the USD Min Price, ignoring any custom per-currency override a publisher set. likecoin-api-public@920eb04 now emits "Min Price HKD"/"Min Price TWD" columns to the Airtable record, so read them in normalizeProductRecord and thread the override through to BookstoreItem's price display.

Purely additive: records not yet re-synced with the new columns pass no override and fall back to ladder conversion exactly as before.

Requires: https://github.com/likecoin/likecoin-api-public/pull/1273