### PR TITLE
🐛 Stop stale service worker from blocking PWA autoUpdate

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -203,6 +203,10 @@ export default defineNuxtConfig({
 
   pwa: {
     registerType: 'autoUpdate',
+    // Serve sw.js and manifest.webmanifest with 'max-age=0, must-revalidate' so
+    // a stale CDN/edge copy can't pin the old worker and block autoUpdate; they
+    // revalidate cheaply via ETag (304). Without this the worker never updates.
+    registerWebManifestInRouteRules: true,
     manifest: {
       name: '3ook.com',
       short_name: '3ook.com',


### PR DESCRIPTION
The CDN was edge-caching /sw.js for hours, so the browser kept re-fetching the old worker and autoUpdate never detected new builds. Serve it 'no-cache' so it revalidates (cheap 304 via ETag) and the CDN won't hold a stale copy.