### PR TITLE
🐛 Load book settings before first theme and CFI restore

### DIFF
--- a/app/pages/reader/epub.vue
+++ b/app/pages/reader/epub.vue
@@ -906,6 +906,13 @@ async function loadEPub() {
   book.spine!.hooks.content.register((document: Document) => {
     applyWritingModeToDocument(document)
   })
+
+  // Settings load lazily (kicked off un-awaited in onMounted). Apply the theme
+  // and resolve the saved CFI only once font-size/line-height/cfi have arrived:
+  // injecting font-size/line-height *after* anchoring reflows the chapter and
+  // strands the restore on an earlier page than the one that was saved.
+  await bookSettingsStore.ensureInitialized(nftClassId.value)
+  await nextTick()
   applyTheme()
   isPageLoading.value = true
 


### PR DESCRIPTION
Injecting font-size/line-height after anchoring the saved CFI reflowed the chapter and stranded the restore on an earlier page. Await the synced settings (kicked off un-awaited in onMounted) and flush the watcher before applyTheme and the restore display, so the layout is final before anchoring.