### PR TITLE
[TAS-5900] 🐛 Proxy staking book list to fix iOS WKWebView load failures

### DIFF
--- a/app/pages/store/index.vue
+++ b/app/pages/store/index.vue
@@ -296,7 +296,7 @@ const { handleError } = useErrorHandler()
 const storePageState = useStorePageState()
 const isMobile = useMediaQuery('(max-width: 425px)')
 const isAdultContentEnabled = useAdultContentSetting()
-const { isApp, isIOS } = useAppDetection()
+const { isApp } = useAppDetection()
 const intercom = useIntercom()
 
 const querySearchTerm = computed(() => getRouteQuery('q', ''))
@@ -770,7 +770,6 @@ useHead(() => {
     }
   }
 
-  const collectiveEndpoint = runtimeConfig.public.likeCoinEVMChainCollectiveAPIEndpoint
   const link = [
     {
       rel: 'canonical',
@@ -783,14 +782,14 @@ useHead(() => {
       crossorigin: 'anonymous' as const,
       key: 'preload-store-tags',
     },
-    // No resource hint for the cross-origin indexer on iOS: priming WKWebView's
-    // app-level NSURLSession pool (preload OR preconnect) can wedge a poisoned
-    // connection that fails every later fetch with "Load failed: <no response>"
-    // until the app is killed — reload alone doesn't recover it.
-    ...(isStakingTagId.value && !isIOS.value
+    // Same-origin proxy preload: the staking listing now routes through our own
+    // origin (/api/store/staking-books), so priming it is safe on iOS — the
+    // cross-origin indexer hop happens server-side and can't poison WKWebView's
+    // NSURLSession pool the way a direct cross-origin fetch could.
+    ...(isStakingTagId.value
       ? [{
           rel: 'preload',
-          href: `${collectiveEndpoint}/book-nfts?pagination.limit=100&sort_by=${mapTagIdToAPIStakingSortValue(tagId.value)}&sort_order=desc`,
+          href: `/api/store/staking-books?sort_by=${mapTagIdToAPIStakingSortValue(tagId.value)}&sort_order=desc&limit=100`,
           as: 'fetch' as const,
           crossorigin: 'anonymous' as const,
           key: 'preload-staking-books',

--- a/app/stores/bookstore.ts
+++ b/app/stores/bookstore.ts
@@ -1,5 +1,3 @@
-import { fetchCollectiveBookNFTs } from '~~/shared/utils/collective-indexer'
-
 interface BookstoreCMSTagProducts {
   items: BookstoreCMSProduct[]
   isFetching: boolean
@@ -386,11 +384,11 @@ export const useBookstoreStore = defineStore('bookstore', () => {
     try {
       stakingBooksMap.value[sortBy].isFetching = true
 
-      const result = await fetchCollectiveBookNFTs({
-        'pagination.limit': limit,
-        'pagination.key': stakingBooksMap.value[sortBy].offset,
-        'sort_order': 'desc',
-        'sort_by': sortBy as 'staked_amount' | 'last_staked_at' | 'number_of_stakers',
+      const result = await fetchStakingBookNFTs({
+        sortBy: sortBy as 'staked_amount' | 'last_staked_at' | 'number_of_stakers',
+        sortOrder: 'desc',
+        limit,
+        key: stakingBooksMap.value[sortBy].offset,
       })
 
       const currentOffset = Number(stakingBooksMap.value[sortBy].offset ?? 0)

--- a/app/utils/api.ts
+++ b/app/utils/api.ts
@@ -1,3 +1,5 @@
+import type { CollectiveBookNFT, CollectiveBookNFTsQueryOptions, CollectivePaginationResponse } from '~~/shared/utils/collective-indexer'
+
 /**
  * Shared client for first-party `/api/*` Nitro routes, with the
  * method-aware retry policy from `createRetryingFetch` (idempotent
@@ -5,6 +7,33 @@
  * via an explicit `retry`).
  */
 export const apiFetch = createRetryingFetch({ baseURL: '/api' })
+
+/**
+ * Fetches the staking book listing through our same-origin `/api/store/staking-books`
+ * proxy instead of hitting the collective indexer directly. iOS WKWebView can wedge
+ * a poisoned connection on cross-origin fetches ("Load failed: <no response>"); routing
+ * through our origin keeps the cross-origin hop server-side and lets page 1 be cached.
+ */
+export function fetchStakingBookNFTs({
+  sortBy = 'staked_amount',
+  sortOrder = 'desc',
+  limit = 100,
+  key,
+}: {
+  sortBy?: NonNullable<CollectiveBookNFTsQueryOptions['sort_by']>
+  sortOrder?: NonNullable<CollectiveBookNFTsQueryOptions['sort_order']>
+  limit?: number
+  key?: string | number
+} = {}) {
+  return apiFetch<CollectivePaginationResponse<CollectiveBookNFT>>('/store/staking-books', {
+    query: {
+      sort_by: sortBy,
+      sort_order: sortOrder,
+      limit,
+      key,
+    },
+  })
+}
 
 export function fetchBookstoreCMSProductsByTagId(tagId: string, {
   offset,

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -150,6 +150,16 @@ export default defineNuxtConfig({
         },
       },
     },
+    '/api/store/staking-books': {
+      security: {
+        corsHandler: {
+          origin: '^https?:\\/\\/([a-zA-Z0-9-]+\\.)?3ook\\.com$',
+          useRegExp: true,
+          methods: ['GET', 'OPTIONS'],
+          allowHeaders: ['Content-Type', 'Authorization'],
+        },
+      },
+    },
   },
 
   sourcemap: {

--- a/server/api/store/staking-books.get.ts
+++ b/server/api/store/staking-books.get.ts
@@ -1,0 +1,68 @@
+import { fetchCollectiveBookNFTs, type CollectiveBookNFTsQueryOptions } from '~~/shared/utils/collective-indexer'
+
+import { StoreStakingBooksQuerySchema } from '~~/server/schemas/store'
+
+type StakingSortBy = NonNullable<CollectiveBookNFTsQueryOptions['sort_by']>
+
+const STAKING_SORT_BY_VALUES: StakingSortBy[] = ['staked_amount', 'last_staked_at', 'number_of_stakers']
+
+function getFirstQueryValue(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value
+}
+
+// Page-1 staking listings are public and identical for every user, so a shared
+// SWR cache keeps the cross-origin indexer call off the SSR render path: past
+// maxAge a render serves the cached payload and revalidates in the background
+// (a cold key still blocks once). Per-instance with the default in-memory cache
+// driver — mirrors `fetchCachedNFTClassAggregatedMetadata` in likecoin-nft.ts.
+const fetchCachedTopStakingBookNFTs = defineCachedFunction(
+  (sortBy: StakingSortBy, sortOrder: 'asc' | 'desc', limit: number) =>
+    fetchCollectiveBookNFTs({
+      'sort_by': sortBy,
+      'sort_order': sortOrder,
+      'pagination.limit': limit,
+    }),
+  {
+    name: 'store-staking-books',
+    group: 'store',
+    swr: true,
+    maxAge: 60, // seconds
+    getKey: (sortBy, sortOrder, limit) => `${sortBy}:${sortOrder}:${limit}`,
+  },
+)
+
+export default defineEventHandler(async (event) => {
+  const query = await getValidatedQuery(event, createValidator(StoreStakingBooksQuerySchema))
+
+  const sortByRaw = getFirstQueryValue(query.sort_by)
+  const sortBy: StakingSortBy = STAKING_SORT_BY_VALUES.includes(sortByRaw as StakingSortBy)
+    ? (sortByRaw as StakingSortBy)
+    : 'staked_amount'
+  const sortOrder = getFirstQueryValue(query.sort_order) === 'asc' ? 'asc' : 'desc'
+  const limit = Math.min(Math.max(1, Number(getFirstQueryValue(query.limit)) || 100), 100)
+  const key = getFirstQueryValue(query.key)
+
+  try {
+    // Paginated cursors are short-lived and request-specific — fetch live and
+    // never cache. Page 1 is shared and served through the SWR cache.
+    if (key) {
+      setHeader(event, 'cache-control', 'no-store')
+      return await fetchCollectiveBookNFTs({
+        'sort_by': sortBy,
+        'sort_order': sortOrder,
+        'pagination.limit': limit,
+        'pagination.key': key,
+      })
+    }
+
+    setHeader(event, 'cache-control', 'public, max-age=60, stale-while-revalidate=600')
+    return await fetchCachedTopStakingBookNFTs(sortBy, sortOrder, limit)
+  }
+  catch (error) {
+    console.error(error)
+    throw createError({
+      statusCode: 500,
+      statusMessage: 'UPSTREAM_ERROR',
+    })
+  }
+})

--- a/server/schemas/store.ts
+++ b/server/schemas/store.ts
@@ -12,6 +12,15 @@ export const StoreProductsQuerySchema = v.object({
   ...PaginationFields,
 })
 
+export const StoreStakingBooksQuerySchema = v.object({
+  sort_by: v.optional(v.union([v.string(), v.array(v.string())])),
+  sort_order: v.optional(v.union([v.string(), v.array(v.string())])),
+  // Collective indexer pagination cursor (`pagination.key`); request-specific.
+  key: v.optional(v.union([v.string(), v.array(v.string())])),
+  // Cursor-based pagination — `limit` only, no offset.
+  limit: PaginationFields.limit,
+})
+
 export const StoreSearchQuerySchema = v.object({
   q: v.pipe(
     v.union([v.string(), v.array(v.string())]),


### PR DESCRIPTION
The store's 熱門 tab fetched the collective indexer cross-origin directly from the WebView. On iOS, WKWebView's NSURLSession pool can wedge a poisoned connection that fails every later fetch with "Load failed: <no response>" until the app is killed; dropping the resource hints (4f27f266) reduced but didn't eliminate it.

Route the listing through a same-origin /api/store/staking-books proxy (page 1 SWR-cached, paginated cursors live) so the cross-origin hop happens server-side, and repoint the preload accordingly.