### PR TITLE
[TAS-5896] 🐛 Relax anti-steering gates when in-app IAP is available

### DIFF
--- a/app/components/PricingPageContent.vue
+++ b/app/components/PricingPageContent.vue
@@ -142,7 +142,7 @@
           <div :class="$slots['pricing-mobile'] ? 'hidden laptop:contents' : undefined">
             <slot name="pricing">
               <div
-                v-if="!isApp || isIAPSupported"
+                v-if="canStartSubscribeFlow"
                 :class="{ 'bg-theme-cyan p-3 rounded-xl': isPaidTrial }"
               >
                 <header
@@ -256,7 +256,7 @@ const isDesktopScreen = useDesktopScreen()
 const { t: $t } = useI18n()
 const getRouteQuery = useRouteQuery()
 const { isApp } = useAppDetection()
-const { isIAPSupported } = useNativeIAP()
+const { canStartSubscribeFlow } = useNativeIAP()
 
 const emit = defineEmits<{
   'open': []

--- a/app/components/TTSPlayerModal.vue
+++ b/app/components/TTSPlayerModal.vue
@@ -126,7 +126,7 @@
 
               <template #body>
                 <div
-                  v-if="!isBookEnglish && (user?.isLikerPlus || !isApp) && !hasCustomVoice"
+                  v-if="!isBookEnglish && (user?.isLikerPlus || canStartSubscribeFlow) && !hasCustomVoice"
                   class="px-4 py-3 space-y-3 border-b border-b-muted"
                 >
                   <UButton
@@ -300,7 +300,7 @@ const affiliateUpsellVoiceValues = computed(() => {
   return new Set(bookOwnerUpsellVoices.value.map(v => encodeAffiliateVoiceId(v.id)))
 })
 
-const { isApp } = useAppDetection()
+const { canStartSubscribeFlow } = useNativeIAP()
 const isDesktopScreen = useDesktopScreen()
 
 const isFullscreen = computed(() => {
@@ -412,7 +412,9 @@ function handleTrialExhausted(source: 'server_402' | 'client_gate') {
   const payload = buildTTSEventPayload({ source })
   stopTextToSpeech()
   useLogEvent('tts_trial_exhausted', payload)
-  if (isApp.value) {
+  // Primary TTS→Plus conversion surface; only degrade to a notice when we
+  // genuinely can't route the user into a subscribe flow.
+  if (!canStartSubscribeFlow.value) {
     errorModal.open({
       title: $t('tts_free_trial_limit_error_title'),
       description: $t('tts_free_trial_limit_error_description_app'),

--- a/app/composables/use-native-iap.ts
+++ b/app/composables/use-native-iap.ts
@@ -67,6 +67,10 @@ export const useNativeIAP = createSharedComposable(() => {
 
   const isIAPSupported = computed(() => isApp.value && isNativeFeatureSupported('iap'))
 
+  // Inverse of the "no checkout in-app" anti-steering gate: true when the user
+  // can complete a purchase from the current surface (web Stripe or in-app IAP).
+  const canStartSubscribeFlow = computed(() => !isApp.value || isIAPSupported.value)
+
   let pendingPurchase: ((r: IAPPurchaseResult) => void) | null = null
   let pendingRestore: ((r: IAPRestoreResult) => void) | null = null
   let pendingOfferings: ((p: IAPOfferingPackage[]) => void) | null = null
@@ -242,5 +246,5 @@ export const useNativeIAP = createSharedComposable(() => {
     })
   }
 
-  return { isIAPSupported, purchase, restore, getOfferings, ensureOfferings, getIAPTrial, manageSubscription }
+  return { isIAPSupported, canStartSubscribeFlow, purchase, restore, getOfferings, ensureOfferings, getIAPTrial, manageSubscription }
 })

--- a/app/pages/about.vue
+++ b/app/pages/about.vue
@@ -47,7 +47,7 @@
       <div
         :class="[
           'grid',
-          { 'sm:grid-cols-2': !isApp },
+          { 'sm:grid-cols-2': canStartSubscribeFlow },
           'gap-4',
           'justify-center',
           'items-center',
@@ -65,7 +65,7 @@
           @click="onClickHeroCtaStore"
         />
         <UButton
-          v-if="!isApp"
+          v-if="canStartSubscribeFlow"
           class="text-theme-white hover:bg-theme-white/20"
           :to="localeRoute({ name: 'member', query: { ll_source: 'about-page' } })"
           :label="$t('about_page_hero_cta_plus')"
@@ -182,12 +182,7 @@
                 class="text-primary"
               />
               <h3
-                v-if="isApp"
-                class="text-xl font-semibold text-gray-900"
-                v-text="$t('about_page_feature_ai_narration')"
-              />
-              <h3
-                v-else
+                v-if="canStartSubscribeFlow"
                 class="text-xl font-semibold text-gray-900"
               >
                 <NuxtLink
@@ -198,6 +193,11 @@
                   {{ $t('about_page_feature_ai_narration') }}
                 </NuxtLink>
               </h3>
+              <h3
+                v-else
+                class="text-xl font-semibold text-gray-900"
+                v-text="$t('about_page_feature_ai_narration')"
+              />
             </div>
             <p
               class="mt-4 text-gray-700"
@@ -602,7 +602,7 @@
 
     <!-- 3ook.com Plus Membership Section -->
     <section
-      v-if="!isApp"
+      v-if="canStartSubscribeFlow"
       id="plus"
       class="w-full bg-gradient-to-r from-primary/10 to-secondary/20 py-12 px-4"
     >
@@ -675,7 +675,6 @@
           </li>
         </ul>
         <UButton
-          v-if="!isApp"
           :to="localeRoute({ name: 'member', query: { ll_source: 'about-page' } })"
           :label="$t('about_page_plus_cta')"
           color="primary"
@@ -851,6 +850,7 @@ const newsletterEmail = ref('')
 
 const metadataStore = useMetadataStore()
 const { isApp } = useAppDetection()
+const { canStartSubscribeFlow } = useNativeIAP()
 
 const authorAvatars = import.meta.glob<{ default: string }>('~/assets/images/about/avatars/*.png', { eager: true })
 function getLocalAvatar(filename: string) {

--- a/app/pages/account/index.vue
+++ b/app/pages/account/index.vue
@@ -704,7 +704,7 @@ const { handleError } = useErrorHandler()
 const toast = useToast()
 const { copy: copyToClipboard } = useClipboard()
 const { isApp } = useAppDetection()
-const { isIAPSupported, restore: restorePurchases, manageSubscription: manageViaIAP } = useNativeIAP()
+const { isIAPSupported, canStartSubscribeFlow, restore: restorePurchases, manageSubscription: manageViaIAP } = useNativeIAP()
 const intercom = useIntercom()
 
 const isRestoringPurchases = ref(false)
@@ -790,7 +790,7 @@ const colorModeLabel = computed(
   () => colorModeOptions.value.find(o => o.value === colorModePreference.value)?.label ?? '',
 )
 
-const isPlusFeatureVisible = computed(() => !isApp.value || !!user.value?.isLikerPlus)
+const isPlusFeatureVisible = computed(() => canStartSubscribeFlow.value || !!user.value?.isLikerPlus)
 
 const stripeConnectStatus = ref<FetchStripeConnectStatusResponseData>({
   hasAccount: false,
@@ -943,7 +943,7 @@ watchImmediate(hasLoggedIn, async (loggedIn) => {
     const isCustomVoiceAction = route.query.action === 'custom-voice'
     if (isCustomVoiceAction) {
       if (!user.value?.isLikerPlus) {
-        if (!isApp.value) {
+        if (canStartSubscribeFlow.value) {
           subscription.openPaywallModal({ utmSource: 'custom_voice' })
         }
         return

--- a/app/pages/member.vue
+++ b/app/pages/member.vue
@@ -180,7 +180,7 @@ const { t: $t } = useI18n()
 const config = useRuntimeConfig()
 const baseURL = config.public.baseURL
 
-const { isApp } = useAppDetection()
+const { canStartSubscribeFlow } = useNativeIAP()
 const { loggedIn: hasLoggedIn } = useUserSession()
 const accountStore = useAccountStore()
 const { displayCurrency } = usePaymentCurrency()
@@ -466,7 +466,7 @@ async function handleSubscribe(payload: {
 }
 
 onMounted(async () => {
-  if (isApp.value) {
+  if (!canStartSubscribeFlow.value) {
     await navigateTo(localeRoute({ name: 'store' }))
     return
   }


### PR DESCRIPTION
The pre-IAP era hard-blocked every subscribe and upsell entry in-app for App Store anti-steering compliance. Now that StoreKit/Play IAP exists, the gates should fire only when there is no purchase route at all — web Stripe or in-app IAP.

Add canStartSubscribeFlow on useNativeIAP (= !isApp || isIAPSupported) and route the gates through it:
- /member: stays renderable in-app when IAP is available
- /account: Plus feature rows + custom-voice paywall trigger reachable
- TTS player: custom-voice row + trial-exhausted paywall reachable

The pre-existing PricingPageContent gate adopts the same flag, so the "can subscribe from here" predicate now lives in one place. No behavior change on app builds where the native shell does not yet advertise iap.