### PR TITLE
💄 Restore missing restore-purchases icon on the account page

### DIFF
--- a/app/pages/account/index.vue
+++ b/app/pages/account/index.vue
@@ -237,7 +237,7 @@
     >
       <UCard :ui="{ body: '!p-0 divide-y-1 divide-(--ui-border)' }">
         <AccountSettingsItem
-          icon="i-material-symbols-restore-rounded"
+          icon="i-material-symbols-sync-rounded"
           :label="$t('account_restore_purchases_label')"
         >
           <div


### PR DESCRIPTION
i-material-symbols-restore-rounded doesn't exist in the iconify material-symbols set (only restore-from-trash-* and restore-page-* variants ship), so the icon silently rendered nothing and the row broke alignment with its neighbours. Swap to sync-rounded, already used for store-sync semantics elsewhere in the app.