### PR TITLE
🐛 Send Origin from book-file proxy to fix ORIGIN_NOT_FOUND

### DIFF
--- a/server/api/book-file.get.ts
+++ b/server/api/book-file.get.ts
@@ -46,6 +46,10 @@ export default defineEventHandler(async (event) => {
   const upstreamHeaders: Record<string, string> = {
     Authorization: `Bearer ${token}`,
   }
+  // Server-to-server `fetch` sends no `Origin`, but `/ebook-cors/` rejects an
+  // absent Origin with `ORIGIN_NOT_FOUND`. Send our own (whitelisted) origin so
+  // its CORS gate passes; the real auth boundary upstream is the Bearer JWT.
+  if (config.public.baseURL) upstreamHeaders.Origin = config.public.baseURL
   const rangeHeader = getHeader(event, 'range')
   if (rangeHeader) upstreamHeaders.Range = rangeHeader
 


### PR DESCRIPTION
The server-side proxy added in 0f582c61 fetches `/ebook-cors/` server-to-server, which sends no Origin header — but the upstream CORS gate rejects an absent Origin with ORIGIN_NOT_FOUND, blocking the request before the Bearer JWT/ownership check runs. Attach our own whitelisted origin (BASE_URL) so the gate passes.