### PR TITLE
✨ Display publisher description on book product page

### DIFF
--- a/app/pages/store/[nftClassId]/index.vue
+++ b/app/pages/store/[nftClassId]/index.vue
@@ -269,6 +269,15 @@
           </ExpandableContent>
         </template>
 
+        <template #publisher>
+          <ExpandableContent>
+            <div
+              class="markdown"
+              v-html="publisherDescriptionHTML"
+            />
+          </ExpandableContent>
+        </template>
+
         <template #table-of-contents>
           <ExpandableContent>
             <div
@@ -1179,6 +1188,10 @@ const authorDescriptionHTML = computed(() => {
   return renderDescription(bookInfo.authorDescription?.value || '')
 })
 
+const publisherDescriptionHTML = computed(() => {
+  return renderDescription(bookInfo.publisherDescription?.value || '')
+})
+
 const buyerMessages = computed(() => {
   const messages = nftStore.getMessagesByNFTClassId(nftClassId.value)
   if (!messages) return []
@@ -1220,6 +1233,14 @@ const infoTabItems = computed(() => {
       label: $t('product_page_info_tab_author_description'),
       slot: 'author',
       value: 'author',
+    })
+  }
+
+  if (bookInfo.publisherDescription.value) {
+    items.push({
+      label: $t('product_page_info_tab_publisher_description'),
+      slot: 'publisher',
+      value: 'publisher',
     })
   }
 

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -690,6 +690,7 @@
   "product_page_info_tab_description": "Description",
   "product_page_info_tab_file_info": "File Info",
   "product_page_info_tab_preview_content": "Preview",
+  "product_page_info_tab_publisher_description": "Publisher",
   "product_page_info_tab_table_of_contents": "Table of Contents",
   "product_page_not_found_error": "Book not found",
   "product_page_plus_promo_description": "Get 1 month of 3ook.com Plus free after purchasing this book. We'll email you a coupon code.",

--- a/i18n/locales/zh-Hant.json
+++ b/i18n/locales/zh-Hant.json
@@ -690,6 +690,7 @@
   "product_page_info_tab_description": "內容簡介",
   "product_page_info_tab_file_info": "檔案資訊",
   "product_page_info_tab_preview_content": "試閱",
+  "product_page_info_tab_publisher_description": "出版社簡介",
   "product_page_info_tab_table_of_contents": "目錄",
   "product_page_not_found_error": "找不到書本",
   "product_page_plus_promo_description": "購買本書即獲 Plus 會員資格，享全站暢聽、獨家聲線與購書折扣無上限！優惠碼將以電子郵件寄送。",

--- a/shared/utils/indexer.ts
+++ b/shared/utils/indexer.ts
@@ -147,14 +147,51 @@ export async function fetchNFTClassesByMetadata(
     }
   }
   else if (filterType === 'publisher') {
-    if (!options.filter) {
-      options.filter = {}
+    // For publisher searches, query both 'publisher.name' and 'publisher' fields
+    const publisherNameOptions = {
+      ...options,
+      filter: { ...options.filter, 'publisher.name': escapedFilterValue },
     }
-    options.filter.publisher = filterValue
+    const publisherOptions = {
+      ...options,
+      filter: { ...options.filter, publisher: escapedFilterValue },
+    }
 
-    return fetch<FetchBookNFTsResponseData>(`/booknfts`, {
-      query: getIndexerQueryOptions(options),
+    const [publisherNameResult, publisherResult] = await Promise.all([
+      fetch<FetchBookNFTsResponseData>(`/booknfts`, {
+        query: getIndexerQueryOptions(publisherNameOptions),
+      }),
+      fetch<FetchBookNFTsResponseData>(`/booknfts`, {
+        query: getIndexerQueryOptions(publisherOptions),
+      }),
+    ])
+
+    // Merge results and remove duplicates
+    const combinedDataMap: Record<string, NFTClass> = {}
+    publisherNameResult.data.forEach((item) => {
+      combinedDataMap[item.address] = item
     })
+    publisherResult.data.forEach((item) => {
+      combinedDataMap[item.address] = item
+    })
+    const combinedData = Object.values(combinedDataMap)
+
+    const queryOptions = getIndexerQueryOptions(options)
+    const actualLimit = parseInt(queryOptions['pagination.limit'] || '30')
+
+    const publisherNameNextKey = publisherNameResult.data.length >= actualLimit ? publisherNameResult.pagination.next_key : undefined
+    const publisherNextKey = publisherResult.data.length >= actualLimit ? publisherResult.pagination.next_key : undefined
+    const combinedNextKey = publisherNameNextKey !== undefined && publisherNextKey !== undefined
+      ? Math.min(publisherNameNextKey, publisherNextKey)
+      : publisherNameNextKey ?? publisherNextKey
+
+    return {
+      data: combinedData,
+      pagination: {
+        count: combinedData.length,
+        next_key: combinedNextKey,
+      },
+    }
   }
 
   throw createError({ statusCode: 400, statusMessage: `Unsupported filter type: ${filterType}` })

--- a/shared/utils/indexer.ts
+++ b/shared/utils/indexer.ts
@@ -99,102 +99,53 @@ export async function fetchNFTClassesByMetadata(
   const fetch = getIndexerAPIFetch()
   const escapedFilterValue = escapeCommasForFilter(filterValue)
 
-  if (filterType === 'author') {
-    // For author searches, query both 'author.name' and 'author' fields
-    const authorNameOptions = {
-      ...options,
-      filter: { ...options.filter, 'author.name': escapedFilterValue },
-    }
-    const authorOptions = {
-      ...options,
-      filter: { ...options.filter, author: escapedFilterValue },
-    }
-
-    const [authorNameResult, authorResult] = await Promise.all([
-      fetch<FetchBookNFTsResponseData>(`/booknfts`, {
-        query: getIndexerQueryOptions(authorNameOptions),
-      }),
-      fetch<FetchBookNFTsResponseData>(`/booknfts`, {
-        query: getIndexerQueryOptions(authorOptions),
-      }),
-    ])
-
-    // Merge results and remove duplicates
-    const combinedDataMap: Record<string, NFTClass> = {}
-    authorNameResult.data.forEach((item) => {
-      combinedDataMap[item.address] = item
-    })
-    authorResult.data.forEach((item) => {
-      combinedDataMap[item.address] = item
-    })
-    const combinedData = Object.values(combinedDataMap)
-
-    const queryOptions = getIndexerQueryOptions(options)
-    const actualLimit = parseInt(queryOptions['pagination.limit'] || '30')
-
-    const authorNameNextKey = authorNameResult.data.length >= actualLimit ? authorNameResult.pagination.next_key : undefined
-    const authorNextKey = authorResult.data.length >= actualLimit ? authorResult.pagination.next_key : undefined
-    const combinedNextKey = authorNameNextKey !== undefined && authorNextKey !== undefined
-      ? Math.min(authorNameNextKey, authorNextKey)
-      : authorNameNextKey ?? authorNextKey
-
-    return {
-      data: combinedData,
-      pagination: {
-        count: combinedData.length,
-        next_key: combinedNextKey,
-      },
-    }
+  // Query both the structured `<type>.name` field and the plain `<type>` field
+  const nameOptions = {
+    ...options,
+    filter: { ...options.filter, [`${filterType}.name`]: escapedFilterValue },
   }
-  else if (filterType === 'publisher') {
-    // For publisher searches, query both 'publisher.name' and 'publisher' fields
-    const publisherNameOptions = {
-      ...options,
-      filter: { ...options.filter, 'publisher.name': escapedFilterValue },
-    }
-    const publisherOptions = {
-      ...options,
-      filter: { ...options.filter, publisher: escapedFilterValue },
-    }
-
-    const [publisherNameResult, publisherResult] = await Promise.all([
-      fetch<FetchBookNFTsResponseData>(`/booknfts`, {
-        query: getIndexerQueryOptions(publisherNameOptions),
-      }),
-      fetch<FetchBookNFTsResponseData>(`/booknfts`, {
-        query: getIndexerQueryOptions(publisherOptions),
-      }),
-    ])
-
-    // Merge results and remove duplicates
-    const combinedDataMap: Record<string, NFTClass> = {}
-    publisherNameResult.data.forEach((item) => {
-      combinedDataMap[item.address] = item
-    })
-    publisherResult.data.forEach((item) => {
-      combinedDataMap[item.address] = item
-    })
-    const combinedData = Object.values(combinedDataMap)
-
-    const queryOptions = getIndexerQueryOptions(options)
-    const actualLimit = parseInt(queryOptions['pagination.limit'] || '30')
-
-    const publisherNameNextKey = publisherNameResult.data.length >= actualLimit ? publisherNameResult.pagination.next_key : undefined
-    const publisherNextKey = publisherResult.data.length >= actualLimit ? publisherResult.pagination.next_key : undefined
-    const combinedNextKey = publisherNameNextKey !== undefined && publisherNextKey !== undefined
-      ? Math.min(publisherNameNextKey, publisherNextKey)
-      : publisherNameNextKey ?? publisherNextKey
-
-    return {
-      data: combinedData,
-      pagination: {
-        count: combinedData.length,
-        next_key: combinedNextKey,
-      },
-    }
+  const valueOptions = {
+    ...options,
+    filter: { ...options.filter, [filterType]: escapedFilterValue },
   }
 
-  throw createError({ statusCode: 400, statusMessage: `Unsupported filter type: ${filterType}` })
+  const [nameResult, valueResult] = await Promise.all([
+    fetch<FetchBookNFTsResponseData>(`/booknfts`, {
+      query: getIndexerQueryOptions(nameOptions),
+    }),
+    fetch<FetchBookNFTsResponseData>(`/booknfts`, {
+      query: getIndexerQueryOptions(valueOptions),
+    }),
+  ])
+
+  // Merge results and remove duplicates
+  const combinedDataMap: Record<string, NFTClass> = {}
+  nameResult.data.forEach((item) => {
+    combinedDataMap[item.address] = item
+  })
+  valueResult.data.forEach((item) => {
+    combinedDataMap[item.address] = item
+  })
+  const combinedData = Object.values(combinedDataMap)
+
+  const actualLimit = options.limit || 30
+  // Merging two queries can yield more than `actualLimit` items; cap to keep
+  // the caller's `data.length === limit` pagination check working.
+  const limitedData = combinedData.slice(0, actualLimit)
+
+  const nameNextKey = nameResult.data.length >= actualLimit ? nameResult.pagination.next_key : undefined
+  const valueNextKey = valueResult.data.length >= actualLimit ? valueResult.pagination.next_key : undefined
+  const combinedNextKey = nameNextKey !== undefined && valueNextKey !== undefined
+    ? Math.min(nameNextKey, valueNextKey)
+    : nameNextKey ?? valueNextKey
+
+  return {
+    data: limitedData,
+    pagination: {
+      count: limitedData.length,
+      next_key: combinedNextKey,
+    },
+  }
 }
 
 export function fetchNFTsByOwnerWalletAddress(walletAddress: string, options: IndexerQueryOptions = {}) {


### PR DESCRIPTION
Render a publisher description tab mirroring the author one, and extend publisher search to query both publisher.name and publisher so object-shaped publisher metadata stays searchable.
<img width="809" height="166" alt="image" src="https://github.com/user-attachments/assets/e2c379c8-abb0-4dd0-816a-655cda3f28ba" />
