### PR TITLE
🔧 Exclude /store paths from iOS universal links

### DIFF
--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -5,6 +5,22 @@
         "appIDs": ["SQMQJBU5RU.land.liker.book3app"],
         "components": [
           {
+            "/": "/store",
+            "exclude": true
+          },
+          {
+            "/": "/store/*",
+            "exclude": true
+          },
+          {
+            "/": "/checkout",
+            "exclude": true
+          },
+          {
+            "/": "/plus/checkout",
+            "exclude": true
+          },
+          {
             "/": "*"
           }
         ]


### PR DESCRIPTION
Keep /store and /store/* opening in the browser instead of deep-linking into the native app, ahead of the catch-all so the excludes match first.