### PR TITLE
✨ Auto-burst stale TTS cache when pronunciation dict changes

### DIFF
--- a/server/api/reader/tts.get.ts
+++ b/server/api/reader/tts.get.ts
@@ -32,6 +32,8 @@ async function serveCachedTTS(
   cacheKey: string,
   contentFormat: string,
   wallet: string,
+  dictVersion: string,
+  getExpectedSig: () => string,
 ): Promise<unknown | null> {
   const file = bucket.file(cacheKey)
   let totalSize: number
@@ -40,6 +42,11 @@ async function serveCachedTTS(
     const metadata = await file.getMetadata()
     totalSize = Number(metadata[0].size)
     contentType = metadata[0].contentType || contentFormat
+    // Auto-burst stale audio when the pronunciation dictionary changes.
+    const meta = metadata[0].metadata ?? {}
+    if (isCachedTTSPronunciationStale({ file, meta, dictVersion, getExpectedSig, cacheKey, label: `user ${wallet}` })) {
+      return null
+    }
   }
   catch (error: unknown) {
     if ((error as { code?: number })?.code === 404) return null
@@ -212,6 +219,14 @@ export default defineEventHandler(async (event) => {
   }
 
   const ttsModel = getMinimaxModel({ voiceId, customVoiceId: customMiniMaxVoiceId, language })
+  // Dictionary version + per-text applicable-rules signature drive cache
+  // invalidation, stamped on write and compared on read so a pronunciation edit
+  // auto-bursts exactly the affected segments. The version is a cheap stamp; the
+  // signature (a ~6k-entry scan for zh-TW) is computed lazily — only on a cache
+  // miss or the version-mismatch check after an edit — so steady-state hits
+  // never pay for it. Built from the synthesized text the provider sends.
+  const dictVersion = TTS_PRONUNCIATION_VERSION[language] ?? 'none'
+  const getExpectedSig = createTTSPronunciationSigGetter(language, text)
   const bucket = getTTSCacheBucket()
   const isCacheEnabled = !!bucket
   const cacheKey = isCacheEnabled
@@ -224,7 +239,7 @@ export default defineEventHandler(async (event) => {
 
   if (isCacheEnabled) {
     try {
-      const result = await serveCachedTTS(event, bucket, cacheKey!, provider.format, session.user.evmWallet)
+      const result = await serveCachedTTS(event, bucket, cacheKey!, provider.format, session.user.evmWallet, dictVersion, getExpectedSig)
       if (result !== null) {
         publishEvent(event, 'TTSCacheHit', ttsEventBase)
         return result
@@ -243,7 +258,7 @@ export default defineEventHandler(async (event) => {
       console.log(`[Speech] In-flight dedup for user ${session.user.evmWallet}: ${cacheKey}`)
       try {
         await pending
-        const result = await serveCachedTTS(event, bucket!, cacheKey, provider.format, session.user.evmWallet)
+        const result = await serveCachedTTS(event, bucket!, cacheKey, provider.format, session.user.evmWallet, dictVersion, getExpectedSig)
         if (result !== null) return result
         console.warn(`[Speech] In-flight dedup cache miss after wait, generating own for user ${session.user.evmWallet}: ${cacheKey}`)
       }
@@ -302,6 +317,8 @@ export default defineEventHandler(async (event) => {
       nftClassId,
       text: text.length > 1800 ? text.substring(0, 1800) + '...' : text,
       textLength: text.length.toString(),
+      pronunciationVersion: dictVersion,
+      pronunciationSig: getExpectedSig(),
       createdAt: new Date().toISOString(),
     },
   }

--- a/server/api/tts/sample.get.ts
+++ b/server/api/tts/sample.get.ts
@@ -15,6 +15,8 @@ async function serveCachedSample(
   bucket: NonNullable<ReturnType<typeof getTTSCacheBucket>>,
   cacheKey: string,
   contentFormat: string,
+  dictVersion: string,
+  getExpectedSig: () => string,
 ): Promise<unknown | null> {
   const file = bucket.file(cacheKey)
   let totalSize: number
@@ -23,6 +25,11 @@ async function serveCachedSample(
     const metadata = await file.getMetadata()
     totalSize = Number(metadata[0].size)
     contentType = metadata[0].contentType || contentFormat
+    // Auto-burst stale sample audio when the pronunciation dictionary changes.
+    const meta = metadata[0].metadata ?? {}
+    if (isCachedTTSPronunciationStale({ file, meta, dictVersion, getExpectedSig, cacheKey, label: 'sample' })) {
+      return null
+    }
   }
   catch (error: unknown) {
     if ((error as { code?: number })?.code === 404) return null
@@ -114,6 +121,12 @@ export default defineEventHandler(async (event) => {
 
   const provider = new MinimaxTTSProvider()
   const ttsModel = getMinimaxModel({ voiceId, customVoiceId: customMiniMaxVoiceId, language })
+  // Stamp + check the pronunciation dictionary version so a dict edit
+  // auto-bursts affected sample audio, mirroring the reader endpoint. The
+  // signature is computed lazily (only on cache miss or version mismatch) from
+  // the synthesized text the provider sends.
+  const dictVersion = TTS_PRONUNCIATION_VERSION[language] ?? 'none'
+  const getExpectedSig = createTTSPronunciationSigGetter(language, text)
   const bucket = getTTSCacheBucket()
   const isCacheEnabled = !!bucket
   const cacheKey = isCacheEnabled
@@ -124,7 +137,7 @@ export default defineEventHandler(async (event) => {
 
   if (isCacheEnabled && cacheKey) {
     try {
-      const result = await serveCachedSample(event, bucket, cacheKey, provider.format)
+      const result = await serveCachedSample(event, bucket, cacheKey, provider.format, dictVersion, getExpectedSig)
       if (result !== null) return result
     }
     catch (error) {
@@ -139,7 +152,7 @@ export default defineEventHandler(async (event) => {
     if (pending) {
       try {
         await pending
-        const result = await serveCachedSample(event, bucket!, cacheKey, provider.format)
+        const result = await serveCachedSample(event, bucket!, cacheKey, provider.format, dictVersion, getExpectedSig)
         if (result !== null) return result
       }
       catch {
@@ -204,6 +217,8 @@ export default defineEventHandler(async (event) => {
           text,
           textLength: text.length.toString(),
           isSample: 'true',
+          pronunciationVersion: dictVersion,
+          pronunciationSig: getExpectedSig(),
           createdAt: new Date().toISOString(),
         },
       },

--- a/server/utils/tts-minimax.ts
+++ b/server/utils/tts-minimax.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import type { BaseTTSProvider, TTSProviderResult, TTSProviderStreamResult, TTSRequestParams } from './api-tts'
 import zhHKPronunciation from './tts-pronunciation/zh-HK.json'
 import zhTWPronunciation from './tts-pronunciation/zh-TW.json'
@@ -76,6 +77,82 @@ export function getTTSPronunciationDictionary(
   const tone = getApplicablePronunciationRules(language, synthesizedText)
     .map(([target, override]) => `${target}/${override}`)
   return tone.length ? { tone } : undefined
+}
+
+// Per-language content hash of the pronunciation rules, computed once at module
+// load. Editing either JSON changes its hash automatically — no manual bump — so
+// cached TTS audio can detect it was generated under a now-outdated dictionary.
+// Per-language so a zh-HK edit leaves every zh-TW cache entry untouched.
+export const TTS_PRONUNCIATION_VERSION: Record<string, string> = Object.fromEntries(
+  Object.entries(TTS_PRONUNCIATION_RULES).map(([language, rules]) =>
+    [language, createHash('sha256').update(JSON.stringify(rules)).digest('hex').slice(0, 12)]),
+)
+
+// Signature for text no pronunciation rule applies to. Shared so the cache's
+// legacy-entry default (server/api/reader/tts.get.ts) stays in lockstep with
+// what getTTSPronunciationSignature emits — if they drift, dict-free legacy
+// audio would wrongly regenerate.
+export const NO_PRONUNCIATION_SIG = 'none'
+
+// Hash of only the pronunciation rules that apply to this exact text — the
+// change detector behind cache invalidation. Derives from the same dictionary
+// the generator sends to Minimax, so pass the post-`injectTTSPauseMarkers` text
+// (a marker spliced into a clause-spanning idiom changes which rules match).
+export function getTTSPronunciationSignature(language: string, synthesizedText: string): string {
+  const dict = getTTSPronunciationDictionary(language, synthesizedText)
+  if (!dict) return NO_PRONUNCIATION_SIG
+  return createHash('sha256').update(dict.tone.join('\n')).digest('hex').slice(0, 16)
+}
+
+// Memoizing getter for a request's pronunciation signature: computes the
+// (~6k-entry for zh-TW) dictionary scan at most once, and only when actually
+// called — so a steady-state cache hit whose version stamp matches never pays
+// for it. Shared by the reader and sample TTS endpoints.
+export function createTTSPronunciationSigGetter(language: string, text: string): () => string {
+  let sig: string | undefined
+  return () => (sig ??= getTTSPronunciationSignature(language, injectTTSPauseMarkers(text)))
+}
+
+// Mirrors Google Cloud Storage's custom-metadata value type (`getMetadata()[0]
+// .metadata`), whose values are coerced to these primitives.
+type CloudStorageMetadata = Record<string, string | number | boolean | null>
+
+// Cache keys whose stamp refresh is already in flight this process, so the
+// concurrent range probes a single playback fans out (see `inFlightWrites` in
+// the TTS endpoints) collapse to one metadata PATCH instead of a write burst.
+const refreshingPronunciationStamps = new Set<string>()
+
+// Decides whether cached TTS audio is stale after a pronunciation-dict edit,
+// shared by the reader and sample endpoints. A version-stamp match is the fast
+// path — the audio is current, so the (~6k-entry) signature scan never runs.
+// On a version miss the segment is stale only if its applicable rules differ
+// from what it was generated with; legacy entries (no stamp) are treated as
+// having had no overrides ('none'), so dict-free text is left alone while text
+// that now needs a replacement is regenerated. When the rules are unchanged we
+// refresh the stamp (fire-and-forget, de-duped per process) so future hits take
+// the version fast-path instead of rescanning every time.
+export function isCachedTTSPronunciationStale(options: {
+  file: { setMetadata: (metadata: { metadata: CloudStorageMetadata }) => Promise<unknown> }
+  meta: CloudStorageMetadata
+  dictVersion: string
+  getExpectedSig: () => string
+  cacheKey: string
+  label: string
+}): boolean {
+  const { file, meta, dictVersion, getExpectedSig, cacheKey, label } = options
+  if (meta.pronunciationVersion === dictVersion) return false
+  const expectedSig = getExpectedSig()
+  if (expectedSig !== (meta.pronunciationSig ?? NO_PRONUNCIATION_SIG)) {
+    console.log(`[Speech] Stale pronunciation for ${label}, regenerating: ${cacheKey}`)
+    return true
+  }
+  if (!refreshingPronunciationStamps.has(cacheKey)) {
+    refreshingPronunciationStamps.add(cacheKey)
+    file.setMetadata({ metadata: { ...meta, pronunciationVersion: dictVersion, pronunciationSig: expectedSig } })
+      .catch((error: unknown) => console.warn(`[Speech] Failed to refresh pronunciation metadata for ${label}: ${cacheKey}`, error))
+      .finally(() => { refreshingPronunciationStamps.delete(cacheKey) })
+  }
+  return false
 }
 
 // Alternative to `pronunciationDict`: splice the override straight into the

--- a/test/unit/tts-minimax.test.ts
+++ b/test/unit/tts-minimax.test.ts
@@ -1,3 +1,7 @@
+// @vitest-environment node
+// These are pure string helpers needing no DOM; the default `nuxt` (unenv)
+// environment stubs out node:crypto, which tts-minimax.ts touches at import
+// time (TTS_PRONUNCIATION_VERSION), so import fails there. Run under real Node.
 import { describe, expect, it } from 'vitest'
 import { applyInlinePronunciation, getTTSPronunciationDictionary, injectTTSPauseMarkers } from '~~/server/utils/tts-minimax'
 


### PR DESCRIPTION
Stamp each cached TTS object with a content-hash of the pronunciation dictionary plus a signature of the rules that actually applied to that segment. On a cache hit, a version match short-circuits; otherwise the segment regenerates only when its applicable rules truly changed — so editing zh-HK.json / zh-TW.json invalidates exactly the affected audio and leaves dict-free segments untouched. Legacy entries without a stamp are treated as having had no overrides, so only ones needing a replacement are reburst. The per-segment signature is computed lazily to keep steady-state hits off the ~6k-entry scan.