### PR TITLE
🚀 Throttle TTS position updates and skip background scroll

### DIFF
--- a/app/components/TTSPlayerModal.vue
+++ b/app/components/TTSPlayerModal.vue
@@ -543,13 +543,32 @@ const offlineModalActions = computed(() => [
   },
 ])
 
-watch(currentTTSSegmentIndex, async (newIndex: number) => {
+const documentVisibility = useDocumentVisibility()
+
+async function scrollToCurrentSegment(index: number) {
   await nextTick()
-  const el = visibleSegmentElements.get(newIndex)
+  const el = visibleSegmentElements.get(index)
   el?.scrollIntoView({
     behavior: 'smooth',
     block: 'center',
   })
+}
+
+watch(currentTTSSegmentIndex, (newIndex: number) => {
+  // Skip the smooth-scroll animation while the app/tab is backgrounded: it
+  // produces no visible result but still costs layout/composite cycles that
+  // iOS WebKit may service in the background during long listening sessions.
+  // The visibility watch below re-centers on foreground to cover skipped advances.
+  if (documentVisibility.value !== 'visible') return
+  scrollToCurrentSegment(newIndex)
+})
+
+// Catch up on return to foreground: background segment advances skip the scroll
+// above, so re-center on the current segment (which may have moved on, or stayed
+// put if playback was paused while backgrounded) once we're visible again.
+watch(documentVisibility, (state) => {
+  if (state !== 'visible') return
+  scrollToCurrentSegment(currentTTSSegmentIndex.value)
 })
 
 const hasStartedPlaying = ref(false)

--- a/app/composables/use-text-to-speech.ts
+++ b/app/composables/use-text-to-speech.ts
@@ -1,4 +1,4 @@
-import { useDocumentVisibility, useEventListener, useStorage } from '@vueuse/core'
+import { useDocumentVisibility, useEventListener, useStorage, useThrottleFn } from '@vueuse/core'
 import type { CustomVoiceData, AffiliateVoiceData } from '~~/shared/types/custom-voice'
 import { computeTTSTextSig, decodeAffiliateVoiceId, isAffiliateVoiceId } from '~~/shared/utils/tts-sig'
 
@@ -434,9 +434,14 @@ export function useTextToSpeech(options: TTSOptions) {
     }
   }
 
-  player.on('positionState', () => {
-    updatePositionState()
-  })
+  // The web audio engine fires 'positionState' from `ontimeupdate` up to
+  // ~60x/sec. setPositionState() hits the iOS WebKit Now-Playing service on
+  // every call, wasting CPU (and battery) to keep the lock-screen scrubber
+  // accurate to the millisecond — ~1s granularity is plenty. The native audio
+  // engine never emits 'positionState', so this throttle is a web/PWA-only path.
+  const throttledUpdatePositionState = useThrottleFn(updatePositionState, 1000, true)
+
+  player.on('positionState', throttledUpdatePositionState)
 
   player.on('rateForced', (rate) => {
     effectivePlaybackRate.value = rate


### PR DESCRIPTION
ontimeupdate fired the positionState handler up to ~60x/sec, hitting the iOS WebKit Now-Playing service on every tick just to keep the lock-screen scrubber millisecond-accurate — wasted CPU and battery during long listening sessions. Throttle setPositionState to ~1s. Also skip the per-segment smooth scrollIntoView while the tab/app is backgrounded, where it produces no visible result but still costs layout/composite work.