### PR TITLE
🐛 Surface upstream wallet-auth errors and hint clock skew

### DIFF
--- a/app/composables/use-error-handler.ts
+++ b/app/composables/use-error-handler.ts
@@ -63,6 +63,12 @@ export default function () {
           }
           break
 
+        case 'WALLET_AUTHORIZATION_PAYLOAD_EXPIRED':
+          handler = {
+            description: $t('error_wallet_authorization_payload_expired'),
+          }
+          break
+
         default:
           break
       }

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -419,6 +419,7 @@
   "error_unknown": "Unknown error.",
   "error_unstake_amount_exceeded": "Amount exceeds your stake",
   "error_unstake_amount_exceeded_description": "You can only unstake up to {amount} LIKE.",
+  "error_wallet_authorization_payload_expired": "Your login signature has expired. Please make sure your device's date and time are correct, then try again.",
   "error_wallet_session_expired": "Your wallet session has expired. Please log in again to continue.",
   "expandable_content_show_less_button_label": "Show Less",
   "expandable_content_show_more_button_label": "Show More",

--- a/i18n/locales/zh-Hant.json
+++ b/i18n/locales/zh-Hant.json
@@ -419,6 +419,7 @@
   "error_unknown": "未知錯誤",
   "error_unstake_amount_exceeded": "超過可解除質押的數量",
   "error_unstake_amount_exceeded_description": "你只能解除 {amount} LIKE 的質押數量。",
+  "error_wallet_authorization_payload_expired": "登入簽署已過期，請確認裝置的日期及時間設定正確後再試。",
   "error_wallet_session_expired": "錢包連線已過期，請重新登入再繼續。",
   "expandable_content_show_less_button_label": "收起內容",
   "expandable_content_show_more_button_label": "查看更多",

--- a/server/api/login.post.ts
+++ b/server/api/login.post.ts
@@ -1,5 +1,6 @@
 import { jwtDecode } from 'jwt-decode'
 import { FieldValue } from 'firebase-admin/firestore'
+import { FetchError } from 'ofetch'
 
 import { LoginBodySchema } from '~~/server/schemas/auth'
 
@@ -31,10 +32,31 @@ export default defineEventHandler(async (event) => {
     intercomToken = authorizeRes.intercomToken
   }
   catch (error) {
-    console.error('Failed to authorize wallet:', error)
+    // Unwrap the upstream response body so the actual failure reason isn't swallowed.
+    // ofetch exposes a text body as a string in `error.data`, or a parsed JSON body's fields.
+    let upstreamError: string | undefined
+    if (error instanceof FetchError) {
+      const data = error.data as string | { error?: string, message?: string } | undefined
+      upstreamError = typeof data === 'string'
+        ? data
+        : data?.error || data?.message
+    }
+
+    console.error('Failed to authorize wallet:', error, upstreamError)
+
+    // A signed message that's no longer valid almost always means the device clock is off.
+    if (upstreamError === 'PAYLOAD_EXPIRED') {
+      throw createError({
+        status: 401,
+        message: 'WALLET_AUTHORIZATION_PAYLOAD_EXPIRED',
+      })
+    }
+
     throw createError({
       status: 401,
-      message: 'WALLET_AUTHORIZATION_FAILED',
+      message: upstreamError
+        ? `WALLET_AUTHORIZATION_FAILED: ${upstreamError}`
+        : 'WALLET_AUTHORIZATION_FAILED',
     })
   }
 


### PR DESCRIPTION
Login swallowed every /wallet/authorize failure as a generic WALLET_AUTHORIZATION_FAILED. Unwrap the ofetch text/JSON body so the real reason is logged and shown, and map the upstream PAYLOAD_EXPIRED case to a friendly prompt asking the user to fix their device clock.