### PR TITLE
🏗️ Delete Firestore session doc on logout

### DIFF
--- a/server/api/logout.post.ts
+++ b/server/api/logout.post.ts
@@ -2,6 +2,14 @@ export default defineEventHandler(async (event) => {
   const session = await getUserSession(event)
   const evmWallet = session?.user?.evmWallet
   const likerId = session?.user?.likerId
+  const jwtId = session?.user?.jwtId
+
+  // Drop the server-side session record before clearing the cookie. Once the JWT
+  // lives only in Firestore (later migration steps), this is what revokes it on
+  // logout — clearing the cookie alone wouldn't.
+  if (evmWallet && jwtId) {
+    await deleteSessionTokens(evmWallet, jwtId)
+  }
 
   await clearUserSession(event)
 

--- a/server/utils/session-tokens.ts
+++ b/server/utils/session-tokens.ts
@@ -67,6 +67,18 @@ export async function saveSessionTokens(
   }
 }
 
+export async function deleteSessionTokens(wallet: string, jwtId: string): Promise<void> {
+  // Best-effort: a failed delete must never block logout. Deleting a missing
+  // doc is a Firestore no-op, so legacy sessions that pre-date the subcollection
+  // need no special handling.
+  try {
+    await getSessionDocRef(wallet, jwtId).delete()
+  }
+  catch (error) {
+    console.warn('[SessionTokens] Failed to delete session tokens:', error)
+  }
+}
+
 export async function refreshSessionTokens(
   wallet: string,
   jwtId: string,


### PR DESCRIPTION
Logout cleared the cookie but left the persisted session record behind, so docs accumulated as orphans and the JWT stayed valid server-side. Add deleteSessionTokens and call it from logout before clearing the cookie — once the token lives only in Firestore, this is what revokes it. Best-effort: a failed delete never blocks logout.