### PR TITLE
🔋 Defer WalletConnect reconnect to avoid idle relayer socket

### DIFF
--- a/app/plugins/wagmi.ts
+++ b/app/plugins/wagmi.ts
@@ -32,6 +32,10 @@ export default defineNuxtPlugin((nuxtApp) => {
         try {
           const recentId = await wagmiConfig.storage?.getItem('recentConnectorId')
           if (!recentId) return
+          // WalletConnect's relayer holds a live websocket whose ~2s heartbeat
+          // keeps the tab awake (battery drain during reading/TTS). Skip restore
+          // on mount; first on-chain action reconnects via restoreConnection().
+          if (recentId === 'walletConnect') return
           const connector = wagmiConfig.connectors.find(c => c.id === recentId)
           if (!connector) return
           await reconnect(wagmiConfig, { connectors: [connector] })


### PR DESCRIPTION
Restoring a WalletConnect session on mount opens its relayer websocket, whose ~2s heartbeat keeps the tab awake and drains battery during reading and TTS. Skip eager restore for walletConnect; the first on-chain action reconnects on demand via accountStore.restoreConnection(). Other connectors (magic, injected) still reconnect on mount as before.