### PR TITLE
🔋 Drop perpetual spin on the index redirect splash

### DIFF
--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -1,7 +1,6 @@
 <template>
   <main class="justify-center items-center w-full max-w-[1440px] mx-auto px-12 opacity-20">
     <UIcon
-      class="animate-spin"
       name="material-symbols-progress-activity"
       size="128"
     />


### PR DESCRIPTION
The `/` page only exists to navigateTo store/shelf, but its loader ran an ungated animate-spin. Under Suspense the splash can linger if the redirect or destination stalls, leaving an infinite CSS transform that keeps WebContent at high energy. Keep the static icon, drop the spin.