### PR TITLE
🔡 Normalize email to lowercase on login and registration

### DIFF
--- a/app/components/LoginPanel.vue
+++ b/app/components/LoginPanel.vue
@@ -8,7 +8,7 @@
 
     <form
       class="mt-6 flex flex-col gap-2"
-      @submit.prevent="handleConnect({ id: 'magic', email: emailInput.trim() })"
+      @submit.prevent="handleConnect({ id: 'magic', email: normalizeEmail(emailInput) })"
     >
       <UInput
         v-model="emailInput"
@@ -117,7 +117,7 @@ watch(logoClickCount, (count) => {
 
 const emailInput = ref(getRouteQuery('email'))
 
-const isEmailValid = computed(() => validateEmail(emailInput.value.trim()))
+const isEmailValid = computed(() => validateEmail(normalizeEmail(emailInput.value)))
 
 const othersConnectors = computed(() => {
   return connectors.filter(c => !['magic', 'injected'].includes(c.id))

--- a/app/components/RegistrationModal.vue
+++ b/app/components/RegistrationModal.vue
@@ -112,6 +112,8 @@ function handleRegisterButtonClick() {
     return
   }
 
+  email.value = normalizeEmail(email.value)
+
   if (!verifyEmail(email.value)) {
     emailError.value = $t('registration_modal_error_email_invalid')
     return

--- a/app/utils/index.ts
+++ b/app/utils/index.ts
@@ -85,6 +85,10 @@ export function validateEmail(email: string): boolean {
   return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.trim())
 }
 
+export function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase()
+}
+
 export function getStoreQueryRoute(title: string) {
   return { name: 'store', query: { q: title } }
 }


### PR DESCRIPTION
Trim and lowercase email at the account-identity entry points so case-variant input (Foo@x.com vs foo@x.com) can't create mismatched or duplicate accounts. The normalized value is what gets signed, sent, and stored. Adds a shared normalizeEmail() util.