### PR TITLE
🐛 Fix TTS auto-resume resetting reading progress on reopen

### DIFF
--- a/app/pages/reader/epub.vue
+++ b/app/pages/reader/epub.vue
@@ -1548,7 +1548,10 @@ async function onClickTTSPlay() {
   openPlayer({
     ttsIndex: activeTTSElementIndex.value,
     sectionIndex: currentSectionIndex.value,
-    cfi: currentPageStartCfi.value,
+    // On auto-resume reopen, `relocated` may not have populated the live page
+    // anchor yet; fall back to the restored reading position so TTS resumes
+    // there instead of defaulting to segment 0 and resetting progress.
+    cfi: currentPageStartCfi.value || currentCfi.value,
     pageEndCFI: currentPageEndCfi.value,
   })
 }


### PR DESCRIPTION
On reopen with the TTS query param, onClickTTSPlay runs before the relocated handler has populated currentPageStartCfi, and the persisted activeTTSElementIndex is cleared on load, so openPlayer fell back to segment 0. The first segment change then overwrote currentCfi and readingProgress with the book start and flushed it to the server. Fall back to the restored currentCfi when the live page anchor isn't ready so TTS resumes where the reader left off.