### PR TITLE
🐛 Serve cached shell for offline SPA sub-route navigations

### DIFF
--- a/app/pages/store/index.vue
+++ b/app/pages/store/index.vue
@@ -299,6 +299,7 @@ const infiniteScrollDetectorElement = useTemplateRef<HTMLLIElement>('infiniteScr
 const shouldLoadMore = useElementVisibility(infiniteScrollDetectorElement)
 const { handleError } = useErrorHandler()
 const storePageState = useStorePageState()
+const isOnline = useOnline()
 const isMobile = useMediaQuery('(max-width: 425px)')
 const isAdultContentEnabled = useAdultContentSetting()
 const { isApp } = useAppDetection()
@@ -902,6 +903,9 @@ async function fetchTags() {
     await bookstoreStore.fetchBookstoreCMSTags()
   }
   catch (error) {
+    // Offline cold launch fails these network fetches expectedly; the cached
+    // shell still renders, so don't surface a blocking error modal.
+    if (!isOnline.value) return
     await handleError(error, {
       title: $t('store_fetch_tags_error'),
     })
@@ -965,6 +969,7 @@ async function fetchItems({ lazy = false, isRefresh = false } = {}): Promise<boo
       return true
     }
     catch (error) {
+      if (!isOnline.value) return false
       await handleError(error, {
         title: isRefresh ? $t('store_fetch_items_error') : $t('store_fetch_more_items_error'),
       })
@@ -977,6 +982,7 @@ async function fetchItems({ lazy = false, isRefresh = false } = {}): Promise<boo
     return true
   }
   catch (error) {
+    if (!isOnline.value) return false
     await handleError(error, {
       title: isRefresh ? $t('store_fetch_items_error') : $t('store_fetch_more_items_error'),
       customHandlerMap: {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -10,6 +10,10 @@ const {
 
 const isDevelopment = NODE_ENV === 'development'
 
+// Workbox cacheName for document navigations; shared so the offline app-shell
+// fallback below opens the same cache the NetworkFirst route writes to.
+const HTML_PAGES_CACHE = 'html-pages'
+
 export default defineNuxtConfig({
   modules: [
     '@nuxt/eslint',
@@ -265,10 +269,31 @@ export default defineNuxtConfig({
             request.mode === 'navigate' && !url.pathname.startsWith('/api'),
           handler: 'NetworkFirst',
           options: {
-            cacheName: 'html-pages',
+            cacheName: HTML_PAGES_CACHE,
             networkTimeoutSeconds: 10,
             expiration: { maxEntries: 64, maxAgeSeconds: 60 * 60 * 24 * 7 },
             cacheableResponse: { statuses: [200] },
+            plugins: [
+              {
+                // A direct offline open of an SPA sub-route (e.g. /shelf) has no
+                // cached document — client-side navigations never hit the SW — so
+                // NetworkFirst throws `no-response`. Serve any cached document as
+                // the shell; Nuxt boots and routes to the real URL client-side.
+                handlerDidError: async () => {
+                  // Inline the cache name: this handler is serialized into the
+                  // generated sw.js via toString(), so the HTML_PAGES_CACHE
+                  // closure isn't in scope at runtime — referencing it throws.
+                  const cache = await caches.open('html-pages')
+                  // ignoreSearch: the homepage is often cached with UTM query
+                  // params (query.global middleware), so a bare '/' would miss.
+                  const shell = await cache.match('/', { ignoreSearch: true })
+                  if (shell) return shell
+                  const [firstKey] = await cache.keys()
+                  const fallback = firstKey ? await cache.match(firstKey) : undefined
+                  return fallback ?? Response.error()
+                },
+              },
+            ],
           },
         },
       ],

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -262,6 +262,18 @@ export default defineNuxtConfig({
           },
         },
         {
+          // @nuxtjs/i18n strips unused keys from the SSR payload and fetches the
+          // full locale from this Nitro route at runtime; without caching it,
+          // offline navigations render raw keys. The :hash makes CacheFirst safe.
+          urlPattern: ({ url }) => url.pathname.startsWith('/_i18n/'),
+          handler: 'CacheFirst',
+          options: {
+            cacheName: 'i18n-messages',
+            expiration: { maxEntries: 16, maxAgeSeconds: 60 * 60 * 24 * 30 },
+            cacheableResponse: { statuses: [0, 200] },
+          },
+        },
+        {
           // Page navigations: prefer fresh network, fall back to the last cached
           // document when offline so the app shell can boot. Skip API routes —
           // they must never be served from a stale document cache.


### PR DESCRIPTION
A direct offline open of an SPA sub-route (e.g. /shelf, /store) had no cached document — client-side navigations never reach the service worker — so NetworkFirst threw `no-response` and Safari/WebView showed an error page. Add a handlerDidError fallback that serves any cached document as the app shell so Nuxt boots and routes to the real URL client-side.

Prefer the homepage with ignoreSearch (it is usually cached with UTM query params via query.global middleware) and extract the shared html-pages cacheName into a constant.