### PR TITLE
🐛 Recover reader from wedged book load on app resume

### DIFF
--- a/app/composables/use-book-file-loader.ts
+++ b/app/composables/use-book-file-loader.ts
@@ -3,6 +3,19 @@
 // which would otherwise strand the reader on the loading bar forever.
 const BOOK_FILE_STALL_TIMEOUT_MS = 30_000
 
+// Strip query params before a book-file URL reaches analytics or error data: it
+// carries a short-lived access token we must not ship to those destinations.
+function getSanitizedBookFileURL(url: string) {
+  try {
+    const parsed = new URL(url, window.location.origin)
+    return parsed.origin + parsed.pathname
+  }
+  catch {
+    // Leave url as-is if it isn't a parseable URL.
+    return url
+  }
+}
+
 export default function () {
   const { t: $t } = useI18n()
   const { user } = useUserSession()
@@ -110,7 +123,7 @@ export default function () {
             statusCode: res.status,
             message: errorText,
             data: {
-              url,
+              url: getSanitizedBookFileURL(url),
               description: $t('error_book_file_loading_failed'),
             },
           })
@@ -118,7 +131,7 @@ export default function () {
 
         if (cacheKey && window.caches) {
           try {
-            const cache = await caches.open(cacheKey)
+            const cache = await raceAbort(caches.open(cacheKey))
             // Fire-and-forget: awaiting would drain the clone before our own
             // stream loop starts, forcing the tee to buffer the whole response.
             // On failure we delete the now-empty cache that caches.open() just
@@ -136,6 +149,10 @@ export default function () {
               })
           }
           catch (error) {
+            // An abort here (raceAbort losing) is a real load failure: surface
+            // it to the outer handler instead of swallowing it, matching the
+            // cache-read path.
+            if (controller.signal.aborted) throw error
             console.error(error)
           }
         }
@@ -239,16 +256,7 @@ export default function () {
       // shows its retry / back-to-shelf modal instead of spinning forever, and
       // record it for production triage.
       if (didStall) {
-        // Strip query params: the book-file URL carries a short-lived access
-        // token we must not ship to analytics destinations.
-        let sanitizedURL = url
-        try {
-          const parsed = new URL(url)
-          sanitizedURL = parsed.origin + parsed.pathname
-        }
-        catch {
-          // Leave url as-is if it isn't a parseable absolute URL.
-        }
+        const sanitizedURL = getSanitizedBookFileURL(url)
         useLogEvent('book_file_load_timeout', {
           url: sanitizedURL,
           from_cache: isFromCache,
@@ -261,7 +269,7 @@ export default function () {
           statusCode: 504,
           message: 'Book file load timed out',
           data: {
-            url,
+            url: sanitizedURL,
             description: $t('error_book_file_loading_failed'),
             isTimeout: true,
           },

--- a/app/composables/use-book-file-loader.ts
+++ b/app/composables/use-book-file-loader.ts
@@ -1,3 +1,8 @@
+// Abort a book-file load when no progress is made within this window. iOS
+// WebKit wedges in-flight cross-origin fetches after the app is backgrounded,
+// which would otherwise strand the reader on the loading bar forever.
+const BOOK_FILE_STALL_TIMEOUT_MS = 30_000
+
 export default function () {
   const { t: $t } = useI18n()
   const { user } = useUserSession()
@@ -5,6 +10,14 @@ export default function () {
 
   const loadingFilesize = ref(0)
   const loadedFilesize = ref(0)
+
+  let activeController: AbortController | undefined
+
+  // Lets the reader abort a wedged in-flight load (e.g. on foreground) so it can
+  // retry without waiting out the stall timeout.
+  function abortLoad() {
+    activeController?.abort(new DOMException('Book file load aborted', 'AbortError'))
+  }
 
   const loadingPercentage = computed(() => {
     if (loadingFilesize.value === 0) return 0
@@ -28,155 +41,240 @@ export default function () {
     loadingFilesize.value = 0
     loadedFilesize.value = 0
 
-    let res
-    let cachePutPromise: Promise<boolean> | undefined
-    const req = new Request(url)
-    if (cacheKey && window.caches) {
-      try {
-        const cache = await caches.open(cacheKey)
-        res = await cache.match(req)
-        if (res) {
-          touchBookFileCacheEntry({
-            cacheKeyPrefix: config.public.cacheKeyPrefix,
-            cacheKey,
-          })
-        }
-      }
-      catch (error) {
-        console.error(error)
-      }
+    // Guard the whole load with an AbortController + stall watchdog. The
+    // watchdog re-arms on every chunk, so a slow-but-progressing download is
+    // never killed — only a stall (no progress within the timeout) aborts.
+    const controller = new AbortController()
+    activeController = controller
+    const startedAt = Date.now()
+    let didStall = false
+    let isFromCache = false
+    let watchdog: ReturnType<typeof setTimeout> | undefined
+    const armWatchdog = () => {
+      if (watchdog) clearTimeout(watchdog)
+      watchdog = setTimeout(() => {
+        didStall = true
+        controller.abort(new DOMException('Book file load stalled', 'TimeoutError'))
+      }, BOOK_FILE_STALL_TIMEOUT_MS)
     }
-    if (!res) {
-      res = await fetch(url, {
-        headers: {
-          Authorization: user.value?.token
-            ? `Bearer ${user.value.token}`
-            : '',
-        },
-      })
-      if (!res.ok) {
-        const errorText = await res.text()
-        throw createError({
-          statusCode: res.status,
-          message: errorText,
-          data: {
-            url,
-            description: $t('error_book_file_loading_failed'),
-          },
-        })
-      }
+    const abortPromise = new Promise<never>((_, reject) => {
+      controller.signal.addEventListener(
+        'abort',
+        () => reject(controller.signal.reason ?? new DOMException('Aborted', 'AbortError')),
+        { once: true },
+      )
+    })
+    // Without a cacheKey raceAbort() never runs, so abortPromise would reject
+    // with no handler on abort. Keep a no-op catch so it can't surface as an
+    // unhandled rejection; the real error is still thrown from the try block.
+    abortPromise.catch(() => {})
+    // Cache API calls take no AbortSignal, so race them against the abort to
+    // avoid wedging there too on a backgrounded WebView.
+    const raceAbort = <T>(promise: Promise<T>) => Promise.race([promise, abortPromise])
 
+    try {
+      armWatchdog()
+
+      let res
+      let cachePutPromise: Promise<boolean> | undefined
+      const req = new Request(url)
       if (cacheKey && window.caches) {
         try {
-          const cache = await caches.open(cacheKey)
-          // Fire-and-forget: awaiting would drain the clone before our own
-          // stream loop starts, forcing the tee to buffer the whole response.
-          // On failure we delete the now-empty cache that caches.open() just
-          // created; otherwise pruneBookFileCaches would treat it as live and
-          // keep the index entry, inflating the LRU total.
-          cachePutPromise = cache.put(req, res.clone())
-            .then(() => true)
-            .catch((error) => {
-              console.error(error)
-              return caches.delete(cacheKey).catch(console.error).then(() => false)
+          const cache = await raceAbort(caches.open(cacheKey))
+          res = await raceAbort(cache.match(req))
+          if (res) {
+            isFromCache = true
+            touchBookFileCacheEntry({
+              cacheKeyPrefix: config.public.cacheKeyPrefix,
+              cacheKey,
             })
+          }
         }
         catch (error) {
+          if (controller.signal.aborted) throw error
           console.error(error)
         }
       }
-    }
-
-    // Deferred until the body has finished streaming, since the byte size is
-    // only known then. Prune reuses the index record() just wrote so opening
-    // a book parses the localStorage index once, not twice.
-    function registerCachedFile(size: number) {
-      if (!cacheKey || !cachePutPromise) return
-      void cachePutPromise.then((didCache) => {
-        if (!didCache) return
-        const index = recordBookFileCacheEntry({
-          cacheKeyPrefix: config.public.cacheKeyPrefix,
-          cacheKey,
-          size,
+      if (!res) {
+        res = await fetch(url, {
+          signal: controller.signal,
+          headers: {
+            Authorization: user.value?.token
+              ? `Bearer ${user.value.token}`
+              : '',
+          },
         })
-        void pruneBookFileCaches({
-          cacheKeyPrefix: config.public.cacheKeyPrefix,
-          keepCacheKey: cacheKey,
-          index,
+        if (!res.ok) {
+          const errorText = await res.text()
+          throw createError({
+            statusCode: res.status,
+            message: errorText,
+            data: {
+              url,
+              description: $t('error_book_file_loading_failed'),
+            },
+          })
+        }
+
+        if (cacheKey && window.caches) {
+          try {
+            const cache = await caches.open(cacheKey)
+            // Fire-and-forget: awaiting would drain the clone before our own
+            // stream loop starts, forcing the tee to buffer the whole response.
+            // On failure we delete the now-empty cache that caches.open() just
+            // created; otherwise pruneBookFileCaches would treat it as live and
+            // keep the index entry, inflating the LRU total.
+            cachePutPromise = cache.put(req, res.clone())
+              .then(() => true)
+              .catch((error) => {
+                console.error(error)
+                // A foreground retry aborts this attempt mid-put; skip the
+                // cleanup delete so it can't clobber the retry's write of the
+                // same cacheKey.
+                if (controller.signal.aborted) return false
+                return caches.delete(cacheKey).catch(console.error).then(() => false)
+              })
+          }
+          catch (error) {
+            console.error(error)
+          }
+        }
+      }
+
+      // Deferred until the body has finished streaming, since the byte size is
+      // only known then. Prune reuses the index record() just wrote so opening
+      // a book parses the localStorage index once, not twice.
+      const registerCachedFile = (size: number) => {
+        if (!cacheKey || !cachePutPromise) return
+        void cachePutPromise.then((didCache) => {
+          if (!didCache) return
+          const index = recordBookFileCacheEntry({
+            cacheKeyPrefix: config.public.cacheKeyPrefix,
+            cacheKey,
+            size,
+          })
+          void pruneBookFileCaches({
+            cacheKeyPrefix: config.public.cacheKeyPrefix,
+            keepCacheKey: cacheKey,
+            index,
+          })
         })
-      })
-    }
+      }
 
-    const streamReader = res?.body?.getReader()
-    if (!streamReader) return
+      const streamReader = res?.body?.getReader()
+      if (!streamReader) return
 
-    const contentLength = Number(
-      res?.headers?.get('X-Original-Content-Length')
-      || res?.headers?.get('Content-Length'),
-    )
-    if (contentLength) {
-      loadingFilesize.value = contentLength
-    }
+      const contentLength = Number(
+        res?.headers?.get('X-Original-Content-Length')
+        || res?.headers?.get('Content-Length'),
+      )
+      if (contentLength) {
+        loadingFilesize.value = contentLength
+      }
 
-    // When content length is known, write directly into a pre-allocated buffer
-    // to avoid holding both chunks[] and combinedChunks simultaneously (~2x peak memory).
-    // Falls back to chunk accumulation if the header was unreliable.
-    if (contentLength) {
-      const buffer = new Uint8Array(contentLength)
-      let offset = 0
-      let overflow: Uint8Array[] | undefined
+      // When content length is known, write directly into a pre-allocated buffer
+      // to avoid holding both chunks[] and combinedChunks simultaneously (~2x peak memory).
+      // Falls back to chunk accumulation if the header was unreliable.
+      if (contentLength) {
+        const buffer = new Uint8Array(contentLength)
+        let offset = 0
+        let overflow: Uint8Array[] | undefined
+        while (true) {
+          const { done, value } = await streamReader.read()
+          if (done) break
+          armWatchdog()
+          if (!overflow && offset + value.length <= buffer.length) {
+            buffer.set(value, offset)
+          }
+          else {
+            if (!overflow) {
+              overflow = [buffer.subarray(0, offset)]
+            }
+            overflow.push(value)
+          }
+          offset += value.length
+          loadedFilesize.value = offset
+        }
+        if (!overflow) {
+          registerCachedFile(offset)
+          return offset < buffer.length
+            ? buffer.buffer.slice(0, offset)
+            : buffer.buffer
+        }
+        // Content-Length was wrong — combine overflow chunks
+        const combined = new Uint8Array(offset)
+        let pos = 0
+        for (const chunk of overflow) {
+          combined.set(chunk, pos)
+          pos += chunk.length
+        }
+        registerCachedFile(offset)
+        return combined.buffer
+      }
+
+      // Fallback: accumulate chunks when content length is unknown
+      let receivedLength = 0
+      const chunks: Uint8Array[] = []
       while (true) {
         const { done, value } = await streamReader.read()
         if (done) break
-        if (!overflow && offset + value.length <= buffer.length) {
-          buffer.set(value, offset)
+        armWatchdog()
+        chunks.push(value)
+        receivedLength += value.length
+        loadedFilesize.value = receivedLength
+      }
+
+      const combinedChunks = new Uint8Array(receivedLength)
+      let position = 0
+      for (const chunk of chunks) {
+        combinedChunks.set(chunk, position)
+        position += chunk.length
+      }
+
+      registerCachedFile(receivedLength)
+      return combinedChunks.buffer
+    }
+    catch (error) {
+      // A stall fired the watchdog: surface a recoverable error so the reader
+      // shows its retry / back-to-shelf modal instead of spinning forever, and
+      // record it for production triage.
+      if (didStall) {
+        // Strip query params: the book-file URL carries a short-lived access
+        // token we must not ship to analytics destinations.
+        let sanitizedURL = url
+        try {
+          const parsed = new URL(url)
+          sanitizedURL = parsed.origin + parsed.pathname
         }
-        else {
-          if (!overflow) {
-            overflow = [buffer.subarray(0, offset)]
-          }
-          overflow.push(value)
+        catch {
+          // Leave url as-is if it isn't a parseable absolute URL.
         }
-        offset += value.length
-        loadedFilesize.value = offset
+        useLogEvent('book_file_load_timeout', {
+          url: sanitizedURL,
+          from_cache: isFromCache,
+          online: navigator.onLine,
+          elapsed_ms: Date.now() - startedAt,
+          loaded_bytes: loadedFilesize.value,
+          total_bytes: loadingFilesize.value,
+        })
+        throw createError({
+          statusCode: 504,
+          message: 'Book file load timed out',
+          data: {
+            url,
+            description: $t('error_book_file_loading_failed'),
+            isTimeout: true,
+          },
+        })
       }
-      if (!overflow) {
-        registerCachedFile(offset)
-        return offset < buffer.length
-          ? buffer.buffer.slice(0, offset)
-          : buffer.buffer
-      }
-      // Content-Length was wrong — combine overflow chunks
-      const combined = new Uint8Array(offset)
-      let pos = 0
-      for (const chunk of overflow) {
-        combined.set(chunk, pos)
-        pos += chunk.length
-      }
-      registerCachedFile(offset)
-      return combined.buffer
+      // Manual abort (foreground retry) or any other error: rethrow as-is. The
+      // reader's attempt guard ignores the superseded manual-abort rejection.
+      throw error
     }
-
-    // Fallback: accumulate chunks when content length is unknown
-    let receivedLength = 0
-    const chunks: Uint8Array[] = []
-    while (true) {
-      const { done, value } = await streamReader.read()
-      if (done) break
-      chunks.push(value)
-      receivedLength += value.length
-      loadedFilesize.value = receivedLength
+    finally {
+      if (watchdog) clearTimeout(watchdog)
+      if (activeController === controller) activeController = undefined
     }
-
-    const combinedChunks = new Uint8Array(receivedLength)
-    let position = 0
-    for (const chunk of chunks) {
-      combinedChunks.set(chunk, position)
-      position += chunk.length
-    }
-
-    registerCachedFile(receivedLength)
-    return combinedChunks.buffer
   }
 
   return {
@@ -189,5 +287,6 @@ export default function () {
     loadingLabel,
 
     loadFileAsBuffer,
+    abortLoad,
   }
 }

--- a/app/composables/use-reader-file-load.ts
+++ b/app/composables/use-reader-file-load.ts
@@ -1,0 +1,76 @@
+import type { Ref } from 'vue'
+
+interface UseReaderFileLoadOptions {
+  isReaderLoading: Ref<boolean>
+  readerType: 'epub' | 'pdf'
+  // The page-specific loader (loadEPub / loadPDF). Kept lazy so it can be
+  // re-run from scratch on a foreground retry.
+  load: () => Promise<void>
+  // Resolved by the page so the literal $t() keys stay greppable.
+  getErrorTitle: () => string
+  // The page's own useErrorHandler instance, whose modal the page renders.
+  handleError: ReturnType<typeof useErrorHandler>['handleError']
+  // Aborts the wedged in-flight book fetch so the retry doesn't wait out the
+  // stall timeout. From the page's own useBookFileLoader instance.
+  abortLoad: () => void
+}
+
+export default function useReaderFileLoad({
+  isReaderLoading,
+  readerType,
+  load,
+  getErrorTitle,
+  handleError,
+  abortLoad,
+}: UseReaderFileLoadOptions) {
+  const localeRoute = useLocaleRoute()
+
+  // Bumped on every attempt so a superseded attempt (e.g. one aborted by a
+  // foreground retry) resolves silently instead of flipping loading state or
+  // showing an error modal.
+  let loadAttempt = 0
+  let wasHiddenWhileLoading = false
+
+  async function startReaderLoad() {
+    const attempt = ++loadAttempt
+    isReaderLoading.value = true
+    try {
+      await load()
+      if (attempt !== loadAttempt) return
+      isReaderLoading.value = false
+    }
+    catch (error) {
+      if (attempt !== loadAttempt) return
+      await handleError(error, {
+        title: getErrorTitle(),
+        onClose: () => {
+          navigateTo(localeRoute({ name: 'shelf' }))
+        },
+      })
+      // Clear the loading state so a dismissed error modal doesn't strand the
+      // reader on the loading bar (and so a later foreground resume, which gates
+      // on isReaderLoading, doesn't fire a spurious retry). Guarded so a
+      // superseded attempt can't clobber a newer one's state.
+      if (attempt === loadAttempt) isReaderLoading.value = false
+    }
+  }
+
+  // iOS WebKit wedges the in-flight cross-origin book fetch when the app is
+  // backgrounded, leaving the reader stuck on the loading bar. On foreground,
+  // abort the wedged attempt and retry instead of waiting out the stall timeout.
+  const visibility = useDocumentVisibility()
+  watch(visibility, (state) => {
+    if (state !== 'visible') {
+      wasHiddenWhileLoading ||= isReaderLoading.value
+      return
+    }
+    const shouldRetry = wasHiddenWhileLoading && isReaderLoading.value
+    wasHiddenWhileLoading = false
+    if (!shouldRetry) return
+    useLogEvent('book_file_load_retry', { reader: readerType })
+    abortLoad()
+    startReaderLoad()
+  })
+
+  return { startReaderLoad }
+}

--- a/app/pages/reader/epub.vue
+++ b/app/pages/reader/epub.vue
@@ -491,13 +491,22 @@ const isAnnotationClickInProgress = ref(false)
 const pendingSavePromise = ref<Promise<Annotation | null> | null>(null)
 const renderedHighlights = new Set<string>()
 
-const { loadingLabel, loadingPercentage, loadFileAsBuffer } = useBookFileLoader()
+const { loadingLabel, loadingPercentage, loadFileAsBuffer, abortLoad } = useBookFileLoader()
 
 const isOnline = useOnline()
 
-onMounted(async () => {
-  isReaderLoading.value = true
+const { startReaderLoad } = useReaderFileLoad({
+  isReaderLoading,
+  readerType: 'epub',
+  load: () => loadEPub(),
+  getErrorTitle: () => isOnline.value
+    ? $t('error_reader_load_epub_failed')
+    : $t('error_reader_book_not_available_offline'),
+  handleError,
+  abortLoad,
+})
 
+onMounted(() => {
   // Kick off background fetches without awaiting so offline / slow API calls
   // don't block the cache-first EPUB load.
   bookSettingsStore.ensureInitialized(nftClassId.value)
@@ -513,21 +522,7 @@ onMounted(async () => {
       .catch(error => console.warn('Failed to fetch NFT metadata:', error))
   }
 
-  try {
-    await loadEPub()
-  }
-  catch (error) {
-    await handleError(error, {
-      title: isOnline.value
-        ? $t('error_reader_load_epub_failed')
-        : $t('error_reader_book_not_available_offline'),
-      onClose: () => {
-        navigateTo(localeRoute({ name: 'shelf' }))
-      },
-    })
-    return
-  }
-  isReaderLoading.value = false
+  startReaderLoad()
 })
 
 const rendition = ref<Rendition>()

--- a/app/pages/reader/pdf.vue
+++ b/app/pages/reader/pdf.vue
@@ -130,13 +130,22 @@ const { setTTSSegments, setChapterTitles, openPlayer } = useTTSPlayerModal({
 })
 const isReaderLoading = ref(true)
 
-const { loadingLabel, loadingPercentage, loadFileAsBuffer } = useBookFileLoader()
+const { loadingLabel, loadingPercentage, loadFileAsBuffer, abortLoad } = useBookFileLoader()
 
 const isOnline = useOnline()
 
-onMounted(async () => {
-  isReaderLoading.value = true
+const { startReaderLoad } = useReaderFileLoad({
+  isReaderLoading,
+  readerType: 'pdf',
+  load: () => loadPDF(),
+  getErrorTitle: () => isOnline.value
+    ? $t('error_reader_load_pdf_failed')
+    : $t('error_reader_book_not_available_offline'),
+  handleError,
+  abortLoad,
+})
 
+onMounted(() => {
   // Fire-and-forget background metadata fetch so offline / slow API calls
   // don't block the cache-first PDF load.
   if (isUploadedBook.value) {
@@ -150,20 +159,7 @@ onMounted(async () => {
       .catch(error => console.warn('Failed to fetch NFT metadata:', error))
   }
 
-  try {
-    await loadPDF()
-  }
-  catch (error) {
-    await handleError(error, {
-      title: isOnline.value
-        ? $t('error_reader_load_pdf_failed')
-        : $t('error_reader_book_not_available_offline'),
-      onClose: () => {
-        navigateTo(localeRoute({ name: 'shelf' }))
-      },
-    })
-  }
-  isReaderLoading.value = false
+  startReaderLoad()
 })
 
 async function loadPDF() {


### PR DESCRIPTION
iOS WebKit wedges the in-flight cross-origin book fetch after the app is backgrounded, leaving the reader stuck on the loading bar forever since loadFileAsBuffer had no timeout and a hung promise never reaches the error modal.

Guard the load with an AbortController + stall watchdog (re-armed per chunk, so slow-but-progressing downloads survive) that surfaces a recoverable error, and abort-and-retry on foreground via a shared useReaderFileLoad composable. Emit book_file_load_timeout / _retry for triage.