### PR TITLE
💄 Use neutral color for bookstore tags

### DIFF
--- a/app/components/PillButton.vue
+++ b/app/components/PillButton.vue
@@ -4,7 +4,8 @@
     :icon="icon"
     :to="to"
     :aria-label="ariaLabel"
-    variant="outline"
+    :variant="isActive ? 'solid' : 'outline'"
+    color="neutral"
     :ui="customizedUI"
   />
 </template>
@@ -30,9 +31,7 @@ const BUTTON_CLASS_BASE = [
   '!ring-theme-black dark:!ring-muted',
 ]
 const BUTTON_CLASS_ACTIVE = [
-  'bg-theme-black dark:bg-theme-cyan',
-  'hover:bg-theme-black/80 hover:dark:bg-theme-cyan/80',
-  'text-theme-cyan dark:text-theme-black',
+  'dark:bg-inverted',
 ]
 const BUTTON_CLASS_INACTIVE = [
   'bg-(--app-bg)',


### PR DESCRIPTION
Before
<img width="341" height="94" src="https://github.com/user-attachments/assets/98fafc66-b0b5-4a6b-a634-72c788f82642" />
<img width="440" src="https://github.com/user-attachments/assets/57e20009-d640-48bd-8cbd-7db2afa9299d" />

After
<img width="383" height="78" src="https://github.com/user-attachments/assets/140fc3f3-a4d1-4e06-a603-8c011596d068" />
<img width="401" height="71" src="https://github.com/user-attachments/assets/927742ae-a4cc-4152-8f15-d315c3d24c84" />