### PR TITLE
✨ Forward paid-Plus reading usage to rev-share ledger

### DIFF
--- a/apphosting.mainnet.yaml
+++ b/apphosting.mainnet.yaml
@@ -83,6 +83,8 @@ env:
     value: 1261473308725104
   - variable: NUXT_SESSION_PASSWORD
     secret: V3_NUXT_SESSION_PASSWORD
+  - variable: PLUS_READING_SERVICE_TOKEN
+    secret: PLUS_READING_SERVICE_TOKEN
   - variable: POSTHOG_DEFAULTS
     value: 2026-01-30
   - variable: POSTHOG_HOST

--- a/apphosting.sepolia.yaml
+++ b/apphosting.sepolia.yaml
@@ -79,6 +79,8 @@ env:
     value: j0ryap5a
   - variable: NUXT_SESSION_PASSWORD
     secret: V3_NUXT_SESSION_PASSWORD
+  - variable: PLUS_READING_SERVICE_TOKEN
+    secret: PLUS_READING_SERVICE_TOKEN
   - variable: POSTHOG_DEFAULTS
     value: 2026-01-30
   - variable: POSTHOG_HOST

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -64,6 +64,7 @@ export default defineNuxtConfig({
     pubsubEnable: process.env.GCLOUD_PUBSUB_ENABLE || '',
     appServer: process.env.APP_SERVER || '3ook-web',
     airtableAPISecret: process.env.AIRTABLE_API_SECRET,
+    plusReadingServiceToken: process.env.PLUS_READING_SERVICE_TOKEN,
     minimaxGroupId: process.env.MINIMAX_GROUP_ID,
     minimaxAPIKey: process.env.MINIMAX_API_KEY,
     ttsCacheBucketPrefix: process.env.TTS_CACHE_BUCKET_PREFIX,

--- a/server/api/account/refresh.post.ts
+++ b/server/api/account/refresh.post.ts
@@ -41,6 +41,7 @@ export default defineEventHandler(async (event) => {
       displayName: userInfoRes.displayName,
       avatar: userInfoRes.avatar,
       isLikerPlus: userInfoRes.isLikerPlus || false,
+      isLikerPlusTrial: userInfoRes.isLikerPlusTrial || false,
       isExpiredLikerPlus: userInfoRes.isExpiredLikerPlus || false,
       likerPlusPeriod: userInfoRes.likerPlusPeriod,
       likerPlusProvider: userInfoRes.likerPlusProvider,

--- a/server/api/analytics/heartbeat.post.ts
+++ b/server/api/analytics/heartbeat.post.ts
@@ -1,7 +1,7 @@
 import { HeartbeatSchema } from '~~/server/schemas/analytics'
 
 export default defineEventHandler(async (event) => {
-  const { wallet, isLikerPlus } = await requireUserWalletWithStatus(event)
+  const { wallet, isLikerPlus, isPaidPlus } = await requireUserWalletWithStatus(event)
   const body = await readValidatedBody(event, createValidator(HeartbeatSchema))
 
   const {
@@ -20,10 +20,19 @@ export default defineEventHandler(async (event) => {
   })
 
   if (paced.activeReadingTimeMsDelta > 0 || paced.ttsActiveTimeMsDelta > 0) {
-    await incrementBookReadingTime(wallet, nftClassId, {
+    const { isBorrowed } = await incrementBookReadingTime(wallet, nftClassId, {
       activeReadingTimeMs: paced.activeReadingTimeMsDelta,
       ttsActiveTimeMs: paced.ttsActiveTimeMsDelta,
       isLikerPlus,
+    })
+
+    await forwardPlusReadingUsage({
+      isPaidPlus,
+      isBorrowed,
+      readerWallet: wallet,
+      classId: nftClassId,
+      readingTimeMs: paced.activeReadingTimeMsDelta,
+      ttsTimeMs: paced.ttsActiveTimeMsDelta,
     })
   }
 

--- a/server/api/analytics/heartbeat.post.ts
+++ b/server/api/analytics/heartbeat.post.ts
@@ -6,6 +6,7 @@ export default defineEventHandler(async (event) => {
 
   const {
     nftClassId,
+    sessionId,
     activeReadingTimeMsDelta,
     ttsActiveTimeMsDelta,
   } = body
@@ -26,13 +27,17 @@ export default defineEventHandler(async (event) => {
       isLikerPlus,
     })
 
-    await forwardPlusReadingUsage({
+    await recordPacedReadingUsage({
+      event,
+      source: 'heartbeat',
+      wallet,
+      nftClassId,
+      sessionId,
+      isLikerPlus,
       isPaidPlus,
       isBorrowed,
-      readerWallet: wallet,
-      classId: nftClassId,
-      readingTimeMs: paced.activeReadingTimeMsDelta,
-      ttsTimeMs: paced.ttsActiveTimeMsDelta,
+      paced,
+      rawDelta: { activeReadingTimeMsDelta, ttsActiveTimeMsDelta },
     })
   }
 

--- a/server/api/analytics/session.post.ts
+++ b/server/api/analytics/session.post.ts
@@ -3,7 +3,7 @@ import { ReadingSessionSchema } from '~~/server/schemas/analytics'
 const COMPLETION_THRESHOLD = 95
 
 export default defineEventHandler(async (event) => {
-  const { wallet, isLikerPlus } = await requireUserWalletWithStatus(event)
+  const { wallet, isLikerPlus, isPaidPlus } = await requireUserWalletWithStatus(event)
   const body = await readValidatedBody(event, createValidator(ReadingSessionSchema))
 
   const {
@@ -33,12 +33,23 @@ export default defineEventHandler(async (event) => {
 
   const tasks: Promise<unknown>[] = []
   if (hasActivity) {
-    tasks.push(incrementBookReadingTime(wallet, nftClassId, {
-      activeReadingTimeMs: paced.activeReadingTimeMsDelta,
-      ttsActiveTimeMs: paced.ttsActiveTimeMsDelta,
-      isLikerPlus,
-      countSession: true,
-    }))
+    // Revenue share runs once the book's borrow status is known, in parallel with
+    // the other session tasks rather than serially after them.
+    tasks.push(
+      incrementBookReadingTime(wallet, nftClassId, {
+        activeReadingTimeMs: paced.activeReadingTimeMsDelta,
+        ttsActiveTimeMs: paced.ttsActiveTimeMsDelta,
+        isLikerPlus,
+        countSession: true,
+      }).then(({ isBorrowed }) => forwardPlusReadingUsage({
+        isPaidPlus,
+        isBorrowed,
+        readerWallet: wallet,
+        classId: nftClassId,
+        readingTimeMs: paced.activeReadingTimeMsDelta,
+        ttsTimeMs: paced.ttsActiveTimeMsDelta,
+      })),
+    )
     tasks.push(updateReadingStreak(wallet))
   }
 

--- a/server/api/analytics/session.post.ts
+++ b/server/api/analytics/session.post.ts
@@ -33,21 +33,36 @@ export default defineEventHandler(async (event) => {
 
   const tasks: Promise<unknown>[] = []
   if (hasActivity) {
-    // Revenue share runs once the book's borrow status is known, in parallel with
-    // the other session tasks rather than serially after them.
+    // Record paced usage (rev-share forward + analytics publish) once the book's
+    // borrow status is known, in parallel with the other session tasks. Shared with
+    // the heartbeat handler so the ledger and ES never drift in cadence.
     tasks.push(
       incrementBookReadingTime(wallet, nftClassId, {
         activeReadingTimeMs: paced.activeReadingTimeMsDelta,
         ttsActiveTimeMs: paced.ttsActiveTimeMsDelta,
         isLikerPlus,
         countSession: true,
-      }).then(({ isBorrowed }) => forwardPlusReadingUsage({
+      }).then(({ isBorrowed }) => recordPacedReadingUsage({
+        event,
+        source: 'session',
+        wallet,
+        nftClassId,
+        sessionId,
+        isLikerPlus,
         isPaidPlus,
         isBorrowed,
-        readerWallet: wallet,
-        classId: nftClassId,
-        readingTimeMs: paced.activeReadingTimeMsDelta,
-        ttsTimeMs: paced.ttsActiveTimeMsDelta,
+        paced,
+        rawDelta: { activeReadingTimeMsDelta, ttsActiveTimeMsDelta },
+        session: {
+          activeReadingTimeMs,
+          ttsActiveTimeMs,
+          pagesViewed,
+          startProgress,
+          endProgress,
+          readerType,
+          chapterIndex,
+          pageIndex,
+        },
       })),
     )
     tasks.push(updateReadingStreak(wallet))
@@ -62,37 +77,13 @@ export default defineEventHandler(async (event) => {
 
   await Promise.all(tasks)
 
-  try {
-    publishEvent(event, 'ReadingSession', {
+  if (isNewCompletion) {
+    publishEvent(event, 'BookCompleted', {
       evmWallet: wallet,
       isLikerPlus,
       nftClassId,
-      sessionId,
-      activeReadingTimeMs,
-      ttsActiveTimeMs,
-      activeReadingTimeMsDelta,
-      ttsActiveTimeMsDelta,
-      activeReadingTimeMsPacedDelta: paced.activeReadingTimeMsDelta,
-      ttsActiveTimeMsPacedDelta: paced.ttsActiveTimeMsDelta,
-      pagesViewed,
-      startProgress,
-      endProgress,
-      readerType,
-      chapterIndex,
-      pageIndex,
+      completionProgress: endProgress,
     })
-
-    if (isNewCompletion) {
-      publishEvent(event, 'BookCompleted', {
-        evmWallet: wallet,
-        isLikerPlus,
-        nftClassId,
-        completionProgress: endProgress,
-      })
-    }
-  }
-  catch (err) {
-    console.warn('[Session] Failed to publish event:', err)
   }
 
   return { success: true, bookCompleted: isNewCompletion }

--- a/server/api/login.post.ts
+++ b/server/api/login.post.ts
@@ -90,6 +90,7 @@ export default defineEventHandler(async (event) => {
     email: body.email || userInfoRes.email,
     loginMethod: body.loginMethod,
     isLikerPlus: userInfoRes.isLikerPlus || false,
+    isLikerPlusTrial: userInfoRes.isLikerPlusTrial || false,
     isExpiredLikerPlus: userInfoRes.isExpiredLikerPlus || false,
     likerPlusPeriod: userInfoRes.likerPlusPeriod,
     likerPlusProvider: userInfoRes.likerPlusProvider,

--- a/server/api/register.post.ts
+++ b/server/api/register.post.ts
@@ -68,6 +68,7 @@ export default defineEventHandler(async (event) => {
     email: body.email,
     loginMethod: body.loginMethod,
     isLikerPlus: userInfoRes.isLikerPlus || false,
+    isLikerPlusTrial: userInfoRes.isLikerPlusTrial || false,
     isExpiredLikerPlus: userInfoRes.isExpiredLikerPlus || false,
     likerPlusSubscriptionStatus: userInfoRes.likerPlusSubscriptionStatus,
     ttsKey: generateTTSKey(),

--- a/server/utils/api-user.ts
+++ b/server/utils/api-user.ts
@@ -8,6 +8,9 @@ import { FIRESTORE_IN_OPERATOR_LIMIT } from '~~/shared/constants/api'
 export async function requireUserWalletWithStatus(event: H3Event): Promise<{
   wallet: string
   isLikerPlus: boolean
+  // Paid (non-trial) Plus. Reading-library revenue share excludes trial usage, so
+  // forwards to the API gate on this, not on isLikerPlus (which includes trial).
+  isPaidPlus: boolean
 }> {
   const session = await requireUserSession(event)
   const wallet = session.user.evmWallet
@@ -17,7 +20,12 @@ export async function requireUserWalletWithStatus(event: H3Event): Promise<{
       message: 'WALLET_NOT_FOUND',
     })
   }
-  return { wallet, isLikerPlus: !!session.user.isLikerPlus }
+  const isLikerPlus = !!session.user.isLikerPlus
+  return {
+    wallet,
+    isLikerPlus,
+    isPaidPlus: isLikerPlus && !session.user.isLikerPlusTrial,
+  }
 }
 
 export async function requireUserWallet(event: H3Event): Promise<string> {
@@ -342,7 +350,7 @@ export async function incrementBookReadingTime(
     isLikerPlus: boolean
     countSession?: boolean
   },
-): Promise<void> {
+): Promise<{ isBorrowed: boolean }> {
   const { activeReadingTimeMs, ttsActiveTimeMs, isLikerPlus, countSession } = payload
   const userDocRef = getUserCollection().doc(userWallet)
   const bookDocRef = userDocRef.collection('books').doc(nftClassId.toLowerCase())
@@ -351,10 +359,12 @@ export async function incrementBookReadingTime(
   // borrowed books. `plusBorrowedAt` is stamped server-side at borrow time, so
   // we read it here rather than trust the client.
   const plusTTSListeningTimeMs = isLikerPlus ? ttsActiveTimeMs : 0
+  let isBorrowed = false
   let plusReadingTimeMs = 0
   if (isLikerPlus && activeReadingTimeMs > 0) {
     const bookDoc = await bookDocRef.get()
-    if (bookDoc.data()?.plusBorrowedAt) {
+    isBorrowed = !!bookDoc.data()?.plusBorrowedAt
+    if (isBorrowed) {
       plusReadingTimeMs = activeReadingTimeMs
     }
   }
@@ -378,6 +388,8 @@ export async function incrementBookReadingTime(
   }, { merge: true })
 
   await batch.commit()
+
+  return { isBorrowed }
 }
 
 export async function updateReadingStreak(

--- a/server/utils/plus-revshare-client.ts
+++ b/server/utils/plus-revshare-client.ts
@@ -1,0 +1,39 @@
+interface PlusReadingUsageInput {
+  isPaidPlus: boolean
+  isBorrowed: boolean
+  readerWallet: string
+  classId: string
+  readingTimeMs: number
+  ttsTimeMs: number
+}
+
+/**
+ * Forwards paced Plus reading/TTS usage to the likecoin-api revenue-share ledger.
+ * The shared service secret (not the user JWT) is what proves the usage passed through
+ * this backend's wall-clock pacing — the anti-fraud boundary the payout pipeline trusts.
+ * Best-effort: errors are logged, never thrown, so it never blocks reading-session
+ * bookkeeping; still awaited so it settles before the serverless handler returns.
+ */
+export async function forwardPlusReadingUsage(input: PlusReadingUsageInput): Promise<void> {
+  // Reading counts only for borrowed books, TTS for any book — both only for paid
+  // (non-trial) Plus, since trial usage must never fund the pool.
+  if (!input.isPaidPlus) return
+  const { ttsTimeMs, readerWallet, classId } = input
+  const readingTimeMs = input.isBorrowed ? input.readingTimeMs : 0
+  if (readingTimeMs <= 0 && ttsTimeMs <= 0) return
+
+  const config = useRuntimeConfig()
+  const token = config.plusReadingServiceToken
+  if (!token) return // unset (e.g. local dev) — skip silently
+
+  try {
+    await getLikeCoinAPIFetch()('/plus/reading/usage', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+      body: { readerWallet, classId, readingTimeMs, ttsTimeMs },
+    })
+  }
+  catch (error) {
+    console.warn('[PlusRevShare] Failed to forward reading usage:', error)
+  }
+}

--- a/server/utils/plus-revshare-client.ts
+++ b/server/utils/plus-revshare-client.ts
@@ -31,6 +31,7 @@ export async function forwardPlusReadingUsage(input: PlusReadingUsageInput): Pro
       method: 'POST',
       headers: { Authorization: `Bearer ${token}` },
       body: { readerWallet, classId, readingTimeMs, ttsTimeMs },
+      timeout: 2000, // bound heartbeat/session latency on a hung upstream; failures are swallowed below
     })
   }
   catch (error) {

--- a/server/utils/reading-usage.ts
+++ b/server/utils/reading-usage.ts
@@ -1,0 +1,93 @@
+import type { H3Event } from 'h3'
+import type { PacedDeltas } from '~~/shared/utils/analytics-pacing'
+
+interface SessionContext {
+  activeReadingTimeMs: number
+  ttsActiveTimeMs: number
+  pagesViewed: number
+  startProgress: number
+  endProgress: number
+  readerType: 'epub' | 'pdf'
+  chapterIndex?: number
+  pageIndex?: number
+}
+
+interface RecordPacedReadingUsageInput {
+  event: H3Event
+  source: 'heartbeat' | 'session'
+  wallet: string
+  nftClassId: string
+  sessionId: string
+  isLikerPlus: boolean
+  isPaidPlus: boolean
+  isBorrowed: boolean
+  paced: PacedDeltas
+  rawDelta: PacedDeltas
+  // Present only for session flushes, which carry cumulative totals and progress.
+  session?: SessionContext
+}
+
+/**
+ * Single sink for paced reading/TTS usage, called from both the heartbeat and the
+ * session handlers so the two never drift in cadence: it forwards the paced delta to
+ * the rev-share ledger and publishes the 3ook_ReadingSession analytics event.
+ * ES must aggregate on the *PacedDelta fields (each event carries its own increment);
+ * the session absolutes are snapshots, not summable across events.
+ */
+export async function recordPacedReadingUsage(input: RecordPacedReadingUsageInput): Promise<void> {
+  const {
+    event,
+    source,
+    wallet,
+    nftClassId,
+    sessionId,
+    isLikerPlus,
+    isPaidPlus,
+    isBorrowed,
+    paced,
+    rawDelta,
+    session,
+  } = input
+
+  // publishEvent is non-blocking (it enqueues onto a pubsub batch), so emit it
+  // before awaiting the ledger forward — the analytics enqueue shouldn't queue
+  // behind the forward's network round-trip.
+  try {
+    publishEvent(event, 'ReadingSession', {
+      source,
+      evmWallet: wallet,
+      isLikerPlus,
+      isBorrowed,
+      nftClassId,
+      sessionId,
+      activeReadingTimeMsDelta: rawDelta.activeReadingTimeMsDelta,
+      ttsActiveTimeMsDelta: rawDelta.ttsActiveTimeMsDelta,
+      activeReadingTimeMsPacedDelta: paced.activeReadingTimeMsDelta,
+      ttsActiveTimeMsPacedDelta: paced.ttsActiveTimeMsDelta,
+      ...(session && {
+        activeReadingTimeMs: session.activeReadingTimeMs,
+        ttsActiveTimeMs: session.ttsActiveTimeMs,
+        pagesViewed: session.pagesViewed,
+        startProgress: session.startProgress,
+        endProgress: session.endProgress,
+        readerType: session.readerType,
+        chapterIndex: session.chapterIndex,
+        pageIndex: session.pageIndex,
+      }),
+    })
+  }
+  catch (err) {
+    console.warn('[ReadingUsage] Failed to publish event:', err)
+  }
+
+  // No-ops internally when the paced delta is zero or the user isn't paid Plus.
+  // Awaited so it settles before the serverless handler returns.
+  await forwardPlusReadingUsage({
+    isPaidPlus,
+    isBorrowed,
+    readerWallet: wallet,
+    classId: nftClassId,
+    readingTimeMs: paced.activeReadingTimeMsDelta,
+    ttsTimeMs: paced.ttsActiveTimeMsDelta,
+  })
+}

--- a/shared/types/api.d.ts
+++ b/shared/types/api.d.ts
@@ -7,6 +7,7 @@ export interface LikerInfoResponseData {
   evmWallet: string
   description: string
   isLikerPlus?: boolean
+  isLikerPlusTrial?: boolean
   isExpiredLikerPlus?: boolean
   likerPlusSubscriptionStatus?: 'active' | 'past_due' | 'canceled'
 }

--- a/shared/types/nuxt-auth-utils.d.ts
+++ b/shared/types/nuxt-auth-utils.d.ts
@@ -11,6 +11,7 @@ declare module '#auth-utils' {
     email?: string
     loginMethod?: string
     isLikerPlus?: boolean
+    isLikerPlusTrial?: boolean
     isExpiredLikerPlus?: boolean
     likerPlusPeriod?: LikerPlusStatus
     likerPlusProvider?: LikerPlusProvider


### PR DESCRIPTION
Wire the reader session/heartbeat handlers to forward paced reading/TTS deltas to the likecoin-api /plus/reading/usage ingest, funding the reading-library revenue share.

- Surface isPaidPlus (Plus AND non-trial) on the session: capture isLikerPlusTrial from the upstream /users/profile through login/register/refresh, and derive it in requireUserWalletWithStatus. Trial usage must never fund the pool.
- incrementBookReadingTime now returns isBorrowed (from the plusBorrowedAt read it already does) so handlers can gate the forward: reading counts only for borrowed books, TTS for any book.
- plus-revshare-client forwards via a shared service secret (proves the data passed through this backend's pacing) — best-effort, never blocks the response.

PLUS_READING_SERVICE_TOKEN must match the value configured in likecoin-api.

Requires: https://github.com/likecoin/likecoin-api-public/pull/1300