### PR TITLE
✨ Unblock TTS for native buyers before Plus webhook lands

### DIFF
--- a/app/components/TTSPlayerModal.vue
+++ b/app/components/TTSPlayerModal.vue
@@ -238,6 +238,7 @@ import { encodeAffiliateVoiceId } from '~~/shared/utils/tts-sig'
 import { estimateTTSMinutes } from '~~/shared/utils/tts-trial'
 
 const { user, loggedIn: hasLoggedIn, fetch: refreshSession } = useUserSession()
+const { hasDevicePlus } = useDevicePlusEntitlement()
 const accountStore = useAccountStore()
 const subscription = useSubscriptionModal()
 const { isProcessingSubscription } = subscription
@@ -388,6 +389,13 @@ const {
         return
       }
       if (!user.value?.isLikerPlus) {
+        // The device store already confirmed the purchase but the backend
+        // webhook hasn't flipped the session flag yet — don't re-nag with the
+        // paywall; show a transient notice while the session reconciles.
+        if (hasDevicePlus.value) {
+          handlePlusActivating()
+          return
+        }
         handleTrialExhausted('server_402')
         return
       }
@@ -429,6 +437,18 @@ function handleTrialExhausted(source: 'server_402' | 'client_gate') {
     utmCampaign: props.nftClassId,
     utmMedium: 'tts',
     redirectRoute: buildSubscribeRedirectRoute(),
+  })
+}
+
+// Store purchase succeeded but the session's Plus flag hasn't caught up yet.
+// Show a transient notice instead of the paywall while the background reconcile
+// refreshes the session; the user can retry playback once it flips.
+function handlePlusActivating() {
+  stopTextToSpeech()
+  errorModal.open({
+    level: 'warning',
+    title: $t('tts_plus_activating_title'),
+    description: $t('tts_plus_activating_description'),
   })
 }
 

--- a/app/composables/use-device-plus-entitlement.ts
+++ b/app/composables/use-device-plus-entitlement.ts
@@ -1,3 +1,5 @@
+import { createSharedComposable } from '@vueuse/core'
+
 // Optimistic Plus entitlement reported by the device store (StoreKit / Play via
 // RevenueCat) the instant a purchase/restore succeeds, bridging the gap until the
 // webhook flips the canonical `isLikerPlus`. In-memory only so it can't outlive
@@ -5,7 +7,10 @@
 const RECONCILE_MAX_ATTEMPTS = 15
 const RECONCILE_DELAY_MS = 3000
 
-export function useDevicePlusEntitlement() {
+// Shared across all consumers (TTS gates, native IAP) so the account-switch watcher
+// and `isPlusOrDevicePlus` computed are instantiated once; state is `useState`-backed
+// so it stays correct even if SSR falls back to a fresh instance per request.
+export const useDevicePlusEntitlement = createSharedComposable(() => {
   const { user, loggedIn } = useUserSession()
   const accountStore = useAccountStore()
 
@@ -53,11 +58,11 @@ export function useDevicePlusEntitlement() {
     // A purchase/restore reply can land after logout; recording it then would
     // leak the optimistic flag into the next login in the same tab.
     if (!loggedIn.value) return
-    hasDevicePlus.value = true
+    if (!hasDevicePlus.value) hasDevicePlus.value = true
     if (import.meta.client && !user.value?.isLikerPlus) {
       void reconcileSessionUntilPlus()
     }
   }
 
   return { hasDevicePlus, isPlusOrDevicePlus, markDevicePlusEntitled }
-}
+})

--- a/app/composables/use-device-plus-entitlement.ts
+++ b/app/composables/use-device-plus-entitlement.ts
@@ -1,0 +1,63 @@
+// Optimistic Plus entitlement reported by the device store (StoreKit / Play via
+// RevenueCat) the instant a purchase/restore succeeds, bridging the gap until the
+// webhook flips the canonical `isLikerPlus`. In-memory only so it can't outlive
+// the session and grant access after expiry — the backend session stays canonical.
+const RECONCILE_MAX_ATTEMPTS = 15
+const RECONCILE_DELAY_MS = 3000
+
+export function useDevicePlusEntitlement() {
+  const { user, loggedIn } = useUserSession()
+  const accountStore = useAccountStore()
+
+  const hasDevicePlus = useState('device-plus-entitlement', () => false)
+  // Guards the reconcile loop so repeated marks don't stack refresh polls.
+  const isReconciling = useState('device-plus-reconciling', () => false)
+
+  // Effective Plus for client-side gates: canonical session flag OR the device
+  // store's confirmed-but-not-yet-reconciled purchase (scoped to this session).
+  const isPlusOrDevicePlus = computed(() => !!user.value?.isLikerPlus || (loggedIn.value && hasDevicePlus.value))
+
+  // Drop the optimistic flag on logout or account switch so a purchase in one
+  // account can't suppress paywalls for the next user in the same tab.
+  watch(() => user.value?.likerId, (newId, oldId) => {
+    if (!newId || (oldId && oldId !== newId)) hasDevicePlus.value = false
+  })
+
+  // Refresh the session until the canonical flag catches up with the device, so
+  // the server TTS gate opens on its own. Bounded; bails if the user logs out.
+  async function reconcileSessionUntilPlus(): Promise<void> {
+    if (isReconciling.value) return
+    isReconciling.value = true
+    try {
+      for (let attempt = 0; attempt < RECONCILE_MAX_ATTEMPTS; attempt++) {
+        if (!user.value || user.value.isLikerPlus) return
+        try {
+          await accountStore.refreshSessionInfo()
+        }
+        catch {
+          // best-effort; retry on the next tick
+        }
+        if (user.value?.isLikerPlus) return
+        if (attempt < RECONCILE_MAX_ATTEMPTS - 1) await sleep(RECONCILE_DELAY_MS)
+      }
+    }
+    finally {
+      isReconciling.value = false
+    }
+  }
+
+  // Called when the device store confirms entitlement (purchase/restore). Flips
+  // the optimistic flag and kicks the background reconcile so the canonical flag
+  // follows without user action.
+  function markDevicePlusEntitled() {
+    // A purchase/restore reply can land after logout; recording it then would
+    // leak the optimistic flag into the next login in the same tab.
+    if (!loggedIn.value) return
+    hasDevicePlus.value = true
+    if (import.meta.client && !user.value?.isLikerPlus) {
+      void reconcileSessionUntilPlus()
+    }
+  }
+
+  return { hasDevicePlus, isPlusOrDevicePlus, markDevicePlusEntitled }
+}

--- a/app/composables/use-native-iap.ts
+++ b/app/composables/use-native-iap.ts
@@ -64,8 +64,10 @@ const REQUEST_TIMEOUT_MS = 20 * 1000
 /**
  * Bridges Plus in-app purchases to the native RevenueCat layer when running
  * inside the native app. Web→native via `postToNative`; native→web replies
- * arrive as `nativeBridgeEvent` CustomEvents. Entitlement truth still comes
- * from the backend session — callers refresh the session after a success.
+ * arrive as `nativeBridgeEvent` CustomEvents. The backend session stays the
+ * canonical entitlement source (callers refresh it after a success); a
+ * device-confirmed purchase is recorded only to optimistically unblock
+ * client-side gates while the webhook flips the canonical flag.
  *
  * Shared across all callers (checkout, pricing page, account) so a single
  * `nativeBridgeEvent` listener and one set of pending-request resolvers are
@@ -73,6 +75,7 @@ const REQUEST_TIMEOUT_MS = 20 * 1000
  */
 export const useNativeIAP = createSharedComposable(() => {
   const { isApp } = useAppDetection()
+  const { markDevicePlusEntitled } = useDevicePlusEntitlement()
 
   const isIAPSupported = computed(() => isApp.value && isNativeFeatureSupported('iap'))
 
@@ -102,6 +105,9 @@ export const useNativeIAP = createSharedComposable(() => {
       if (!detail?.type) return
       switch (detail.type) {
         case 'iapPurchaseResult':
+          // The device store confirms entitlement instantly; record it so the
+          // paywall/TTS gates unblock without waiting out the backend webhook.
+          if (detail.status === 'success' && detail.isPlus) markDevicePlusEntitled()
           pendingPurchase?.({
             status: detail.status,
             period: detail.period,
@@ -112,6 +118,7 @@ export const useNativeIAP = createSharedComposable(() => {
           pendingPurchase = null
           break
         case 'iapRestoreResult':
+          if (detail.status === 'success' && detail.isPlus) markDevicePlusEntitled()
           pendingRestore?.({ status: detail.status, isPlus: detail.isPlus, message: detail.message })
           pendingRestore = null
           break

--- a/app/composables/use-native-iap.ts
+++ b/app/composables/use-native-iap.ts
@@ -107,7 +107,7 @@ export const useNativeIAP = createSharedComposable(() => {
         case 'iapPurchaseResult':
           // The device store confirms entitlement instantly; record it so the
           // paywall/TTS gates unblock without waiting out the backend webhook.
-          if (detail.status === 'success' && detail.isPlus) markDevicePlusEntitled()
+          if (isIAPSupported.value && detail.status === 'success' && detail.isPlus) markDevicePlusEntitled()
           pendingPurchase?.({
             status: detail.status,
             period: detail.period,
@@ -118,7 +118,7 @@ export const useNativeIAP = createSharedComposable(() => {
           pendingPurchase = null
           break
         case 'iapRestoreResult':
-          if (detail.status === 'success' && detail.isPlus) markDevicePlusEntitled()
+          if (isIAPSupported.value && detail.status === 'success' && detail.isPlus) markDevicePlusEntitled()
           pendingRestore?.({ status: detail.status, isPlus: detail.isPlus, message: detail.message })
           pendingRestore = null
           break

--- a/app/composables/use-tts-trial-usage.ts
+++ b/app/composables/use-tts-trial-usage.ts
@@ -37,8 +37,11 @@ async function fetchServerUsage(wallet: string): Promise<ServerUsage | null> {
 export function useTTSTrialUsage() {
   const { loggedIn: hasLoggedIn, user } = useUserSession()
 
+  // Trust the device store's confirmed purchase too, so a paid user isn't
+  // gated client-side while the backend webhook flips the canonical flag.
+  const { isPlusOrDevicePlus: isLikerPlus } = useDevicePlusEntitlement()
+
   const wallet = computed(() => user.value?.evmWallet || '')
-  const isLikerPlus = computed(() => !!user.value?.isLikerPlus)
 
   // Reactive key: wallet switch rebinds the ref to the new wallet's storage
   // key automatically. `anon` is a sentinel for the logged-out state — the UI

--- a/app/composables/use-tts-try-modal.ts
+++ b/app/composables/use-tts-try-modal.ts
@@ -9,15 +9,13 @@ interface TTSTryModalState {
 }
 
 export function useTTSTryModal() {
-  const { user } = useUserSession()
+  const { isPlusOrDevicePlus: isPlus } = useDevicePlusEntitlement()
   const overlay = useOverlay()
 
   const state = useStorage<TTSTryModalState>(TTS_TRY_MODAL_KEY, {
     shouldOffer: true,
     cooldownUntil: Date.now(),
   })
-
-  const isPlus = computed(() => user.value?.isLikerPlus || false)
 
   const shouldShowTTSTryModal = computed(() => {
     if (isPlus.value) {

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -965,6 +965,8 @@
   "tts_samples_section_affiliate_exclusive_badge": "Referral exclusive",
   "tts_samples_section_footer": "Subscribe to unlock bilingual narration and more voices.",
   "tts_samples_section_title": "Try Text-to-Speech",
+  "tts_plus_activating_description": "Your Plus subscription is being activated. Please try again in a moment.",
+  "tts_plus_activating_title": "Activating your subscription",
   "tts_session_expired_description": "Please log in again to continue listening.",
   "tts_session_expired_title": "Your session has expired",
   "tts_trial_chip_exhausted_label": "Free trial used. Upgrade now!",

--- a/i18n/locales/zh-Hant.json
+++ b/i18n/locales/zh-Hant.json
@@ -965,6 +965,8 @@
   "tts_samples_section_affiliate_exclusive_badge": "推薦獨家",
   "tts_samples_section_footer": "訂閱即享雙語朗讀功能，解鎖更多聲音。",
   "tts_samples_section_title": "體驗聽書",
+  "tts_plus_activating_description": "正在啟用你的 Plus 訂閱，請稍候再試。",
+  "tts_plus_activating_title": "正在啟用訂閱",
   "tts_session_expired_description": "請重新登入以繼續收聽。",
   "tts_session_expired_title": "登入時段已過期",
   "tts_trial_chip_exhausted_label": "試用時數已用完，立即升級！",


### PR DESCRIPTION
After a StoreKit/Play purchase, the canonical isLikerPlus flag only flips once the RevenueCat→backend webhook reconciles the session, so a paid user stayed gated by the TTS paywall until they manually refreshed. Track an optimistic device-store entitlement that ungates client-side gates and background-reconciles the session, and show an "activating" notice instead of the paywall when the server 402s while it catches up.