### PR TITLE
♻️ Key TTS cache by Minimax voice id

### DIFF
--- a/server/api/reader/tts.get.ts
+++ b/server/api/reader/tts.get.ts
@@ -207,7 +207,6 @@ export default defineEventHandler(async (event) => {
     provider = getTTSProvider(voiceId)
   }
 
-  const customVoiceWallet = isCustomVoice ? session.user.evmWallet : undefined
   const logText = text.replace(/(\r\n|\n|\r)/gm, ' ')
   console.log(`[Speech] User ${session.user.evmWallet} requested conversion. Language: ${language}, Text: "${logText.substring(0, 50)}${logText.length > 50 ? '...' : ''}", Voice: ${voiceId}${customMiniMaxVoiceId ? ` (${customMiniMaxVoiceId})` : ''}`)
 
@@ -229,17 +228,16 @@ export default defineEventHandler(async (event) => {
   const getExpectedSig = createTTSPronunciationSigGetter(language, text)
   const bucket = getTTSCacheBucket()
   const isCacheEnabled = !!bucket
-  const cacheKey = isCacheEnabled
-    ? (isAffiliateVoice && customMiniMaxVoiceId
-        ? generateAffiliateVoiceTTSCacheKey(customMiniMaxVoiceId, language, text, ttsModel)
-        : customVoiceWallet
-          ? generateCustomVoiceTTSCacheKey(customVoiceWallet, language, text, ttsModel)
-          : generateTTSCacheKey(language, voiceId, text, ttsModel))
+  // Custom and affiliate voices carry their Minimax id directly; system voices
+  // resolve theirs from the internal alias.
+  const minimaxVoiceId = customMiniMaxVoiceId ?? getMinimaxVoiceId(voiceId)
+  const cacheKey = isCacheEnabled && minimaxVoiceId
+    ? generateTTSCacheKey(minimaxVoiceId, language, text, ttsModel)
     : null
 
-  if (isCacheEnabled) {
+  if (isCacheEnabled && cacheKey) {
     try {
-      const result = await serveCachedTTS(event, bucket, cacheKey!, provider.format, session.user.evmWallet, dictVersion, getExpectedSig)
+      const result = await serveCachedTTS(event, bucket, cacheKey, provider.format, session.user.evmWallet, dictVersion, getExpectedSig)
       if (result !== null) {
         publishEvent(event, 'TTSCacheHit', ttsEventBase)
         return result

--- a/server/api/tts/sample.get.ts
+++ b/server/api/tts/sample.get.ts
@@ -129,10 +129,9 @@ export default defineEventHandler(async (event) => {
   const getExpectedSig = createTTSPronunciationSigGetter(language, text)
   const bucket = getTTSCacheBucket()
   const isCacheEnabled = !!bucket
-  const cacheKey = isCacheEnabled
-    ? (isAffiliate && customMiniMaxVoiceId
-        ? generateAffiliateVoiceTTSCacheKey(customMiniMaxVoiceId, language, text, ttsModel)
-        : generateTTSCacheKey(language, voiceId, text, ttsModel))
+  const minimaxVoiceId = customMiniMaxVoiceId ?? getMinimaxVoiceId(voiceId)
+  const cacheKey = isCacheEnabled && minimaxVoiceId
+    ? generateTTSCacheKey(minimaxVoiceId, language, text, ttsModel)
     : null
 
   if (isCacheEnabled && cacheKey) {

--- a/server/api/user/custom-voice.delete.ts
+++ b/server/api/user/custom-voice.delete.ts
@@ -42,7 +42,7 @@ export default defineEventHandler(async (event) => {
         })
       : Promise.resolve(),
     ttsBucket
-      ? ttsBucket.deleteFiles({ prefix: getCustomVoiceTTSCachePrefix(wallet) }).catch((error) => {
+      ? ttsBucket.deleteFiles({ prefix: getTTSCachePrefixForVoice(customVoice.voiceId) }).catch((error) => {
           console.warn('[CustomVoice] Failed to delete TTS cache files:', error)
         })
       : Promise.resolve(),

--- a/server/api/user/custom-voice.post.ts
+++ b/server/api/user/custom-voice.post.ts
@@ -113,7 +113,7 @@ export default defineEventHandler(async (event): Promise<CustomVoiceData> => {
 
   const oldTTSCacheDeleted: Promise<void> = existingVoicePromise.then(async (existing) => {
     if (!existing?.voiceId || !ttsBucket) return
-    await ttsBucket.deleteFiles({ prefix: getCustomVoiceTTSCachePrefix(wallet) }).catch((error) => {
+    await ttsBucket.deleteFiles({ prefix: getTTSCachePrefixForVoice(existing.voiceId) }).catch((error) => {
       console.warn('[CustomVoice] Failed to delete TTS cache files:', error)
     })
   })

--- a/server/utils/storage.ts
+++ b/server/utils/storage.ts
@@ -7,14 +7,19 @@ function getDefaultBucket() {
   return storage.bucket()
 }
 
-export function generateTTSCacheKey(language: string, voiceId: string, text: string, model: string): string {
+// All TTS audio is cached under its resolved Minimax voice id so a voice
+// version bump (e.g. three_book_pazu_v3 -> _v4) or a re-cloned custom voice
+// (new cv_<wallet>_<timestamp> id) lands on a fresh path automatically, instead
+// of serving stale audio under a stable alias. Voice id leads the path so a
+// single voice's audio can be prefix-purged (see getTTSCachePrefixForVoice).
+export function generateTTSCacheKey(minimaxVoiceId: string, language: string, text: string, model: string): string {
   const config = useRuntimeConfig()
   if (!config.ttsCacheBucketPrefix) {
     throw new Error('TTS cache bucket is not configured')
   }
   // Create a hash of the text to avoid filesystem issues with special characters
   const textHash = createHash('sha256').update(text).digest('hex')
-  return `${config.ttsCacheBucketPrefix}/${model}/${language}/${voiceId}/${textHash}.mp3`
+  return `${config.ttsCacheBucketPrefix}/${minimaxVoiceId}/${model}/${language}/${textHash}.mp3`
 }
 
 export function getTTSCacheBucket() {
@@ -26,29 +31,15 @@ export function getTTSCacheBucket() {
   return getDefaultBucket()
 }
 
-function generateVoiceTTSCacheKey(subfolder: string, id: string, language: string, text: string, model: string): string {
+// Prefix matching every cached segment for one Minimax voice, used to purge a
+// custom voice's audio when it is deleted or re-cloned. The trailing slash
+// keeps cv_xxx_123 from matching cv_xxx_1234.
+export function getTTSCachePrefixForVoice(minimaxVoiceId: string): string {
   const config = useRuntimeConfig()
   if (!config.ttsCacheBucketPrefix) {
     throw new Error('TTS cache bucket is not configured')
   }
-  const textHash = createHash('sha256').update(text).digest('hex')
-  return `${config.ttsCacheBucketPrefix}/${subfolder}/${id}/${model}/${language}/${textHash}.mp3`
-}
-
-export function generateCustomVoiceTTSCacheKey(wallet: string, language: string, text: string, model: string): string {
-  return generateVoiceTTSCacheKey('custom-voices', wallet, language, text, model)
-}
-
-export function generateAffiliateVoiceTTSCacheKey(providerVoiceId: string, language: string, text: string, model: string): string {
-  return generateVoiceTTSCacheKey('affiliate-voices', providerVoiceId, language, text, model)
-}
-
-export function getCustomVoiceTTSCachePrefix(wallet: string): string {
-  const config = useRuntimeConfig()
-  if (!config.ttsCacheBucketPrefix) {
-    throw new Error('TTS cache bucket is not configured')
-  }
-  return `${config.ttsCacheBucketPrefix}/custom-voices/${wallet}/`
+  return `${config.ttsCacheBucketPrefix}/${minimaxVoiceId}/`
 }
 
 export function getCustomVoiceAudioPrefix(wallet: string): string {

--- a/server/utils/tts-minimax.ts
+++ b/server/utils/tts-minimax.ts
@@ -30,6 +30,10 @@ export function getVoiceDisplayName(voiceId: string): string | undefined {
   return VOICE_CONFIG[voiceId]?.displayName
 }
 
+export function getMinimaxVoiceId(voiceId: string): string | undefined {
+  return VOICE_CONFIG[voiceId]?.minimaxVoiceId
+}
+
 // Pronunciation overrides keyed by Minimax synthesis language. Each maps a
 // source word (`target`) to its `override`: Mandarin Pinyin (tone 1–5)
 // or Cantonese Jyutping (tone 1–6) wrapped in half-width parentheses, spanning


### PR DESCRIPTION
Unify the three cache-key builders into one keyed by the resolved Minimax voice id (`{prefix}/{voiceId}/{model}/{lang}/{hash}.mp3`). A voice version bump (e.g. three_book_pazu_v3 -> _v4) or a re-cloned custom voice now lands on a fresh path automatically instead of serving stale audio under a stable alias. Voice id leads the path so a single voice can still be prefix-purged.