### PR TITLE
✨ Flush reading/TTS analytics at natural boundaries

### DIFF
--- a/app/composables/use-reading-session.ts
+++ b/app/composables/use-reading-session.ts
@@ -1,5 +1,5 @@
-import { useDocumentVisibility, useIdle } from '@vueuse/core'
-import { HEARTBEAT_INTERVAL_MS, MAX_HEARTBEAT_DELTA_MS, MAX_SESSION_DURATION_MS } from '~~/shared/constants/analytics'
+import { useDocumentVisibility, useIdle, useThrottleFn } from '@vueuse/core'
+import { ANALYTICS_FLUSH_THROTTLE_MS, HEARTBEAT_INTERVAL_MS, MAX_HEARTBEAT_DELTA_MS, MAX_SESSION_DURATION_MS } from '~~/shared/constants/analytics'
 
 const IDLE_TIMEOUT_MS = 2 * 60 * 1000
 
@@ -53,6 +53,10 @@ export function useReadingSession(options: ReadingSessionOptions) {
     isTabVisible.value && !idle.value,
   )
 
+  // Commit accumulated time at natural boundaries (TTS pause/stop/close, end of a
+  // reading burst). Throttled so rapid toggles collapse to one paced Firestore write.
+  const flushDeltas = useThrottleFn(sendHeartbeat, ANALYTICS_FLUSH_THROTTLE_MS)
+
   watch(isActivelyReading, (active) => {
     if (active) {
       lastActiveTimestamp = Date.now()
@@ -60,6 +64,9 @@ export function useReadingSession(options: ReadingSessionOptions) {
     else if (lastActiveTimestamp) {
       activeReadingTimeMs += Date.now() - lastActiveTimestamp
       lastActiveTimestamp = null
+      // When the tab is hidden the terminal beacon flushes reliably; a $fetch here
+      // would race it and may be cancelled, so only flush on idle-while-visible.
+      if (isTabVisible.value) flushDeltas()
     }
   }, { immediate: true })
 
@@ -70,6 +77,8 @@ export function useReadingSession(options: ReadingSessionOptions) {
     else if (lastTTSTimestamp) {
       ttsActiveTimeMs += Date.now() - lastTTSTimestamp
       lastTTSTimestamp = null
+      // Only flush while visible, same as the idle path above.
+      if (isTabVisible.value) flushDeltas()
     }
   }, { immediate: true })
 

--- a/shared/constants/analytics.ts
+++ b/shared/constants/analytics.ts
@@ -2,3 +2,4 @@ export const MAX_SESSION_DURATION_MS = 4 * 60 * 60 * 1000
 export const HEARTBEAT_INTERVAL_MS = 5 * 60 * 1000
 export const MAX_HEARTBEAT_DELTA_MS = 10 * 60 * 1000
 export const WALL_CLOCK_JITTER_MS = 30 * 1000
+export const ANALYTICS_FLUSH_THROTTLE_MS = 30 * 1000


### PR DESCRIPTION
Previously deltas only synced on the 5-min heartbeat and the terminal beacon, so up to 5 min of listening time could be lost when the app is backgrounded or killed (beacon/unmount are unreliable on mobile/native).

Commit accumulated time on TTS pause/stop/close and at the end of a reading burst (idle), via a throttled non-terminal flush so rapid toggles collapse to one paced Firestore write. Tab-hide stays on the terminal beacon to avoid racing it with a cancellable fetch.