### PR TITLE
🐛 Fix TTS extracting prop never reaching PDFReader

### DIFF
--- a/app/components/PDFReader.vue
+++ b/app/components/PDFReader.vue
@@ -212,7 +212,7 @@
             icon="i-material-symbols-play-arrow-rounded"
             variant="solid"
             color="primary"
-            :loading="isTTSExtracting"
+            :loading="isTtsExtracting"
             :ui="ttsButtonUI"
             @click="handleMobileTTSClick"
           />
@@ -226,7 +226,7 @@
               :aria-label="$t('reader_text_to_speech_button')"
               variant="solid"
               color="primary"
-              :loading="isTTSExtracting"
+              :loading="isTtsExtracting"
               :disabled="isAudioHidden"
               :ui="ttsButtonUI"
               @click="onClickTTSPlay"
@@ -319,7 +319,7 @@ interface Props {
   bookName?: string
   pdfBuffer?: ArrayBuffer | null
   isAudioHidden?: boolean
-  isTTSExtracting?: boolean
+  isTtsExtracting?: boolean
   bookFileCacheKey: string
   bookProgressKeyPrefix: string
   nftClassId: string


### PR DESCRIPTION
The prop was declared isTTSExtracting but bound via kebab-case :is-tts-extracting, which Vue camelizes to isTtsExtracting — so the prop was silently dropped and the TTS button's loading spinner never fired during PDF text extraction. Rename the prop to isTtsExtracting so the kebab binding round-trips.