### PR TITLE
🐛 Keep counting TTS listening time across tab visibility changes

### DIFF
--- a/app/composables/use-reading-session.ts
+++ b/app/composables/use-reading-session.ts
@@ -64,8 +64,8 @@ export function useReadingSession(options: ReadingSessionOptions) {
     else if (lastActiveTimestamp) {
       activeReadingTimeMs += Date.now() - lastActiveTimestamp
       lastActiveTimestamp = null
-      // When the tab is hidden the terminal beacon flushes reliably; a $fetch here
-      // would race it and may be cancelled, so only flush on idle-while-visible.
+      // Fires on idle-while-visible or the hide transition; on hide the terminal
+      // beacon flushes and a $fetch would race it, so restrict to the visible case.
       if (isTabVisible.value) flushDeltas()
     }
   }, { immediate: true })
@@ -77,8 +77,9 @@ export function useReadingSession(options: ReadingSessionOptions) {
     else if (lastTTSTimestamp) {
       ttsActiveTimeMs += Date.now() - lastTTSTimestamp
       lastTTSTimestamp = null
-      // Only flush while visible, same as the idle path above.
-      if (isTabVisible.value) flushDeltas()
+      // TTS plays in the background, so commit on pause/stop even while hidden;
+      // a server flush works from a hidden-but-alive tab (beacon covers unload).
+      flushDeltas()
     }
   }, { immediate: true })
 
@@ -99,9 +100,9 @@ export function useReadingSession(options: ReadingSessionOptions) {
     if (!chapterIndex && !pageIndex) {
       pagesViewed.add(Math.floor(progress.value))
     }
-    // Continuous play never toggles the idle/TTS watchers, so without this the
-    // in-progress span only commits on the 5-min heartbeat. Visible-only, throttled.
-    if (isTabVisible.value) flushDeltas()
+    // TTS advances progress in the background too, so flush regardless of
+    // visibility — like the book-settings sync. Throttled; beacon covers unload.
+    flushDeltas()
   }, { immediate: true })
 
   function drainAccumulators(cap: number) {

--- a/app/composables/use-reading-session.ts
+++ b/app/composables/use-reading-session.ts
@@ -29,13 +29,13 @@ export function useReadingSession(options: ReadingSessionOptions) {
   let lastActiveTimestamp: number | null = null
   let lastTTSTimestamp: number | null = null
 
-  function resetSession() {
+  function resetSession({ seedTTSMs = 0 } = {}) {
     sessionId = crypto.randomUUID()
     startProgress = progress.value
     pagesViewed = new Set<number | string>()
     sessionFlushed = false
     activeReadingTimeMs = 0
-    ttsActiveTimeMs = 0
+    ttsActiveTimeMs = seedTTSMs
     sessionActiveReadingTimeMs = 0
     sessionTTSActiveTimeMs = 0
     lastActiveTimestamp = null
@@ -215,7 +215,14 @@ export function useReadingSession(options: ReadingSessionOptions) {
       flushSessionBeacon()
     }
     else {
-      resetSession()
+      // Audio keeps playing while hidden, so carry that listening span into the
+      // new session; resetSession() nulls the clocks and the source refs don't
+      // toggle on return, so re-arm both here or they never restart.
+      const now = Date.now()
+      const carriedTTSMs = ttsActiveTimeMs + (lastTTSTimestamp ? now - lastTTSTimestamp : 0)
+      resetSession({ seedTTSMs: carriedTTSMs })
+      if (isTextToSpeechPlaying?.value) lastTTSTimestamp = now
+      if (isActivelyReading.value) lastActiveTimestamp = now
       logSessionStart()
       resumeHeartbeat()
     }

--- a/app/composables/use-reading-session.ts
+++ b/app/composables/use-reading-session.ts
@@ -99,6 +99,9 @@ export function useReadingSession(options: ReadingSessionOptions) {
     if (!chapterIndex && !pageIndex) {
       pagesViewed.add(Math.floor(progress.value))
     }
+    // Continuous play never toggles the idle/TTS watchers, so without this the
+    // in-progress span only commits on the 5-min heartbeat. Visible-only, throttled.
+    if (isTabVisible.value) flushDeltas()
   }, { immediate: true })
 
   function drainAccumulators(cap: number) {


### PR DESCRIPTION
Returning to a hidden tab ran resetSession(), which nulled the TTS and reading clocks. Since isTextToSpeechPlaying never toggles on return, its watcher never re-armed lastTTSTimestamp, so TTS time froze permanently after one tab switch; reading time only re-armed on the next idle cycle.

Re-arm both clocks after the reset, and carry the in-flight TTS span (audio keeps playing while hidden) into the new session via a seed, so offscreen listening counts while offscreen reading still does not.