### PR TITLE
[TAS-6072] ✨ Grant affiliate voices by publisher wallet

### DIFF
--- a/app/components/TTSPlayerModal.vue
+++ b/app/components/TTSPlayerModal.vue
@@ -286,12 +286,14 @@ const props = withDefaults(
 )
 
 const { fetchConfig: fetchPlusAffiliateConfig, voicesForBook } = usePlusAffiliate()
-const plusAffiliateVoices = computed(() => voicesForBook(props.nftClassId))
 
 const {
+  ownerWallet: bookOwnerWallet,
   ownerLikerId: bookOwnerLikerId,
   upsellVoices: bookOwnerUpsellVoices,
 } = useBookOwnerAffiliate(() => props.nftClassId)
+
+const plusAffiliateVoices = computed(() => voicesForBook(props.nftClassId, bookOwnerWallet))
 
 const isLikerPlus = computed(() => !!user.value?.isLikerPlus)
 

--- a/app/composables/use-book-owner-affiliate.ts
+++ b/app/composables/use-book-owner-affiliate.ts
@@ -6,16 +6,20 @@ export function useBookOwnerAffiliate(
 ) {
   const { user } = useUserSession()
   const metadataStore = useMetadataStore()
+  const bookstoreStore = useBookstoreStore()
 
   const nftClassIdRef = computed(() => toValue(nftClassId) || '')
-  const { nftClassOwnerWalletAddress } = useEVMBookInfo({ nftClassId: nftClassIdRef })
+  // Use the bookstore-listing owner wallet (the lister) so the displayed voices
+  // match exactly what the server grants — it gates on the same `ownerWallet`.
+  const ownerWallet = computed(() =>
+    bookstoreStore.getBookstoreInfoByNFTClassId(nftClassIdRef.value)?.ownerWallet || '')
 
   const loadedConfig = useState<AffiliatePublicConfig | null>('book-owner-affiliate-config', () => null)
   const loadedLikerId = useState<string | null>('book-owner-affiliate-loaded-liker-id', () => null)
   const isLoading = useState<boolean>('book-owner-affiliate-loading', () => false)
 
   const ownerLikerId = computed(() => {
-    const wallet = nftClassOwnerWalletAddress.value
+    const wallet = ownerWallet.value
     if (!wallet) return undefined
     return metadataStore.getLikerInfoByWalletAddress(wallet)?.likerId
   })
@@ -26,7 +30,7 @@ export function useBookOwnerAffiliate(
       loadedLikerId.value = null
       return
     }
-    const wallet = nftClassOwnerWalletAddress.value
+    const wallet = ownerWallet.value
     if (!wallet || isLoading.value) return
     isLoading.value = true
     try {
@@ -45,14 +49,16 @@ export function useBookOwnerAffiliate(
     }
   }
 
-  watchImmediate(nftClassOwnerWalletAddress, () => {
+  watchImmediate(ownerWallet, () => {
     fetchConfig()
   })
 
-  const upsellVoices = computed(() => getAffiliateVoicesForBook(loadedConfig.value, nftClassIdRef.value))
+  const upsellVoices = computed(() =>
+    getAffiliateVoicesForBook(loadedConfig.value, nftClassIdRef.value, ownerWallet.value))
 
   return {
     config: loadedConfig,
+    ownerWallet,
     ownerLikerId,
     upsellVoices,
     fetchConfig,

--- a/app/composables/use-plus-affiliate.ts
+++ b/app/composables/use-plus-affiliate.ts
@@ -1,12 +1,18 @@
 import type { AffiliatePublicConfig } from '~~/shared/types/affiliate'
 import type { AffiliateVoiceData } from '~~/shared/types/custom-voice'
+import { checksumEVMAddress } from '~~/shared/utils'
 
 export function getAffiliateVoicesForBook(
   config: AffiliatePublicConfig | null,
   nftClassId: string | undefined,
+  ownerWallet?: string,
 ): AffiliateVoiceData[] {
   if (!config?.active || !nftClassId) return []
-  if (!config.affiliateClassIds.includes(nftClassId.toLowerCase())) return []
+  const byClass = config.affiliateClassIds.includes(nftClassId.toLowerCase())
+  const checksummedOwnerWallet = checksumEVMAddress(ownerWallet)
+  const byWallet = !!checksummedOwnerWallet
+    && config.affiliatePublisherWallets.includes(checksummedOwnerWallet)
+  if (!byClass && !byWallet) return []
   return config.customVoices
 }
 
@@ -43,8 +49,11 @@ export function usePlusAffiliate() {
     }
   }
 
-  function voicesForBook(nftClassId: MaybeRefOrGetter<string | undefined>): AffiliateVoiceData[] {
-    return getAffiliateVoicesForBook(loadedConfig.value, toValue(nftClassId))
+  function voicesForBook(
+    nftClassId: MaybeRefOrGetter<string | undefined>,
+    ownerWallet?: MaybeRefOrGetter<string | undefined>,
+  ): AffiliateVoiceData[] {
+    return getAffiliateVoicesForBook(loadedConfig.value, toValue(nftClassId), toValue(ownerWallet))
   }
 
   return {

--- a/server/api/affiliate/[likerId].get.ts
+++ b/server/api/affiliate/[likerId].get.ts
@@ -44,6 +44,7 @@ export default defineEventHandler(async (event): Promise<AffiliatePublicConfig> 
     giftOnTrial: config.giftOnTrial,
     isPlusDiscountAllowed,
     affiliateClassIds: config.affiliateClassIds,
+    affiliatePublisherWallets: config.affiliatePublisherWallets,
     customVoices: config.customVoices.map(v => ({
       id: v.id,
       name: v.name,

--- a/server/api/reader/tts.get.ts
+++ b/server/api/reader/tts.get.ts
@@ -178,7 +178,7 @@ export default defineEventHandler(async (event) => {
     }
     // Ownership is gated at the reader-page level; this check is a sanity
     // boundary to stop an arbitrary book from riding an affiliate voice URL.
-    if (!isBookInAffiliateVoiceScope(affiliateConfig, nftClassId)) {
+    if (!(await isBookInAffiliateVoiceScope(affiliateConfig, nftClassId))) {
       throw createError({ status: 403, message: 'BOOK_NOT_IN_AFFILIATE' })
     }
     const affiliateVoice = affiliateConfig.customVoices.find(v => v.id === affiliateVoiceSlot)

--- a/server/types/affiliate.d.ts
+++ b/server/types/affiliate.d.ts
@@ -15,6 +15,7 @@ export interface AffiliateGiftBook {
 export interface AffiliateConfig {
   active: boolean
   affiliateClassIds: string[]
+  affiliatePublisherWallets: string[]
   giftBooks?: AffiliateGiftBook[]
   giftOnTrial?: boolean
   customVoices: AffiliateCustomVoice[]

--- a/server/utils/affiliate.ts
+++ b/server/utils/affiliate.ts
@@ -1,12 +1,14 @@
 import type { AffiliateConfig, AffiliateCustomVoice } from '~~/server/types/affiliate'
-import { normalizeNFTClassId } from '~~/shared/utils'
+import { fetchCachedNFTClassAggregatedMetadata } from '~~/server/utils/likecoin-nft'
+import { checkIsEVMAddress, checksumEVMAddress, normalizeNFTClassId } from '~~/shared/utils'
 import { getLikeCoinAPIFetch } from '~~/shared/utils/api'
 import { normalizeLikerId } from '~~/shared/utils/liker-id'
 
 type UpstreamAffiliateResponse =
-  & Omit<AffiliateConfig, 'affiliateClassIds' | 'customVoices'>
+  & Omit<AffiliateConfig, 'affiliateClassIds' | 'affiliatePublisherWallets' | 'customVoices'>
   & {
     affiliateClassIds?: string[]
+    affiliatePublisherWallets?: string[]
     customVoices?: Partial<AffiliateCustomVoice>[]
     isPlusDiscountAllowed?: boolean
   }
@@ -42,6 +44,9 @@ async function getAffiliateEntry(likerId: string): Promise<AffiliateEntry | null
           ? {
               active: true,
               affiliateClassIds: (upstream.affiliateClassIds ?? []).map(id => id.toLowerCase()),
+              affiliatePublisherWallets: (upstream.affiliatePublisherWallets ?? [])
+                .map(w => checksumEVMAddress(w))
+                .filter(Boolean),
               giftBooks: (upstream.giftBooks ?? [])
                 .filter(b => typeof b?.classId === 'string' && !!b.classId)
                 .map((b) => {
@@ -87,6 +92,17 @@ export async function getAffiliatePlusDiscountAllowed(likerId: string): Promise<
   return (await getAffiliateEntry(likerId))?.isPlusDiscountAllowed ?? false
 }
 
-export function isBookInAffiliateVoiceScope(config: AffiliateConfig, nftClassId: string): boolean {
-  return config.affiliateClassIds.includes(nftClassId.toLowerCase())
+// A book is in scope when it is explicitly listed in `affiliateClassIds`, or
+// when it is listed in the bookstore by one of the affiliate's publisher
+// wallets — letting a publisher whitelist their wallet instead of each book.
+export async function isBookInAffiliateVoiceScope(config: AffiliateConfig, nftClassId: string): Promise<boolean> {
+  if (config.affiliateClassIds.includes(nftClassId.toLowerCase())) return true
+  if (!config.affiliatePublisherWallets.length) return false
+  // Only on-chain NFT class IDs can have bookstore metadata; skip uploaded-book
+  // and preview IDs so we don't make guaranteed-failing upstream calls.
+  if (!checkIsEVMAddress(nftClassId)) return false
+  const metadata = await fetchCachedNFTClassAggregatedMetadata(nftClassId, ['bookstore'])
+    .catch(() => null)
+  const ownerWallet = checksumEVMAddress(metadata?.bookstoreInfo?.ownerWallet)
+  return !!ownerWallet && config.affiliatePublisherWallets.includes(ownerWallet)
 }

--- a/shared/types/affiliate.d.ts
+++ b/shared/types/affiliate.d.ts
@@ -18,5 +18,6 @@ export type AffiliatePublicConfig =
     giftOnTrial?: boolean
     isPlusDiscountAllowed?: boolean
     affiliateClassIds: string[]
+    affiliatePublisherWallets: string[]
     customVoices: AffiliateVoiceData[]
   }

--- a/shared/utils/index.ts
+++ b/shared/utils/index.ts
@@ -1,5 +1,14 @@
+import { getAddress } from 'viem'
+
 export function checkIsEVMAddress(address: string) {
   return /^0x[a-fA-F0-9]{40}$/.test(address)
+}
+
+// Wallet addresses are compared in checksummed (EIP-55) form, unlike NFT class
+// IDs which are lowercased. Returns '' for anything that isn't an EVM address.
+export function checksumEVMAddress(address?: string) {
+  if (!address || !checkIsEVMAddress(address)) return ''
+  return getAddress(address)
 }
 
 export function normalizeNFTClassId(id?: string) {

--- a/test/unit/affiliate-voices.test.ts
+++ b/test/unit/affiliate-voices.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { getAffiliateVoicesForBook } from '~/composables/use-plus-affiliate'
+import type { AffiliatePublicConfig } from '~~/shared/types/affiliate'
+
+const VOICES = [{ id: 'chiming', name: 'Chiming' }]
+
+// Publisher wallets are stored checksummed (EIP-55), unlike the lowercased class IDs.
+const PUBLISHER_WALLET = '0xabCDeF0123456789AbcdEf0123456789aBCDEF01'
+const STRANGER_WALLET = '0xfEdcBA9876543210FedCBa9876543210fEdCBa98'
+
+const activeConfig: AffiliatePublicConfig = {
+  active: true,
+  affiliateClassIds: ['0xaaa'],
+  affiliatePublisherWallets: [PUBLISHER_WALLET],
+  customVoices: VOICES,
+}
+
+describe('getAffiliateVoicesForBook', () => {
+  it('returns no voices when config is null or inactive', () => {
+    expect(getAffiliateVoicesForBook(null, '0xaaa')).toEqual([])
+    expect(getAffiliateVoicesForBook({ active: false }, '0xaaa')).toEqual([])
+  })
+
+  it('returns no voices when nftClassId is missing', () => {
+    expect(getAffiliateVoicesForBook(activeConfig, undefined)).toEqual([])
+  })
+
+  it('grants voices when the book is in affiliateClassIds (case-insensitive)', () => {
+    expect(getAffiliateVoicesForBook(activeConfig, '0xAAA')).toEqual(VOICES)
+  })
+
+  it('grants voices when the book is listed by a publisher wallet (checksum-insensitive)', () => {
+    // Lowercased owner wallet still matches the checksummed config entry.
+    expect(getAffiliateVoicesForBook(activeConfig, '0xother', PUBLISHER_WALLET.toLowerCase())).toEqual(VOICES)
+  })
+
+  it('denies when neither the classId nor the owner wallet match', () => {
+    expect(getAffiliateVoicesForBook(activeConfig, '0xother', STRANGER_WALLET)).toEqual([])
+    expect(getAffiliateVoicesForBook(activeConfig, '0xother')).toEqual([])
+  })
+})


### PR DESCRIPTION
Affiliate TTS voices were gated solely by an explicit affiliateClassIds list. Also allow them when a book is listed by a wallet in the new affiliatePublisherWallets allow-list, so a publisher can whitelist their wallet instead of enumerating every book. The server gate resolves the book's bookstore ownerWallet; the upsell and Plus paths gate on the same wallet so the displayed voices match what the server grants.

Requires: https://github.com/likecoin/likecoin-api-public/pull/1310