### PR TITLE
[TAS-6077] ✨ Pass gift, affiliate & attribution to IAP subscription purchase

### DIFF
--- a/app/composables/use-native-iap.ts
+++ b/app/composables/use-native-iap.ts
@@ -137,7 +137,15 @@ export const useNativeIAP = createSharedComposable(() => {
   // `likerId` is the backend internal user id — used as the RevenueCat
   // app_user_id the native side logs in with and the webhook resolves against.
   // Same field name as the `identifyUser` payload to avoid sending the wrong id.
-  function purchase(period: SubscriptionPlan, likerId?: string): Promise<IAPPurchaseResult> {
+  // `attributes` are custom RevenueCat subscriber attributes (gift book, affiliate
+  // channel, ad-attribution ids) the native side sets before purchase so they reach
+  // the webhook's subscriber_attributes — the IAP equivalent of Stripe checkout
+  // metadata. The native handler ignores reserved ($-prefixed) keys.
+  function purchase(
+    period: SubscriptionPlan,
+    likerId?: string,
+    attributes?: Record<string, string>,
+  ): Promise<IAPPurchaseResult> {
     if (!isIAPSupported.value) {
       return Promise.resolve({ status: 'error', message: 'IAP not supported' })
     }
@@ -159,7 +167,7 @@ export const useNativeIAP = createSharedComposable(() => {
         clearTimeout(timer)
         resolve(r)
       }
-      postToNative({ type: 'iapPurchase', period, likerId })
+      postToNative({ type: 'iapPurchase', period, likerId, attributes })
     })
   }
 

--- a/app/composables/use-subscription-checkout.ts
+++ b/app/composables/use-subscription-checkout.ts
@@ -120,21 +120,57 @@ export function useSubscriptionCheckout() {
         })
         return
       }
-      // Stripe-only options (a coupon, or the gift-NFT-with-yearly flow) can't be
-      // honored by store IAP. We still complete the purchase as a plain subscription,
-      // but log when one is present to measure real exposure before handling it.
-      // trialPeriodDays / mustCollectPaymentMethod are intentionally excluded:
-      // store IAP applies its own intro offers, so they aren't a mismatch here.
-      if (coupon || nftClassId) {
+      // Coupons can't be honored by store IAP (the store controls pricing). A gift
+      // NFT only attaches to yearly, so a gift on a monthly plan is dropped. Yearly
+      // gifts + affiliate attribution + ad-attribution DO carry through, as RevenueCat
+      // subscriber attributes set natively before purchase (see below). We still
+      // complete the purchase when an option is unsupported, but log to measure
+      // exposure. trialPeriodDays / mustCollectPaymentMethod are intentionally
+      // excluded: store IAP applies its own intro offers, so they aren't a mismatch.
+      const hasUnsupportedGift = Boolean(nftClassId) && !isYearly
+      if (coupon || hasUnsupportedGift) {
         useLogEvent('subscription_iap_unsupported_options', {
           has_coupon: Boolean(coupon),
-          has_nft_class_id: Boolean(nftClassId),
+          has_unsupported_gift: hasUnsupportedGift,
         })
       }
       try {
         isProcessingSubscription.value = true
         useLogEvent('begin_checkout', eventPayloadWithCoupon)
-        const result = await purchaseViaIAP(plan, user.value.likerId)
+        // The native purchase carries no metadata, so pass the gift book, affiliate
+        // channel, and ad-attribution as RevenueCat subscriber attributes. The native
+        // shell sets them before purchase and the grant webhook reads them back — the
+        // IAP equivalent of Stripe checkout metadata. Drop empty attribution values so
+        // we never overwrite an attribute with a blank.
+        const from = getRouteQuery('from')
+        const analyticsParams = getAnalyticsParameters()
+        const attributes: Record<string, string> = {}
+        const setAttribute = (key: string, value?: string | null) => {
+          if (value) attributes[key] = value
+        }
+        // Always send plusGiftClassId — unlike attribution, it must be cleared, not
+        // kept. RevenueCat attributes are sticky per-subscriber, so a non-gift
+        // purchase after a prior gift would otherwise inherit the stale class id and
+        // the webhook would re-grant the book. Empty string is the webhook's tombstone
+        // for "no gift". Gift only attaches to yearly.
+        attributes.plusGiftClassId = isYearly && nftClassId ? nftClassId : ''
+        setAttribute('plusFrom', from)
+        setAttribute('fbClickId', analyticsParams.fbClickId)
+        setAttribute('fbp', analyticsParams.fbp)
+        setAttribute('fbc', analyticsParams.fbc)
+        setAttribute('gaClientId', analyticsParams.gaClientId)
+        setAttribute('gaSessionId', analyticsParams.gaSessionId)
+        setAttribute('gadClickId', analyticsParams.gadClickId)
+        setAttribute('gadSource', analyticsParams.gadSource)
+        setAttribute('utmSource', analyticsParams.utmSource || utmSource)
+        setAttribute('utmMedium', analyticsParams.utmMedium || utmMedium)
+        setAttribute('utmCampaign', analyticsParams.utmCampaign || utmCampaign)
+        setAttribute('utmContent', analyticsParams.utmContent)
+        setAttribute('utmTerm', analyticsParams.utmTerm)
+        setAttribute('referrer', analyticsParams.referrer)
+        setAttribute('posthogDistinctId', analyticsParams.posthogDistinctId)
+
+        const result = await purchaseViaIAP(plan, user.value.likerId, attributes)
         if (result.status === 'cancelled') return
         if (result.status !== 'success') {
           throw createError({
@@ -147,7 +183,13 @@ export function useSubscriptionCheckout() {
         }
         blockingModal.open({ title: $t('common_processing') })
         await pollSessionUntilPlus()
-        await navigateTo(localeRoute({ name: 'plus-success', query: { period: plan } }))
+        // Flag a pending gift so the success page waits for the webhook to attach the
+        // book (the cart is created async on grant) before routing to the claim page.
+        const hasGift = isYearly && Boolean(nftClassId)
+        await navigateTo(localeRoute({
+          name: 'plus-success',
+          query: { period: plan, ...(hasGift ? { gift: '1' } : {}) },
+        }))
       }
       catch (error) {
         useLogEvent('subscription_checkout_error', {

--- a/app/pages/plus/success.vue
+++ b/app/pages/plus/success.vue
@@ -73,7 +73,7 @@ useHead({
   meta: [{ name: 'robots', content: 'noindex, nofollow' }],
 })
 
-async function fetchPlusGiftStatus() {
+async function fetchPlusGiftStatus({ shouldHandleError = true } = {}) {
   try {
     const {
       giftClassId: giftNFTClassId,
@@ -89,10 +89,12 @@ async function fetchPlusGiftStatus() {
     }
   }
   catch (error) {
-    await handleError(error, {
-      title: $t('subscription_success_fetch_gift_error'),
-      description: $t('subscription_success_fetch_gift_error_description'),
-    })
+    if (shouldHandleError) {
+      await handleError(error, {
+        title: $t('subscription_success_fetch_gift_error'),
+        description: $t('subscription_success_fetch_gift_error_description'),
+      })
+    }
     return {}
   }
 }
@@ -107,16 +109,37 @@ onMounted(async () => {
       await accountStore.refreshSessionInfo()
       retry++
     }
-    // The gift-with-yearly flow is Stripe-only (see use-subscription-checkout
-    // skipping `nftClassId` for IAP), and `/plus/gift` keys off a Stripe
-    // subscription Id, so calling it for RevenueCat subscribers always errors.
-    const isRevenueCatSubscriber = user.value?.likerPlusProvider === 'revenuecat'
+    // The gift book attaches asynchronously — Stripe writes it to the subscription
+    // during invoice processing, RevenueCat creates the cart in its grant webhook —
+    // so `/plus/gift` (now provider-aware) can lag the entitlement. The IAP checkout
+    // sets `gift=1` when a gift is expected; poll briefly for the webhook to land.
+    // The Stripe redirect carries no flag and reads once.
+    const isGiftExpected = getRouteQuery('gift') === '1'
+    const MAX_GIFT_RETRIES = 4
+    // Suppress the error dialog while polling through expected webhook lag;
+    // only surface one on the final attempt. The Stripe path reads once.
+    let gift: {
+      giftNFTClassId?: string
+      giftCartId?: string
+      giftPaymentId?: string
+      giftClaimToken?: string
+    } = await fetchPlusGiftStatus({ shouldHandleError: !isGiftExpected })
+    let giftRetry = 0
+    while (
+      isGiftExpected
+      && !(gift.giftNFTClassId && gift.giftCartId && gift.giftPaymentId && gift.giftClaimToken)
+      && giftRetry < MAX_GIFT_RETRIES
+    ) {
+      await sleep(5000)
+      giftRetry++
+      gift = await fetchPlusGiftStatus({ shouldHandleError: giftRetry === MAX_GIFT_RETRIES })
+    }
     const {
       giftNFTClassId,
       giftCartId,
       giftPaymentId,
       giftClaimToken,
-    } = isRevenueCatSubscriber ? {} : await fetchPlusGiftStatus()
+    } = gift
     if (isRedirected.value) {
       // Restore the persisted currency before logging: post-Stripe-redirect the
       // payment-currency state is fresh 'auto' and resolves to USD until


### PR DESCRIPTION
Native IAP carries no checkout metadata, so send the gift book, affiliate channel, and ad-attribution as RevenueCat subscriber attributes for the grant webhook to read back. Yearly gifts are no longer logged as unsupported, and the success page polls the now provider-aware /plus/gift for the async-attached book before routing to the claim page.