### PR TITLE
💄 Unify member page footer links style

### DIFF
--- a/app/components/PricingPageContent.vue
+++ b/app/components/PricingPageContent.vue
@@ -204,8 +204,8 @@
                 :to="learnMoreRoute"
                 variant="link"
                 color="neutral"
-                block
                 size="sm"
+                :ui="{ label: 'border-b border-current leading-5' }"
               />
 
               <UAlert
@@ -251,7 +251,7 @@
           >
             <template #selectedBooksOnly>
               <UButton
-                class="inline p-0 rounded-none border-b border-current text-xs"
+                class="inline p-0 rounded-none border-b border-current text-xs leading-5"
                 variant="link"
                 color="neutral"
                 :label="$t('tts_samples_section_affiliate_books_note_selected_books_only')"


### PR DESCRIPTION
Before
<img width="462" height="126" src="https://github.com/user-attachments/assets/354990b2-7ea8-41c7-9ba2-475d0522308f" />

After
<img width="488" height="161" src="https://github.com/user-attachments/assets/0e8eb31c-b1ca-4ca4-a47f-731088ea0415" />

