### PR TITLE
👔 Halve Plus trial period to 7 days

### DIFF
--- a/shared/constants/pricing.ts
+++ b/shared/constants/pricing.ts
@@ -209,6 +209,6 @@ export const TWD_PRICE_TIER_LIST = [
 ]
 
 export const PLUS_BOOK_PURCHASE_DISCOUNT = 0.2 // 20% discount
-export const DEFAULT_TRIAL_PERIOD_DAYS = 14
-export const PAID_TRIAL_PERIOD_DAYS_THRESHOLD = 14
+export const DEFAULT_TRIAL_PERIOD_DAYS = 7
+export const PAID_TRIAL_PERIOD_DAYS_THRESHOLD = 7
 export const PAID_TRIAL_PRICE = 1


### PR DESCRIPTION
Lower the default trial length and the paid-trial threshold from 14 to 7 days, keeping the two equal so the paid/free trial heuristic is unchanged.