### PR TITLE
🐛 Refresh borrowed book reading time on shelf

### DIFF
--- a/app/stores/bookshelf.ts
+++ b/app/stores/bookshelf.ts
@@ -91,7 +91,9 @@ export const useBookshelfStore = defineStore('bookshelf', () => {
         ...plusReadingBookIds.value.map(id =>
           nftStore.lazyFetchNFTClassAggregatedMetadataById(id),
         ),
-        bookSettingsStore.fetchBatchSettings(plusReadingBookIds.value),
+        // Force-refresh: server-accumulated reading/TTS totals change outside
+        // the client, so skip-if-initialized would surface a stale cached 0.
+        bookSettingsStore.fetchBatchSettings(plusReadingBookIds.value, { force: true }),
       ])
     }
     catch (error) {


### PR DESCRIPTION
Borrowed Plus-reading books cached settings (with reading time 0) when opened in the reader, and the persisted skip-if-initialized fetch never refreshed them, so the bookshelf menu omitted the read/TTS time row. Force-refresh on shelf load, matching the owned-book path.