### PR TITLE
🚩 Remove plus-library flag and always enable library

### DIFF
--- a/app/components/AppTabBar.vue
+++ b/app/components/AppTabBar.vue
@@ -90,14 +90,11 @@ const getRouteBaseNameString = useRouteBaseNameString()
 const { getLabelGraphic } = useGraphicLabel()
 const { loggedIn: hasLoggedIn, user } = useUserSession()
 const { isApp } = useAppDetection()
-const isPlusLibraryEnabled = useFeatureFlagEnabled('plus-library')
 
 const menuItems = computed(() => {
   const routeName = getRouteBaseNameString()
-  const isLibraryEnabled = isPlusLibraryEnabled.value === true
   // In app, the library replaces the store as the primary browse tab.
-  // The store stays as a fallback while the library flag is off/unresolved.
-  const isStoreHidden = isApp.value && isLibraryEnabled
+  const isStoreHidden = isApp.value
   return [
     ...(isStoreHidden
       ? []
@@ -107,15 +104,12 @@ const menuItems = computed(() => {
           icon: 'i-material-symbols-storefront-outline',
           iconActive: 'i-material-symbols-storefront',
         }]),
-    // Plus-reading library; only shown once the feature flag resolves true.
-    ...(isLibraryEnabled
-      ? [{
-          key: 'library',
-          label: $t('tab_bar_library'),
-          icon: 'i-3ook-com-library-outline-rounded',
-          iconActive: 'i-3ook-com-library-rounded',
-        }]
-      : []),
+    {
+      key: 'library',
+      label: $t('tab_bar_library'),
+      icon: 'i-3ook-com-library-outline-rounded',
+      iconActive: 'i-3ook-com-library-rounded',
+    },
     {
       key: 'shelf',
       label: $t('tab_bar_shelf'),

--- a/app/components/PricingPlanBenefits.vue
+++ b/app/components/PricingPlanBenefits.vue
@@ -38,7 +38,7 @@
         <UIcon name="i-material-symbols-check" />
         <span v-text="feature" />
       </li>
-      <li v-if="isPlusLibraryEnabled">
+      <li>
         <UIcon name="i-material-symbols-check" />
         <span v-text="$t('pricing_page_feature_library')" />
       </li>
@@ -109,8 +109,6 @@ const props = withDefaults(defineProps<{
 const isYearlyPlan = computed(() => {
   return props.selectedPlan === 'yearly'
 })
-
-const isPlusLibraryEnabled = useFeatureFlagEnabled('plus-library')
 
 const { t: $t } = useI18n()
 const intercom = useIntercom()

--- a/app/pages/reader.vue
+++ b/app/pages/reader.vue
@@ -71,15 +71,8 @@ else {
     nftStore.lazyFetchNFTClassAggregatedMetadataById(nftClassId.value)
       .catch(error => console.warn('Failed to fetch NFT metadata:', error)),
   ])
-  // Only a non-owner Plus member on a Plus-reading book can borrow, so resolve
-  // the feature flag only then — owners and others never wait on it to open a
-  // book. Borrowing is gated behind a PostHog flag for staged internal testing;
-  // PostHog is client-only, so allow it through on the server and let the client
-  // re-evaluate and redirect if the flag is off.
-  let canBorrowWithPlus = false
-  if (!isOwner && isLikerPlus.value && bookInfo.isPlusReadingEnabled.value) {
-    canBorrowWithPlus = import.meta.server || await fetchFeatureFlagEnabled('plus-library')
-  }
+  // Only a non-owner Plus member on a Plus-reading book can borrow.
+  const canBorrowWithPlus = !isOwner && isLikerPlus.value && bookInfo.isPlusReadingEnabled.value
   if (!isOwner && !canBorrowWithPlus) {
     await navigateTo(localeRoute({ name: 'shelf', query: route.query }))
   }

--- a/app/pages/store/[nftClassId]/index.vue
+++ b/app/pages/store/[nftClassId]/index.vue
@@ -1056,12 +1056,7 @@ const bookInfo = useBookInfo({ nftClassId })
 const isLibrary = computed(() => getRouteBaseName(route) === 'library-nftClassId')
 const listingRouteName = computed(() => (isLibrary.value ? 'library' : 'store'))
 
-// Plus-reading is gated behind a PostHog flag for staged internal testing on
-// prod, combined with the per-book backend flag.
-const isPlusReadingFeatureEnabled = useFeatureFlagEnabled('plus-library')
-const isPlusReadingEnabled = computed(() =>
-  isPlusReadingFeatureEnabled.value && bookInfo.isPlusReadingEnabled.value,
-)
+const isPlusReadingEnabled = bookInfo.isPlusReadingEnabled
 
 // Non-owners of a Plus-reading book see a CTA: Plus members read it directly,
 // while guests/non-Plus users are routed to subscribe.
@@ -1576,21 +1571,8 @@ const { gridClasses, getGridItemClassesByIndex } = usePaginatedGrid({
 })
 
 onMounted(async () => {
-  const mightRedirect = isLibrary.value || (isApp.value && bookInfo.isPlusReadingEnabled.value)
-  const isPlusLibraryEnabled = mightRedirect && await fetchFeatureFlagEnabled('plus-library')
-
-  // The library is gated behind a feature flag
-  if (isLibrary.value && !isPlusLibraryEnabled) {
-    await navigateTo(localeRoute({
-      name: 'store-nftClassId',
-      params: { nftClassId: nftClassId.value },
-      query: route.query,
-    }), { replace: true })
-    return
-  }
-
   // The app hides the store, so send Plus-reading titles to the library.
-  if (!isLibrary.value && isPlusLibraryEnabled) {
+  if (!isLibrary.value && isApp.value && bookInfo.isPlusReadingEnabled.value) {
     await navigateTo(localeRoute({
       name: 'library-nftClassId',
       params: { nftClassId: nftClassId.value },

--- a/app/pages/store/index.vue
+++ b/app/pages/store/index.vue
@@ -273,7 +273,7 @@
           :lazy="index >= columnMax"
           :priority="index < columnMax"
           :ll-medium="llMedium"
-          :should-show-plus-reading-icon="isPlusReadingFeatureEnabled && !isLibraryTab"
+          :should-show-plus-reading-icon="!isLibraryTab"
           :is-library="isLibraryTab"
           ll-source="bookstore"
         />
@@ -308,7 +308,6 @@ const getRouteBaseNameString = useRouteBaseNameString()
 // /store and /library share this file; the route name selects the mode.
 const routeName = computed(() => getRouteBaseNameString() || 'store')
 const isLibraryTab = computed(() => routeName.value === 'library')
-const isPlusReadingFeatureEnabled = useFeatureFlagEnabled('plus-library')
 const getRouteQuery = useRouteQuery()
 const runtimeConfig = useRuntimeConfig()
 const bookstoreStore = useBookstoreStore()
@@ -1058,13 +1057,9 @@ async function fetchItems({ lazy = false, isRefresh = false } = {}): Promise<boo
 }
 
 onMounted(async () => {
-  // /store and /library share this page; PostHog is client-only, so evaluate
-  // the `plus-library` flag after mount before deciding which tab to show.
-  const mightRedirect = isLibraryTab.value || isApp.value
-  const isPlusLibraryEnabled = mightRedirect && await fetchFeatureFlagEnabled('plus-library')
-
-  // The app surfaces eligible users to /library and gates everyone else to /store.
-  const targetName = isPlusLibraryEnabled ? 'library' : 'store'
+  // /store and /library share this page. The app surfaces users to /library;
+  // web visitors stay on whichever tab they landed on.
+  const targetName = (isLibraryTab.value || isApp.value) ? 'library' : 'store'
   if (routeName.value !== targetName) {
     await navigateTo(localeRoute({ name: targetName, query: route.query }), { replace: true })
     return


### PR DESCRIPTION
The library and Plus-reading features have graduated from staged internal testing, so drop the PostHog gate and enable them for everyone. Removing the client-only flag also avoids a SDK round-trip on the book-open and store/library redirect paths.