### PR TITLE
🐛 Guard store products against transient undefined at mount

### DIFF
--- a/app/pages/store/index.vue
+++ b/app/pages/store/index.vue
@@ -745,11 +745,22 @@ const baseProducts = computed<BookstoreItemList>(() => {
   return cmsProducts.value
 })
 
+// Coalesce to an empty list: at the async-setup mount/hydration boundary the
+// upstream chain can briefly resolve undefined, which crashed the many reads
+// funnelling through products.value (.items, .nextItemsKey, …).
+const EMPTY_PRODUCTS: BookstoreItemList = {
+  items: [],
+  isFetchingItems: false,
+  hasFetchedItems: false,
+  nextItemsKey: undefined,
+}
+
 const products = computed<BookstoreItemList>(() => {
-  if (!isLibraryTab.value) return baseProducts.value
+  const base = baseProducts.value ?? EMPTY_PRODUCTS
+  if (!isLibraryTab.value) return base
   return {
-    ...baseProducts.value,
-    items: baseProducts.value.items.filter(getIsPlusReading),
+    ...base,
+    items: base.items.filter(getIsPlusReading),
   }
 })
 


### PR DESCRIPTION
The store/library page reads products.value across several computeds, the onMounted SWR check and the template. At the async-setup mount/hydration boundary the upstream chain could briefly resolve undefined, crashing reads like products.value.items / .nextItemsKey (Sentry: "Cannot read properties of undefined").

Coalesce the products computed to a shared empty list so the getter is total and every downstream read stays safe.