### PR TITLE
🐛 Guard PostHog featureFlags override against unready proxy

### DIFF
--- a/app/composables/use-pricing-page-campaign.ts
+++ b/app/composables/use-pricing-page-campaign.ts
@@ -123,7 +123,10 @@ export function usePricingPageCampaign(options: {
     const currentCampaignId = campaignId.value
     if (!currentCampaignId) return
     onLoaded(({ posthog }) => {
-      posthog.featureFlags.overrideFeatureFlags({
+      // onLoaded can fire before window.posthog is assigned (failed init or
+      // init race), where @nuxt/scripts' proxy yields a stub queue fn instead
+      // of the real featureFlags object — guard so the chain can't throw.
+      posthog.featureFlags?.overrideFeatureFlags?.({
         'pricing-page-campaign': currentCampaignId,
       })
     })


### PR DESCRIPTION
onLoaded can fire before window.posthog is assigned (failed init or init race), where @nuxt/scripts' npm-mode proxy yields a stub queue fn instead of the real featureFlags object. The chained overrideFeatureFlags call then threw "is not a function", auto-captured to Sentry via capture_console_errors. Optional-chain the access so it no-ops until the SDK is ready.