### PR TITLE
👔 Share Plus TTS revenue only for borrowed books

### DIFF
--- a/server/utils/api-user.ts
+++ b/server/utils/api-user.ts
@@ -356,17 +356,18 @@ export async function incrementBookReadingTime(
   const userDocRef = getUserCollection().doc(userWallet)
   const bookDocRef = userDocRef.collection('books').doc(nftClassId.toLowerCase())
 
-  // TTS share accrues for Plus listening on any book; reading share only for
-  // borrowed books. `plusBorrowedAt` is stamped server-side at borrow time, so
-  // we read it here rather than trust the client.
-  const plusTTSListeningTimeMs = isLikerPlus ? ttsActiveTimeMs : 0
+  // Both reading and TTS share accrue only for borrowed (Plus-library) books;
+  // owned reads/listens don't fund the pool. `plusBorrowedAt` is stamped
+  // server-side at borrow time, so we read it here rather than trust the client.
   let isBorrowed = false
   let plusReadingTimeMs = 0
-  if (isLikerPlus && activeReadingTimeMs > 0) {
+  let plusTTSListeningTimeMs = 0
+  if (isLikerPlus && (activeReadingTimeMs > 0 || ttsActiveTimeMs > 0)) {
     const bookDoc = await bookDocRef.get()
     isBorrowed = !!bookDoc.data()?.plusBorrowedAt
     if (isBorrowed) {
       plusReadingTimeMs = activeReadingTimeMs
+      plusTTSListeningTimeMs = ttsActiveTimeMs
     }
   }
 

--- a/server/utils/plus-revshare-client.ts
+++ b/server/utils/plus-revshare-client.ts
@@ -15,11 +15,12 @@ interface PlusReadingUsageInput {
  * bookkeeping; still awaited so it settles before the serverless handler returns.
  */
 export async function forwardPlusReadingUsage(input: PlusReadingUsageInput): Promise<void> {
-  // Reading counts only for borrowed books, TTS for any book — both only for paid
-  // (non-trial) Plus, since trial usage must never fund the pool.
+  // Reading and TTS both count only for borrowed (Plus-library) books, and only
+  // for paid (non-trial) Plus, since trial usage must never fund the pool.
   if (!input.isPaidPlus) return
-  const { ttsTimeMs, readerWallet, classId } = input
+  const { readerWallet, classId } = input
   const readingTimeMs = input.isBorrowed ? input.readingTimeMs : 0
+  const ttsTimeMs = input.isBorrowed ? input.ttsTimeMs : 0
   if (readingTimeMs <= 0 && ttsTimeMs <= 0) return
 
   const config = useRuntimeConfig()


### PR DESCRIPTION
TTS listening previously funded the reading-library rev-share pool for any owned Plus book; now it accrues only for borrowed (Plus-library) books, like reading time. The borrow lookup now also runs on TTS-only heartbeats so listening on a borrowed book isn't dropped when reading is paused.