### PR TITLE
🐛 Defer Plus embedded-checkout exposure to decision point

### DIFF
--- a/app/composables/use-ab-test.ts
+++ b/app/composables/use-ab-test.ts
@@ -3,15 +3,23 @@ import type { MaybeRefOrGetter } from 'vue'
 
 export interface ABTestConfig {
   experimentKey: MaybeRefOrGetter<string>
+  // When true, mounting the component records no exposure; the variant is read
+  // (and $feature_flag_called sent) only when captureExposure is called. Use for
+  // experiments whose treatment happens at a later decision point (e.g. checkout).
+  manualExposure?: boolean
 }
 
 export function useABTest(config: ABTestConfig) {
   const experimentKey = computed(() => toValue(config.experimentKey))
+  const manualExposure = config.manualExposure ?? false
   const variant = ref<string | null>(null)
+  let posthogInstance: PostHog | undefined
 
-  const updateVariant = (posthog: PostHog) => {
+  const readVariant = (posthog: PostHog): string | null => {
     const flag = posthog.getFeatureFlag(experimentKey.value)
-    variant.value = typeof flag === 'string' ? flag : null
+    const next = typeof flag === 'string' ? flag : null
+    if (variant.value !== next) variant.value = next
+    return next
   }
 
   let unsubscribe: (() => void) | undefined
@@ -19,11 +27,13 @@ export function useABTest(config: ABTestConfig) {
   onMounted(() => {
     const { onLoaded } = useScriptPostHog()
     onLoaded(({ posthog }) => {
-      unsubscribe = posthog.onFeatureFlags(() => {
-        updateVariant(posthog)
-      })
-      updateVariant(posthog)
-      stopWatch = watch(experimentKey, () => updateVariant(posthog))
+      posthogInstance = posthog
+      // Manual-exposure callers read the variant on demand via captureExposure,
+      // so skip the reactive subscription that would fire exposures on render.
+      if (manualExposure) return
+      unsubscribe = posthog.onFeatureFlags(() => readVariant(posthog))
+      readVariant(posthog)
+      stopWatch = watch(experimentKey, () => readVariant(posthog))
     })
   })
   onScopeDispose(() => {
@@ -35,8 +45,16 @@ export function useABTest(config: ABTestConfig) {
     return variant.value === variantName
   }
 
+  // Read the flag and record an exposure ($feature_flag_called) for the current
+  // key, returning the variant. Returns the last known variant if PostHog hasn't
+  // loaded yet; PostHog de-dupes the event per flag+value within a page load.
+  function captureExposure(): string | null {
+    return posthogInstance ? readVariant(posthogInstance) : variant.value
+  }
+
   return {
     variant: readonly(variant),
     isVariant,
+    captureExposure,
   }
 }

--- a/app/composables/use-subscription-checkout.ts
+++ b/app/composables/use-subscription-checkout.ts
@@ -26,7 +26,13 @@ export function useSubscriptionCheckout() {
   const { isApp } = useAppDetection()
   const { isIAPSupported, purchase: purchaseViaIAP } = useNativeIAP()
   const runtimeConfig = useRuntimeConfig()
-  const embeddedCheckoutABTest = useABTest({ experimentKey: 'plus-embedded-checkout' })
+  // Defer exposure to the checkout decision point (post-login) instead of mount,
+  // so only treatment-eligible users are counted and we avoid re-bucketing across
+  // the login boundary (the cause of the earlier sample-ratio mismatch).
+  const embeddedCheckoutABTest = useABTest({
+    experimentKey: 'plus-embedded-checkout',
+    manualExposure: true,
+  })
 
   const isProcessingSubscription = ref(false)
 
@@ -229,12 +235,17 @@ export function useSubscriptionCheckout() {
         await navigateTo(localeRoute({ name: 'plus-success', query: { period: plan } }))
       }
       else {
-        const canUseEmbeddedCheckout = (
+        // Only web Stripe users can receive the treatment — app users always get
+        // the hosted flow, so capture exposure here (not on mount) to keep the
+        // experiment population clean.
+        const isEmbeddedCheckoutEligible = (
           !isApp.value
-          && embeddedCheckoutABTest.isVariant('test')
           && !!runtimeConfig.public.stripePublishableKey
         )
-        const uiMode: CheckoutUIMode = canUseEmbeddedCheckout ? 'embedded' : 'hosted'
+        const embeddedVariant = isEmbeddedCheckoutEligible
+          ? embeddedCheckoutABTest.captureExposure()
+          : null
+        const uiMode: CheckoutUIMode = embeddedVariant === 'test' ? 'embedded' : 'hosted'
         const { url, clientSecret, paymentId } = await likeCoinSessionAPI.fetchLikerPlusCheckoutLink({
           period: plan,
           from: getRouteQuery('from'),


### PR DESCRIPTION
The plus-embedded-checkout experiment fired its exposure on component mount, before the forced login, so anonymous users got re-bucketed on identify (continuity off) — causing a significant sample-ratio mismatch and dual-bucketed users.

Add a manualExposure mode to useABTest that resolves the variant on demand via captureExposure instead of subscribing on mount. Checkout now records exposure only at the post-login decision point, and only for treatment-eligible (web Stripe) users.