### PR TITLE
🐛 Polyfill Array/String .at() for old iOS Safari

### DIFF
--- a/app/plugins/polyfill.ts
+++ b/app/plugins/polyfill.ts
@@ -4,6 +4,38 @@ if (!Object.hasOwn) {
   }
 }
 
+// Resolve a relative index per the `at` spec: truncate toward zero, NaN to 0,
+// negative counts from the end. Returns -1 when out of range.
+function resolveRelativeIndex(length: number, index: number): number {
+  const i = Math.trunc(Number(index)) || 0
+  const resolved = i < 0 ? length + i : i
+  return resolved >= 0 && resolved < length ? resolved : -1
+}
+
+if (!Array.prototype.at) {
+  Object.defineProperty(Array.prototype, 'at', {
+    value: function <T>(this: T[], index: number): T | undefined {
+      const i = resolveRelativeIndex(this.length, index)
+      return i < 0 ? undefined : this[i]
+    },
+    writable: true,
+    configurable: true,
+    enumerable: false,
+  })
+}
+
+if (!String.prototype.at) {
+  Object.defineProperty(String.prototype, 'at', {
+    value: function (this: string, index: number): string | undefined {
+      const i = resolveRelativeIndex(this.length, index)
+      return i < 0 ? undefined : this[i]
+    },
+    writable: true,
+    configurable: true,
+    enumerable: false,
+  })
+}
+
 if (!Promise.withResolvers) {
   Promise.withResolvers = function<T>() {
     let resolve!: (value: T | PromiseLike<T>) => void


### PR DESCRIPTION
iOS 15.3 (Safari <15.4) lacks Array/String.prototype.at, crashing /store with "e.split(Ud).at is not a function" from a bundled dep. Defined non-enumerable to match native semantics.