### PR TITLE
✨ Forward non-library engagement with idempotent retry

### DIFF
--- a/server/utils/plus-revshare-client.ts
+++ b/server/utils/plus-revshare-client.ts
@@ -1,3 +1,6 @@
+import { randomUUID } from 'node:crypto'
+import { API_MAX_RETRIES } from '~~/shared/utils/fetch-retry'
+
 interface PlusReadingUsageInput {
   isPaidPlus: boolean
   isBorrowed: boolean
@@ -8,20 +11,31 @@ interface PlusReadingUsageInput {
 }
 
 /**
- * Forwards paced Plus reading/TTS usage to the likecoin-api revenue-share ledger.
+ * Forwards paced reading/TTS usage to the likecoin-api reading-usage ledger.
  * The shared service secret (not the user JWT) is what proves the usage passed through
  * this backend's wall-clock pacing — the anti-fraud boundary the payout pipeline trusts.
- * Best-effort: errors are logged, never thrown, so it never blocks reading-session
- * bookkeeping; still awaited so it settles before the serverless handler returns.
+ * Splits each delta into the rev-share-eligible slice (paid Plus + borrowed) that funds
+ * the payout pool and the non-library remainder (owned/non-Plus reads) that the API
+ * records for publisher engagement stats only. Best-effort: errors are logged, never
+ * thrown, so it never blocks reading-session bookkeeping; still awaited so it settles
+ * before the serverless handler returns.
+ *
+ * Each call carries a unique `id` so the API can dedup retries: the ledger increments are
+ * non-idempotent, but ofetch resends the same body (same id) on a transient `<no response>`,
+ * and the API skips an already-seen id. That's what makes enabling retry here safe — it must
+ * stay paired with the API-side dedup (deploy the API before this).
  */
 export async function forwardPlusReadingUsage(input: PlusReadingUsageInput): Promise<void> {
-  // Reading and TTS both count only for borrowed (Plus-library) books, and only
-  // for paid (non-trial) Plus, since trial usage must never fund the pool.
-  if (!input.isPaidPlus) return
   const { readerWallet, classId } = input
-  const readingTimeMs = input.isBorrowed ? input.readingTimeMs : 0
-  const ttsTimeMs = input.isBorrowed ? input.ttsTimeMs : 0
-  if (readingTimeMs <= 0 && ttsTimeMs <= 0) return
+  // Rev-share funds only borrowed (Plus-library) reads by paid (non-trial) Plus; the
+  // rest is non-library engagement, reported to publishers but never funding the pool.
+  const revShareEligible = input.isPaidPlus && input.isBorrowed
+  const readingTimeMs = revShareEligible ? input.readingTimeMs : 0
+  const ttsTimeMs = revShareEligible ? input.ttsTimeMs : 0
+  const nonLibraryReadingTimeMs = input.readingTimeMs - readingTimeMs
+  const nonLibraryTtsTimeMs = input.ttsTimeMs - ttsTimeMs
+  if (readingTimeMs <= 0 && ttsTimeMs <= 0
+    && nonLibraryReadingTimeMs <= 0 && nonLibraryTtsTimeMs <= 0) return
 
   const config = useRuntimeConfig()
   const token = config.plusReadingServiceToken
@@ -31,7 +45,20 @@ export async function forwardPlusReadingUsage(input: PlusReadingUsageInput): Pro
     await getLikeCoinAPIFetch()('/plus/reading/usage', {
       method: 'POST',
       headers: { Authorization: `Bearer ${token}` },
-      body: { readerWallet, classId, readingTimeMs, ttsTimeMs },
+      body: {
+        // Generated once per call; reused across retries so duplicates dedup server-side.
+        id: randomUUID(),
+        readerWallet,
+        classId,
+        readingTimeMs,
+        ttsTimeMs,
+        nonLibraryReadingTimeMs,
+        nonLibraryTtsTimeMs,
+      },
+      // Opt this POST into retry (the wrapper leaves payload methods at 0 by default);
+      // safe now that the API dedups on `id`. Must equal API_MAX_RETRIES — the backoff
+      // curve assumes a retry budget starting there.
+      retry: API_MAX_RETRIES,
       timeout: 2000, // bound heartbeat/session latency on a hung upstream; failures are swallowed below
     })
   }

--- a/server/utils/reading-usage-client.ts
+++ b/server/utils/reading-usage-client.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto'
 import { API_MAX_RETRIES } from '~~/shared/utils/fetch-retry'
 
-interface PlusReadingUsageInput {
+interface ReadingUsageInput {
   isPaidPlus: boolean
   isBorrowed: boolean
   readerWallet: string
@@ -25,15 +25,15 @@ interface PlusReadingUsageInput {
  * and the API skips an already-seen id. That's what makes enabling retry here safe — it must
  * stay paired with the API-side dedup (deploy the API before this).
  */
-export async function forwardPlusReadingUsage(input: PlusReadingUsageInput): Promise<void> {
+export async function forwardReadingUsage(input: ReadingUsageInput): Promise<void> {
   const { readerWallet, classId } = input
   // Rev-share funds only borrowed (Plus-library) reads by paid (non-trial) Plus; the
   // rest is non-library engagement, reported to publishers but never funding the pool.
-  const revShareEligible = input.isPaidPlus && input.isBorrowed
-  const readingTimeMs = revShareEligible ? input.readingTimeMs : 0
-  const ttsTimeMs = revShareEligible ? input.ttsTimeMs : 0
-  const nonLibraryReadingTimeMs = input.readingTimeMs - readingTimeMs
-  const nonLibraryTtsTimeMs = input.ttsTimeMs - ttsTimeMs
+  const isRevShareEligible = input.isPaidPlus && input.isBorrowed
+  const readingTimeMs = isRevShareEligible ? input.readingTimeMs : 0
+  const ttsTimeMs = isRevShareEligible ? input.ttsTimeMs : 0
+  const nonLibraryReadingTimeMs = isRevShareEligible ? 0 : input.readingTimeMs
+  const nonLibraryTtsTimeMs = isRevShareEligible ? 0 : input.ttsTimeMs
   if (readingTimeMs <= 0 && ttsTimeMs <= 0
     && nonLibraryReadingTimeMs <= 0 && nonLibraryTtsTimeMs <= 0) return
 
@@ -59,10 +59,10 @@ export async function forwardPlusReadingUsage(input: PlusReadingUsageInput): Pro
       // safe now that the API dedups on `id`. Must equal API_MAX_RETRIES — the backoff
       // curve assumes a retry budget starting there.
       retry: API_MAX_RETRIES,
-      timeout: 2000, // bound heartbeat/session latency on a hung upstream; failures are swallowed below
+      timeout: 2000, // per-attempt cap on a hung upstream; total may exceed it across retries (failures swallowed below)
     })
   }
   catch (error) {
-    console.warn('[PlusRevShare] Failed to forward reading usage:', error)
+    console.warn('[ReadingUsage] Failed to forward reading usage:', error)
   }
 }

--- a/server/utils/reading-usage.ts
+++ b/server/utils/reading-usage.ts
@@ -80,9 +80,10 @@ export async function recordPacedReadingUsage(input: RecordPacedReadingUsageInpu
     console.warn('[ReadingUsage] Failed to publish event:', err)
   }
 
-  // No-ops internally when the paced delta is zero or the user isn't paid Plus.
-  // Awaited so it settles before the serverless handler returns.
-  await forwardPlusReadingUsage({
+  // No-ops internally only when every paced delta is zero; otherwise forwards
+  // rev-share-eligible and non-library engagement separately. Awaited so it
+  // settles before the serverless handler returns.
+  await forwardReadingUsage({
     isPaidPlus,
     isBorrowed,
     readerWallet: wallet,


### PR DESCRIPTION
forwardPlusReadingUsage now forwards owned / non-Plus reads (split out as nonLibrary* fields) for publisher engagement stats, not just rev-share-eligible library reads. Each call carries a unique id and enables retry — safe now that the API dedups on it.

Deploy AFTER the likecoin-api change that adds the id dedup; otherwise a retried <no response> against the old API would double-count.

Requires: https://github.com/likecoin/likecoin-api-public/pull/1326