### PR TITLE
🐛 Fix reader search focus crash on exposed inputRef

### DIFF
--- a/app/components/ReaderSearch.vue
+++ b/app/components/ReaderSearch.vue
@@ -160,8 +160,9 @@ const results = ref<ReaderSearchResult[]>([])
 const isSearching = ref(false)
 const hasSearched = ref(false)
 
-const mobileInput = useTemplateRef<{ inputRef?: Ref<HTMLInputElement | null> } | null>('mobileInput')
-const desktopInput = useTemplateRef<{ inputRef?: Ref<HTMLInputElement | null> } | null>('desktopInput')
+type InputExpose = { inputRef?: HTMLInputElement | null } | null
+const mobileInput = useTemplateRef<InputExpose>('mobileInput')
+const desktopInput = useTemplateRef<InputExpose>('desktopInput')
 const mobileFocusKeeper = useTemplateRef<HTMLInputElement | null>('mobileFocusKeeper')
 
 function handleMobileTriggerClick() {
@@ -237,7 +238,7 @@ function handleSelect(result: ReaderSearchResult) {
 function focusInput() {
   nextTick(() => {
     const input = isDesktop.value ? desktopInput.value : mobileInput.value
-    input?.inputRef?.value?.focus()
+    input?.inputRef?.focus()
   })
 }
 


### PR DESCRIPTION
Nuxt UI's UInput exposes inputRef already unwrapped by defineExpose, so the extra .value read the input's string content and threw "focus is not a function" once the field had text. Drop the .value and correct the template-ref type to match the unwrapped element.