### PR TITLE
📈 Track library views and engagement distinctly from store

### DIFF
--- a/app/components/BookstoreItem.vue
+++ b/app/components/BookstoreItem.vue
@@ -199,14 +199,23 @@ function fetchBookInfo() {
 }
 
 function onBookCoverClick() {
-  useLogEvent('select_item', {
-    items: [{
-      item_id: props.nftClassId,
-      item_name: bookName.value,
-      price: price.value,
-      quantity: 1,
-    }],
-  })
+  // In the library the book is already owned, so opening it to read isn't an
+  // ecommerce action — keep the GA4 `select_item` for the store path only.
+  if (props.isLibrary) {
+    useLogEvent('library_book_click', {
+      nft_class_id: props.nftClassId,
+    })
+  }
+  else {
+    useLogEvent('select_item', {
+      items: [{
+        item_id: props.nftClassId,
+        item_name: bookName.value,
+        price: price.value,
+        quantity: 1,
+      }],
+    })
+  }
   emit('open', props.nftClassId)
 }
 </script>

--- a/app/pages/store/index.vue
+++ b/app/pages/store/index.vue
@@ -1104,10 +1104,15 @@ onMounted(async () => {
   // /store and /library share this page. The app surfaces users to /library;
   // web visitors stay on whichever tab they landed on.
   const targetName = (isLibraryTab.value || isApp.value) ? 'library' : 'store'
+  const viewEvent = targetName === 'library' ? 'library_view' : 'store_view'
   if (routeName.value !== targetName) {
+    // Log before redirecting: this shared page component won't re-run onMounted
+    // after navigateTo, so app users sent /store -> /library would never log.
+    useLogEvent(viewEvent)
     await navigateTo(localeRoute({ name: targetName, query: route.query }), { replace: true })
     return
   }
+  useLogEvent(viewEvent)
 
   if (!route.query.tag && !isSearchMode.value) {
     await storePageState.restoreIfNeeded()
@@ -1210,12 +1215,12 @@ async function handleTagClick(tagValue?: string) {
   if (isLibraryTab.value) dismissLibraryIntroBanner()
 
   if (tagValue === 'local-histories') {
-    useLogEvent('store_tag_click', { tag_id: tagValue })
+    useLogEvent(isLibraryTab.value ? 'library_tag_click' : 'store_tag_click', { tag_id: tagValue })
     await navigateTo(localeRoute({ name: 'local-histories' }))
     return
   }
 
-  useLogEvent('store_tag_click', { tag_id: tagValue })
+  useLogEvent(isLibraryTab.value ? 'library_tag_click' : 'store_tag_click', { tag_id: tagValue })
   tagId.value = tagValue
 }
 
@@ -1247,17 +1252,17 @@ const isSearchInputOpen = ref(false)
 const searchInputValue = ref('')
 
 function handleSearchTagClick() {
-  useLogEvent('store_tag_search_click')
+  useLogEvent(isLibraryTab.value ? 'library_tag_search_click' : 'store_tag_search_click')
   searchInputValue.value = ''
 }
 
 function handleClearSearchInputButton() {
-  useLogEvent('store_search_input_clear_button_click')
+  useLogEvent(isLibraryTab.value ? 'library_search_input_clear_button_click' : 'store_search_input_clear_button_click')
   searchInputValue.value = ''
 }
 
 function handleContactUsClick() {
-  useLogEvent('store_no_search_results_contact_click', { search_term: querySearchTerm.value })
+  useLogEvent(isLibraryTab.value ? 'library_no_search_results_contact_click' : 'store_no_search_results_contact_click', { search_term: querySearchTerm.value })
   const searchTerm = querySearchTerm.value || queryAuthorName.value || queryPublisherName.value || queryOwnerWallet.value
   intercom.showNewMessage($t('store_no_search_results_contact_prefill', { term: searchTerm }))
 }
@@ -1270,7 +1275,7 @@ async function handleSearchSubmit() {
   if (checkIsEVMAddress(searchInputValue.value)) {
     query = 'owner_wallet'
   }
-  useLogEvent('store_search_submit')
+  useLogEvent(isLibraryTab.value ? 'library_search_submit' : 'store_search_submit')
   await navigateTo({ query: { [query]: searchInputValue.value } })
 }
 </script>


### PR DESCRIPTION
The library tab reused store event names, so its views, tag clicks, searches, and book opens were indistinguishable from the store in PostHog. Branch these into library_* events. The view event is logged before the /store -> /library redirect since the shared page component won't re-run onMounted afterwards, and library book opens use a dedicated event rather than the GA4 ecommerce select_item.