### PR TITLE
✨ Point native users to the full catalogue at end of list

### DIFF
--- a/app/pages/store/index.vue
+++ b/app/pages/store/index.vue
@@ -309,6 +309,13 @@
           size="48"
         />
       </div>
+
+      <!-- In-app browse hides the store, so point native users to the full catalogue as plain text. -->
+      <p
+        v-if="isApp && !isSearchMode && itemsCount > 0 && !hasMoreItems"
+        class="w-full text-center text-sm text-muted py-8"
+        v-text="$t('store_list_end_more_books_text')"
+      />
     </main>
   </div>
 </template>

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -867,6 +867,7 @@
   "store_fetch_more_items_error": "Unable to load more books",
   "store_fetch_tags_error": "Unable to load tags",
   "store_genre_prefix": "Genre: ",
+  "store_list_end_more_books_text": "Discover more books at 3ook.com",
   "store_no_items": "No books",
   "store_no_items_learn_more": "Learn more about 3ook.com",
   "store_no_search_results": "No results found",

--- a/i18n/locales/zh-Hant.json
+++ b/i18n/locales/zh-Hant.json
@@ -867,6 +867,7 @@
   "store_fetch_more_items_error": "無法載入更多書本",
   "store_fetch_tags_error": "無法載入分類",
   "store_genre_prefix": "分類：",
+  "store_list_end_more_books_text": "前往 3ook.com 探索更多書籍",
   "store_no_items": "沒有書本",
   "store_no_items_learn_more": "了解更多關於 3ook.com",
   "store_no_search_results": "沒有找到結果",


### PR DESCRIPTION

<img width="342" height="686" alt="image" src="https://github.com/user-attachments/assets/b42716b6-93b1-4abc-b788-2236b3549239" />

The store tab is hidden in-app, so add a plain-text 3ook.com mention at the end of the loaded list. Kept as text, not a link, to stay clear of App Store guideline 3.1.1.