### PR TITLE
✨ Add new featured publishers to the about page

### DIFF
--- a/app/pages/about.vue
+++ b/app/pages/about.vue
@@ -976,6 +976,12 @@ const featuredPublishers = [
   { name: '集誌社', likerId: 'thecollectivehk' },
   { name: 'Kubrick', likerId: 'kubrick_hk' },
   { name: 'dirty press', likerId: 'kcyguj' },
+  { name: '重版文化', likerId: 'ndpeks' },
+  { name: '科學月刊', likerId: 'scimonth' },
+  { name: '啓明出版', likerId: 'bsymfp' },
+  { name: '大銀', likerId: 'jseees' },
+  { name: 'Penana Limited', likerId: 'dxrvrk' },
+  { name: '崧博出版', likerId: 'zsnzbv' },
 ]
 
 function getAvatarSrc(likerId: string) {


### PR DESCRIPTION
Add 重版文化, 科學月刊, 啓明出版, 大銀 and Penana Limited (routed by owner wallet) plus the 崧博出版 imprints 崧燁文化, 財經錢線, 沐燁文化 and 樂律文化. The imprints share one wallet, so they route by publisher tag to keep each tile on its own books. Resolve avatars by wallet for the wallet-based entries.