### PR TITLE
[TAS-5084] ✨ Add footnote return button to EPUB reader

### DIFF
--- a/app/pages/reader/epub.vue
+++ b/app/pages/reader/epub.vue
@@ -321,10 +321,11 @@
         <Transition name="reader-load">
           <UButton
             v-if="footnoteReturnCfi && !isReaderLoading"
-            class="absolute bottom-6 left-1/2 -translate-x-1/2 shadow-lg z-10"
+            class="absolute bottom-4.5 left-1/2 -translate-x-1/2 shadow-lg z-10"
             icon="i-material-symbols-u-turn-left-rounded"
             color="neutral"
             variant="solid"
+            size="sm"
             :label="$t('reader_footnote_return_button')"
             @click="handleFootnoteReturn"
           />
@@ -658,6 +659,10 @@ const currentPageHref = ref<string>('')
 const footnoteReturnCfi = ref<string>('')
 // Captured at link-click, confirmed once `relocated` lands on a different page.
 let pendingFootnoteReturnCfi: string | null = null
+function dismissFootnoteReturn() {
+  footnoteReturnCfi.value = ''
+  pendingFootnoteReturnCfi = null
+}
 const currentCfi = useSyncedBookSettings({
   nftClassId: nftClassId.value,
   key: 'cfi',
@@ -993,7 +998,14 @@ async function loadEPub() {
         if (element.tagName === 'A') {
           const href = element.getAttribute('href') || ''
           if (href && !isExternalLink(href)) {
-            pendingFootnoteReturnCfi = currentPageStartCfi.value || currentCfi.value
+            // A further in-book jump while a return is pending/active means the
+            // user is navigating onward — dismiss rather than chain origins.
+            if (footnoteReturnCfi.value || pendingFootnoteReturnCfi) {
+              dismissFootnoteReturn()
+            }
+            else {
+              pendingFootnoteReturnCfi = currentPageStartCfi.value || currentCfi.value || null
+            }
           }
           return
         }
@@ -1404,6 +1416,8 @@ async function setActiveNavItem(item: NavItem, { isSilentError = false } = {}) {
   activeTTSElementIndex.value = undefined
   activeNavItemHref.value = item.href
   isPageLoading.value = true
+  // Explicit TOC navigation isn't a footnote jump; drop any pending return.
+  dismissFootnoteReturn()
 
   let hasDisplayed = await displayRendition(item.href, { isSilentError: true })
   if (hasDisplayed) return
@@ -1700,10 +1714,10 @@ function handleMobileTTSClick() {
 }
 async function handleFootnoteReturn() {
   const target = footnoteReturnCfi.value
-  if (!target) return
+  if (!target || !rendition.value) return
   isPageLoading.value = true
   try {
-    await rendition.value?.display(target)
+    await rendition.value.display(target)
     // Keep the button on failure so the user can retry; clear only on success.
     footnoteReturnCfi.value = ''
   }

--- a/app/pages/reader/epub.vue
+++ b/app/pages/reader/epub.vue
@@ -317,6 +317,18 @@
           class="absolute bottom-6 right-12 text-xs text-muted"
           v-text="percentageLabel"
         />
+
+        <Transition name="reader-load">
+          <UButton
+            v-if="footnoteReturnCfi && !isReaderLoading"
+            class="absolute bottom-6 left-1/2 -translate-x-1/2 shadow-lg z-10"
+            icon="i-material-symbols-u-turn-left-rounded"
+            color="neutral"
+            variant="solid"
+            :label="$t('reader_footnote_return_button')"
+            @click="handleFootnoteReturn"
+          />
+        </Transition>
       </div>
     </div>
 
@@ -642,6 +654,10 @@ const isAtFirstPage = computed(() => {
 const currentPageStartCfi = ref<string>('')
 const currentPageEndCfi = ref<string>('')
 const currentPageHref = ref<string>('')
+// Origin page to return to after a footnote jump; '' hides the return button.
+const footnoteReturnCfi = ref<string>('')
+// Captured at link-click, confirmed once `relocated` lands on a different page.
+let pendingFootnoteReturnCfi: string | null = null
 const currentCfi = useSyncedBookSettings({
   nftClassId: nftClassId.value,
   key: 'cfi',
@@ -972,8 +988,13 @@ async function loadEPub() {
     }
     cleanUpClickListener = useEventListener(view.window, 'click', (event) => {
       for (const element of event.composedPath() as HTMLElement[]) {
-        // NOTE: Ignore clicks on links
+        // NOTE: Ignore clicks on links, but record the current page first so a
+        // footnote/in-book jump can offer a way back (confirmed in `relocated`).
         if (element.tagName === 'A') {
+          const href = element.getAttribute('href') || ''
+          if (href && !isExternalLink(href)) {
+            pendingFootnoteReturnCfi = currentPageStartCfi.value || currentCfi.value
+          }
           return
         }
       }
@@ -1115,6 +1136,17 @@ async function loadEPub() {
     const href = location.start.href
     currentPageHref.value = href
     activeNavItemHref.value = resolveActiveNavItemHref(href)
+    // Footnote return: a just-clicked in-book link drove this relocation; offer
+    // a way back only if we actually landed on a different page. Otherwise drop
+    // the button once the user is back on the origin page by any other means.
+    if (pendingFootnoteReturnCfi) {
+      const origin = pendingFootnoteReturnCfi
+      pendingFootnoteReturnCfi = null
+      footnoteReturnCfi.value = origin && !isSegmentOnCurrentPage(origin) ? origin : ''
+    }
+    else if (footnoteReturnCfi.value && isSegmentOnCurrentPage(footnoteReturnCfi.value)) {
+      footnoteReturnCfi.value = ''
+    }
     // During listen mode `onSegmentChange` owns progress: it writes the
     // segment-accurate position, while `relocated` only sees the page start
     // (and stale data while the modal covers the reader on native).
@@ -1160,6 +1192,13 @@ function openTTSTryModal() {
     onDismiss: () => setTTSQueryParam(false),
   })
 }
+// Absolute (scheme or protocol-relative) links open externally; everything else
+// is an in-book link that epub.js navigates via display().
+const EXTERNAL_LINK_RE = /^(?:[a-z][a-z0-9+.-]*:|\/\/)/i
+function isExternalLink(href: string): boolean {
+  return EXTERNAL_LINK_RE.test(href)
+}
+
 function getHrefBasePath(href: string): string {
   return href.split('#')[0] ?? href
 }
@@ -1659,6 +1698,30 @@ function handleMobileTTSClick() {
   }
   onClickTTSPlay()
 }
+async function handleFootnoteReturn() {
+  const target = footnoteReturnCfi.value
+  if (!target) return
+  isPageLoading.value = true
+  try {
+    await rendition.value?.display(target)
+    // Keep the button on failure so the user can retry; clear only on success.
+    footnoteReturnCfi.value = ''
+  }
+  catch (error) {
+    console.error('Failed to return from footnote:', error)
+    toast.add({
+      title: $t('reader_epub_rendition_display_failed'),
+      color: 'error',
+      duration: 3000,
+      progress: false,
+    })
+  }
+  finally {
+    isPageLoading.value = false
+  }
+  useLogEvent('reader_footnote_return', { nft_class_id: nftClassId.value })
+}
+
 function handleLeftArrowButtonClick() {
   turnPageLeft()
   useLogEvent('reader_navigate_button_arrow')

--- a/app/pages/reader/epub.vue
+++ b/app/pages/reader/epub.vue
@@ -326,6 +326,7 @@
             color="neutral"
             variant="solid"
             size="sm"
+            :disabled="isPageLoading"
             :label="$t('reader_footnote_return_button')"
             @click="handleFootnoteReturn"
           />
@@ -1715,6 +1716,7 @@ function handleMobileTTSClick() {
 async function handleFootnoteReturn() {
   const target = footnoteReturnCfi.value
   if (!target || !rendition.value) return
+  if (isPageLoading.value) return
   isPageLoading.value = true
   try {
     await rendition.value.display(target)

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -767,6 +767,7 @@
   "reader_display_orientation_vertical": "Vertical",
   "reader_display_restore_defaults_button": "Restore Defaults",
   "reader_epub_rendition_display_failed": "The page cannot be displayed.",
+  "reader_footnote_return_button": "Return to reading",
   "reader_menu_button": "Reader Menu",
   "reader_page_input_label": "Page number",
   "reader_page_mode_dual": "Two-page view",

--- a/i18n/locales/zh-Hant.json
+++ b/i18n/locales/zh-Hant.json
@@ -767,6 +767,7 @@
   "reader_display_orientation_vertical": "直排",
   "reader_display_restore_defaults_button": "恢復預設",
   "reader_epub_rendition_display_failed": "無法顯示該頁。",
+  "reader_footnote_return_button": "返回閱讀內容",
   "reader_menu_button": "閱讀器選單",
   "reader_page_input_label": "頁碼",
   "reader_page_mode_dual": "雙頁顯示",


### PR DESCRIPTION
Tapping a footnote link does a one-way epub.js jump with no history, so readers had no way back to where they were. Capture the origin page on in-book link clicks and surface a floating "Return to reading" button that jumps back; it auto-dismisses once the reader is back at the origin.