### PR TITLE
🐛 Strip inter-character spaces from CJK PDF text for TTS

### DIFF
--- a/app/pages/reader/pdf.vue
+++ b/app/pages/reader/pdf.vue
@@ -214,11 +214,12 @@ async function extractTTSSegmentsFromPDF(pdfDocument: PDFDocumentProxy) {
           return yPosition < headerThreshold && yPosition > footerThreshold
         })
 
-      const pageText = mainContentItems
-        .filter((item: (TextItem | TextMarkedContent)) => 'str' in item)
-        .map((item: TextItem) => item.str)
-        .join(' ')
-        .trim()
+      const pageText = removeRedundantCJKSpaces(
+        mainContentItems
+          .filter((item: (TextItem | TextMarkedContent)) => 'str' in item)
+          .map((item: TextItem) => item.str)
+          .join(' '),
+      ).trim()
 
       if (pageText) {
         pagesWithText++

--- a/app/utils/tts.ts
+++ b/app/utils/tts.ts
@@ -7,9 +7,15 @@
 // so they are untouched.
 const FULLWIDTH_PUNCT_KEEP = new Set(['！', '，', '：', '；', '？'])
 
+// PDF extraction emits CJK radical look-alikes (U+2E80-U+2EFF, U+2F00-U+2FDF)
+// that look like ideographs but the TTS model can't pronounce. Fold per-character
+// via NFKC; a whole-string NFKC would also flatten the fullwidth punctuation below.
+const CJK_RADICAL_REGEX = /[\u2E80-\u2EFF\u2F00-\u2FDF]/g
+
 export function sanitizeTTSText(text: string): string {
   if (!text) return ''
   return text
+    .replace(CJK_RADICAL_REGEX, c => c.normalize('NFKC'))
     .replace(/[\uFF01-\uFF5E]/g, c =>
       FULLWIDTH_PUNCT_KEEP.has(c) ? c : String.fromCharCode(c.charCodeAt(0) - 0xFEE0))
     .replace(/^\s*-{2,}\s*$/gm, '')

--- a/app/utils/tts.ts
+++ b/app/utils/tts.ts
@@ -27,6 +27,20 @@ export function isSpeakableText(text: string): boolean {
   return SPEAKABLE_REGEX.test(sanitizeTTSText(text))
 }
 
+// PDF text extraction emits each glyph as its own item, so joining items with a
+// space injects a space between every CJK character (此 時 校 內). CJK scripts
+// don't use inter-character spaces, and the gaps confuse the TTS model, so
+// collapse whitespace sitting between two CJK characters. Latin text (where the
+// joining space separates real words) is left untouched. Tabs and ideographic
+// spaces (U+3000) can leak in from glyph items too, so the separator covers them.
+const CJK_CHAR = '\\u2E80-\\u2EFF\\u2F00-\\u2FDF\\u3000-\\u303F\\u3040-\\u30FF\\u3100-\\u312F\\u3400-\\u4DBF\\u4E00-\\u9FFF\\uF900-\\uFAFF\\uFF00-\\uFFEF'
+const CJK_SPACE_REGEX = new RegExp(`([${CJK_CHAR}])[ \\t\\u3000]+(?=[${CJK_CHAR}])`, 'g')
+
+export function removeRedundantCJKSpaces(text: string): string {
+  if (!text) return ''
+  return text.replace(CJK_SPACE_REGEX, '$1')
+}
+
 const CLOSING_PUNCT = '[」』】》）)\u2019\u201D]'
 const SENTENCE_REGEX = new RegExp(`([.!?。！？…⋯︙]${CLOSING_PUNCT}*[\\s\\u200B]*)`)
 const CLAUSE_REGEX = new RegExp(`([;:,，；：、—─―︱⸺]${CLOSING_PUNCT}*[\\s\\u200B]*)`)

--- a/app/utils/tts.ts
+++ b/app/utils/tts.ts
@@ -33,13 +33,10 @@ export function isSpeakableText(text: string): boolean {
   return SPEAKABLE_REGEX.test(sanitizeTTSText(text))
 }
 
-// PDF text extraction emits each glyph as its own item, so joining items with a
-// space injects a space between every CJK character (此 時 校 內). CJK scripts
-// don't use inter-character spaces, and the gaps confuse the TTS model, so
-// collapse whitespace sitting between two CJK characters. Latin text (where the
-// joining space separates real words) is left untouched. Tabs and ideographic
-// spaces (U+3000) can leak in from glyph items too, so the separator covers them.
-const CJK_CHAR = '\\u2E80-\\u2EFF\\u2F00-\\u2FDF\\u3000-\\u303F\\u3040-\\u30FF\\u3100-\\u312F\\u3400-\\u4DBF\\u4E00-\\u9FFF\\uF900-\\uFAFF\\uFF00-\\uFFEF'
+// PDF glyph-per-item extraction injects a space between every CJK character
+// (此 時 校 內); collapse space/tab/U+3000 between two CJK chars. Fullwidth
+// alphanumerics are excluded so real word gaps (like ASCII Latin) survive.
+const CJK_CHAR = '\\u2E80-\\u2EFF\\u2F00-\\u2FDF\\u3000-\\u303F\\u3040-\\u30FF\\u3100-\\u312F\\u3400-\\u4DBF\\u4E00-\\u9FFF\\uF900-\\uFAFF\\uFF01-\\uFF0F\\uFF1A-\\uFF20\\uFF3B-\\uFF40\\uFF5B-\\uFFEF'
 const CJK_SPACE_REGEX = new RegExp(`([${CJK_CHAR}])[ \\t\\u3000]+(?=[${CJK_CHAR}])`, 'g')
 
 export function removeRedundantCJKSpaces(text: string): string {

--- a/test/unit/tts.test.ts
+++ b/test/unit/tts.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   sanitizeTTSText,
+  removeRedundantCJKSpaces,
   isSpeakableText,
   splitTextIntoSegments,
   mergeShortTTSSegments,
@@ -89,6 +90,42 @@ describe('sanitizeTTSText', () => {
     const input = '﹁好＊﹂\n---\n好⋯⋯好—壞'
     const result = sanitizeTTSText(input)
     expect(result).toBe('「好」\n\n好。好，壞')
+  })
+})
+
+describe('removeRedundantCJKSpaces', () => {
+  it('returns empty string for falsy input', () => {
+    expect(removeRedundantCJKSpaces('')).toBe('')
+  })
+
+  it('collapses spaces between CJK characters', () => {
+    expect(removeRedundantCJKSpaces('此 時 校 內')).toBe('此時校內')
+  })
+
+  it('collapses spaces around CJK punctuation', () => {
+    expect(removeRedundantCJKSpaces('校 園 閒 逛 ， 慢慢 回 想')).toBe('校園閒逛，慢慢回想')
+  })
+
+  // Kangxi radicals (U+2F00–U+2FDF) appear in place of normal glyphs in some PDFs
+  it('handles Kangxi radical characters', () => {
+    expect(removeRedundantCJKSpaces('享 ⽤ 午 餐')).toBe('享⽤午餐')
+  })
+
+  it('collapses tabs and ideographic spaces between CJK characters', () => {
+    expect(removeRedundantCJKSpaces('此\t時　校')).toBe('此時校')
+  })
+
+  it('keeps spaces inside Latin text', () => {
+    expect(removeRedundantCJKSpaces('hello world')).toBe('hello world')
+  })
+
+  it('keeps spaces between CJK and Latin tokens', () => {
+    expect(removeRedundantCJKSpaces('第 3 章')).toBe('第 3 章')
+  })
+
+  it('handles a full extracted PDF line', () => {
+    const input = '此 時 校 內 最 熱 鬧 的 地 ⽅ 就 是 ⼩ 賣 部。少 年 在 享 ⽤ 午 餐 後 於 校 園 閒 逛 ， 慢慢 回 想 起 ⾃ ⼰ ⼊ 讀 這 所 學 校 的 原 因。'
+    expect(removeRedundantCJKSpaces(input)).toBe('此時校內最熱鬧的地⽅就是⼩賣部。少年在享⽤午餐後於校園閒逛，慢慢回想起⾃⼰⼊讀這所學校的原因。')
   })
 })
 

--- a/test/unit/tts.test.ts
+++ b/test/unit/tts.test.ts
@@ -36,6 +36,15 @@ describe('sanitizeTTSText', () => {
     expect(sanitizeTTSText('好，壞；對：錯！嗎？')).toBe('好，壞；對：錯！嗎？')
   })
 
+  // Regression: PDF extraction emits Kangxi/CJK radical look-alikes (⽅ U+2F45,
+  // ⼩ U+2F29) that Minimax cannot pronounce; NFKC folds them to ideographs.
+  it('normalizes CJK radical look-alikes to ideographs', () => {
+    expect(sanitizeTTSText('地⽅')).toBe('地方')
+    expect(sanitizeTTSText('⼩賣部')).toBe('小賣部')
+    expect(sanitizeTTSText('此時校內最熱鬧的地⽅就是⼩賣部，慢慢回想。'))
+      .toBe('此時校內最熱鬧的地方就是小賣部，慢慢回想。')
+  })
+
   it('normalizes fullwidth alphanumerics adjacent to kept punctuation', () => {
     expect(sanitizeTTSText('Ａ，Ｂ；１２３')).toBe('A，B；123')
   })

--- a/test/unit/tts.test.ts
+++ b/test/unit/tts.test.ts
@@ -128,8 +128,14 @@ describe('removeRedundantCJKSpaces', () => {
     expect(removeRedundantCJKSpaces('hello world')).toBe('hello world')
   })
 
+  // Fullwidth Latin is in the CJK forms block but word-spaced like ASCII Latin
+  it('keeps spaces between fullwidth Latin words', () => {
+    expect(removeRedundantCJKSpaces('ＨＥＬＬＯ ＷＯＲＬＤ')).toBe('ＨＥＬＬＯ ＷＯＲＬＤ')
+  })
+
   it('keeps spaces between CJK and Latin tokens', () => {
     expect(removeRedundantCJKSpaces('第 3 章')).toBe('第 3 章')
+    expect(removeRedundantCJKSpaces('第 ３ 章')).toBe('第 ３ 章')
   })
 
   it('handles a full extracted PDF line', () => {


### PR DESCRIPTION
PDF.js emits each glyph as its own text item, so joining items with a space inserts a space between every CJK character (此 時 校 內). The gaps confuse the TTS model. Collapse whitespace between two CJK characters during PDF extraction, leaving Latin word spacing untouched.