### PR TITLE
📈 Tag Plus activity in shared analytics events

### DIFF
--- a/app/components/TTSPlayerModal.props.ts
+++ b/app/components/TTSPlayerModal.props.ts
@@ -7,6 +7,7 @@ export interface TTSPlayerModalProps {
   bookAuthorName?: string | undefined
   bookLanguage?: string | undefined
   nftClassId?: string
+  isLibraryBook?: boolean
   startIndex?: number
   specificLanguageVoice?: string
   isAutoClose?: boolean

--- a/app/components/TTSPlayerModal.vue
+++ b/app/components/TTSPlayerModal.vue
@@ -357,6 +357,7 @@ const {
   buildTTSEventPayload,
 } = useTextToSpeech({
   nftClassId: props.nftClassId,
+  isLibraryBook: () => !!props.isLibraryBook,
   bookName: props.bookTitle,
   bookAuthorName: props.bookAuthorName,
   bookCoverSrc: props.bookCoverSrc,

--- a/app/composables/use-plus-reading-tracker.ts
+++ b/app/composables/use-plus-reading-tracker.ts
@@ -18,6 +18,10 @@ export function usePlusReadingTracker(params: {
   const nftClassIdRef = computed(() => toValue(params.nftClassId))
   const { checkOwnership } = useUserBookOwnership(nftClassIdRef)
 
+  // True once the open is confirmed a borrowed Plus-library read (vs an owned or
+  // free read). Resolved asynchronously, so read it at emit time, not on mount.
+  const isLibraryBook = ref(false)
+
   async function registerIfBorrowed() {
     if (!import.meta.client) return
     if (params.isUploadedBook.value) return
@@ -33,8 +37,11 @@ export function usePlusReadingTracker(params: {
     if (isOwner) return
     if (!params.isPlusReadingEnabled.value) return
 
+    isLibraryBook.value = true
     await bookshelfStore.registerPlusReadingOpen(nftClassIdRef.value)
   }
 
   onMounted(registerIfBorrowed)
+
+  return { isLibraryBook: readonly(isLibraryBook) }
 }

--- a/app/composables/use-reading-session.ts
+++ b/app/composables/use-reading-session.ts
@@ -10,10 +10,13 @@ interface ReadingSessionOptions {
   isTextToSpeechPlaying?: Ref<boolean>
   chapterIndex?: Ref<number | undefined>
   pageIndex?: Ref<number | undefined>
+  // True when this is a borrowed Plus-library read. Resolved asynchronously,
+  // so it may still be false when the session starts but is set by session end.
+  isLibraryBook?: Ref<boolean>
 }
 
 export function useReadingSession(options: ReadingSessionOptions) {
-  const { readerType, progress, isTextToSpeechPlaying, chapterIndex, pageIndex } = options
+  const { readerType, progress, isTextToSpeechPlaying, chapterIndex, pageIndex, isLibraryBook } = options
   const nftClassId = toRef(options.nftClassId)
 
   const { loggedIn, user: sessionUser } = useUserSession()
@@ -173,6 +176,7 @@ export function useReadingSession(options: ReadingSessionOptions) {
       tts_active_time_ms: payload.ttsActiveTimeMs,
       pages_viewed: payload.pagesViewed,
       is_liker_plus_at_event_time: !!sessionUser.value?.isLikerPlus,
+      is_library_book: !!isLibraryBook?.value,
     })
   }
 
@@ -205,6 +209,7 @@ export function useReadingSession(options: ReadingSessionOptions) {
     useLogEvent('reading_session_start', {
       nft_class_id: toValue(nftClassId),
       reader_type: readerType,
+      is_library_book: !!isLibraryBook?.value,
     })
   }
 

--- a/app/composables/use-subscription-checkout.ts
+++ b/app/composables/use-subscription-checkout.ts
@@ -84,6 +84,7 @@ export function useSubscriptionCheckout() {
     const eventPayload = {
       currency: currency.value,
       value: price,
+      product_type: 'plus',
       items: [{
         id: `plus-${plan}`,
         name: `Plus (${plan})`,

--- a/app/composables/use-text-to-speech.ts
+++ b/app/composables/use-text-to-speech.ts
@@ -39,6 +39,7 @@ interface TTSOptions {
   bookLanguage?: string | Ref<string> | ComputedRef<string>
   customVoice?: Ref<CustomVoiceData | null>
   affiliateVoices?: Ref<AffiliateVoiceData[]> | ComputedRef<AffiliateVoiceData[]>
+  isLibraryBook?: MaybeRefOrGetter<boolean>
 }
 
 export function useTextToSpeech(options: TTSOptions) {
@@ -91,6 +92,7 @@ export function useTextToSpeech(options: TTSOptions) {
       nft_class_id: nftClassId,
       tts_session_id: ttsSessionId.value || undefined,
       is_liker_plus_at_event_time: !!sessionUser.value?.isLikerPlus,
+      is_library_book: !!toValue(options.isLibraryBook),
       ...(ttsTrialUsage.isLoaded.value
         ? {
             cumulative_chars_used: ttsTrialUsage.charactersUsed.value,

--- a/app/composables/use-tts-player-modal.ts
+++ b/app/composables/use-tts-player-modal.ts
@@ -44,6 +44,13 @@ export function useTTSPlayerModal(options: TTSPlayerOptions) {
     props: ttsPlayerModalProps.value,
   })
 
+  // `overlay.create` snapshots props once, but the reader confirms
+  // `isLibraryBook` asynchronously — sync it so an open player doesn't tag TTS
+  // analytics with the stale initial value. Harmless when the modal is closed.
+  watch(() => toValue(options.isLibraryBook), () => {
+    updateTTSPlayerModalProps()
+  })
+
   const route = useRoute()
   watch(() => route.path, () => {
     modal.close()

--- a/app/composables/use-tts-player-modal.ts
+++ b/app/composables/use-tts-player-modal.ts
@@ -5,6 +5,7 @@ import { isUploadedBookId } from '~~/shared/utils/uploaded-book'
 
 interface TTSPlayerOptions {
   nftClassId: MaybeRef<string>
+  isLibraryBook?: MaybeRef<boolean>
   onSegmentChange?: (segment: TTSSegment & { index: number, isResync?: boolean }) => void
   onClose?: () => void
 }
@@ -30,6 +31,7 @@ export function useTTSPlayerModal(options: TTSPlayerOptions) {
     bookAuthorName: bookInfo.authorName.value,
     bookLanguage: bookInfo.inLanguage.value,
     nftClassId: toValue(options.nftClassId),
+    isLibraryBook: toValue(options.isLibraryBook),
     segments: ttsSegments.value,
     chapterTitlesBySection: chapterTitlesBySection.value,
     startIndex: startIndex.value,

--- a/app/pages/reader/epub.vue
+++ b/app/pages/reader/epub.vue
@@ -563,6 +563,7 @@ const { isTTSQueryParam, setTTSQueryParam } = useTTSQueryParam()
 
 const { setTTSSegments, setChapterTitles, openPlayer } = useTTSPlayerModal({
   nftClassId: nftClassId.value,
+  isLibraryBook,
   onClose: () => setTTSQueryParam(false),
   onSegmentChange: async (segment) => {
     if (!segment?.cfi) return

--- a/app/pages/reader/epub.vue
+++ b/app/pages/reader/epub.vue
@@ -392,7 +392,7 @@ const {
   bookProgressKeyPrefix,
 } = useReader()
 
-usePlusReadingTracker({
+const { isLibraryBook } = usePlusReadingTracker({
   nftClassId,
   isUploadedBook,
   isPlusReadingEnabled: bookInfo.isPlusReadingEnabled,
@@ -627,6 +627,7 @@ if (!isUploadedBook.value) {
     progress: computed(() => Math.min(readingProgress.value * 100, 100)),
     isTextToSpeechPlaying: isTTSPlaying,
     chapterIndex: currentSectionIndex,
+    isLibraryBook,
   })
 }
 

--- a/app/pages/reader/pdf.vue
+++ b/app/pages/reader/pdf.vue
@@ -113,6 +113,7 @@ const { isTTSQueryParam, setTTSQueryParam } = useTTSQueryParam()
 
 const { setTTSSegments, setChapterTitles, openPlayer } = useTTSPlayerModal({
   nftClassId: nftClassId.value,
+  isLibraryBook,
   onClose: () => setTTSQueryParam(false),
   onSegmentChange: (segment) => {
     if (segment) {

--- a/app/pages/reader/pdf.vue
+++ b/app/pages/reader/pdf.vue
@@ -65,7 +65,7 @@ const {
   bookProgressKeyPrefix,
 } = useReader()
 
-usePlusReadingTracker({
+const { isLibraryBook } = usePlusReadingTracker({
   nftClassId,
   isUploadedBook,
   isPlusReadingEnabled: bookInfo.isPlusReadingEnabled,
@@ -98,6 +98,7 @@ if (!isUploadedBook.value) {
     progress: pdfProgress,
     isTextToSpeechPlaying: isTTSPlaying,
     pageIndex: currentPageIndex,
+    isLibraryBook,
   })
 }
 


### PR DESCRIPTION
Two analytics events fire in contexts that mix Plus and non-Plus activity, so funnels and metrics built on them can't isolate the Plus slice. This adds explicit discriminator properties at the source.

## Changes

- **Commerce** (`add_to_cart`, `begin_checkout`): these events are shared with the book store, so Plus experiment funnels count book purchases too. Emit `product_type: 'plus'` to give metrics a positive Plus-vs-book discriminator. (`use-subscription-checkout.ts`)
- **Reading** (`reading_session_start`, `reading_session_end`): these fire for every book opened — owned, free, and borrowed Plus-library reads alike. Add `is_library_book` so analytics can separate borrowed Plus-library reads from owned/free, matching the `readingTimeMs` vs `nonLibraryReadingTimeMs` split the rev-share settlement uses. Surfaces the existing borrow detection in `usePlusReadingTracker` as a (readonly) ref and threads it through `useReadingSession`. (`use-plus-reading-tracker.ts`, `use-reading-session.ts`, `reader/epub.vue`, `reader/pdf.vue`)

## Notes

- `is_library_book` resolves asynchronously, so `reading_session_start` may emit `false` on a real borrow; `reading_session_end` (the event carrying the reading/TTS durations) is always accurate.
- No payout/settlement logic is touched — this is analytics tagging only.