### PR TITLE
⚡️ Cache i18n messages route for 1 day instead of 10s

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -258,6 +258,11 @@ export default defineNuxtConfig({
     ],
     defaultLocale: 'zh-Hant',
     detectBrowserLanguage: false,
+    experimental: {
+      // Cache the messages route for 1 day (default is 10s) so browsers and the
+      // CDN reuse unchanged translations. Safe: the route URL is content-hashed.
+      httpCacheDuration: 60 * 60 * 24,
+    },
   },
 
   icon: {


### PR DESCRIPTION
The @nuxtjs/i18n messages route defaulted to a 10s HTTP cache, so browsers and the CDN re-fetched unchanged translations constantly. Bump httpCacheDuration to 1 day; safe because the route URL is content-hashed, so a translation change ships a new URL rather than serving stale content.