### PR TITLE
✨ Grant affiliate voices from own publisher config too

### DIFF
--- a/app/composables/use-plus-affiliate.ts
+++ b/app/composables/use-plus-affiliate.ts
@@ -1,6 +1,19 @@
-import type { AffiliatePublicConfig } from '~~/shared/types/affiliate'
+import type { AffiliatePublicConfig, AffiliateVoiceSource, PlusAffiliateSourcesResponse } from '~~/shared/types/affiliate'
 import type { AffiliateVoiceData } from '~~/shared/types/custom-voice'
 import { checksumEVMAddress } from '~~/shared/utils'
+
+// A book is in scope when explicitly listed in affiliateClassIds, or when owned
+// by one of the affiliate's publisher wallets. Mirrors the server-side check in
+// server/utils/affiliate.ts (display-only; synthesis re-verifies).
+function isBookInScope(
+  scope: { affiliateClassIds: string[], affiliatePublisherWallets: string[] },
+  nftClassId: string,
+  ownerWallet?: string,
+): boolean {
+  if (scope.affiliateClassIds.includes(nftClassId.toLowerCase())) return true
+  const checksummedOwnerWallet = checksumEVMAddress(ownerWallet)
+  return !!checksummedOwnerWallet && scope.affiliatePublisherWallets.includes(checksummedOwnerWallet)
+}
 
 export function getAffiliateVoicesForBook(
   config: AffiliatePublicConfig | null,
@@ -8,38 +21,79 @@ export function getAffiliateVoicesForBook(
   ownerWallet?: string,
 ): AffiliateVoiceData[] {
   if (!config?.active || !nftClassId) return []
-  const byClass = config.affiliateClassIds.includes(nftClassId.toLowerCase())
-  const checksummedOwnerWallet = checksumEVMAddress(ownerWallet)
-  const byWallet = !!checksummedOwnerWallet
-    && config.affiliatePublisherWallets.includes(checksummedOwnerWallet)
-  if (!byClass && !byWallet) return []
-  return config.customVoices
+  return isBookInScope(config, nftClassId, ownerWallet) ? config.customVoices : []
+}
+
+export function getAffiliateVoicesFromSources(
+  sources: AffiliateVoiceSource[],
+  nftClassId: string | undefined,
+  ownerWallet?: string,
+): AffiliateVoiceData[] {
+  if (!nftClassId) return []
+  // Voice ids are globally unique, so dedupe in case self and referrer both
+  // scope the same book and surface a shared voice.
+  const seen = new Set<string>()
+  const voices: AffiliateVoiceData[] = []
+  for (const source of sources) {
+    if (!isBookInScope(source, nftClassId, ownerWallet)) continue
+    for (const voice of source.customVoices) {
+      if (seen.has(voice.id)) continue
+      seen.add(voice.id)
+      voices.push(voice)
+    }
+  }
+  return voices
 }
 
 export function usePlusAffiliate() {
-  const { user } = useUserSession()
-  const affiliateFrom = computed(() => user.value?.plusAffiliateFrom)
+  const { loggedIn, user } = useUserSession()
 
-  const loadedConfig = useState<AffiliatePublicConfig | null>('plus-affiliate-config', () => null)
-  // Track which affiliateFrom the cached state belongs to so a session
-  // refresh that swaps the attribution triggers a refetch instead of
-  // serving stale config.
-  const loadedFrom = useState<string | null>('plus-affiliate-loaded-from', () => null)
+  const sources = useState<AffiliateVoiceSource[]>('plus-affiliate-sources', () => [])
+  // Track which identity the cached sources belong to so a session refresh that
+  // swaps attribution (or likerId) triggers a refetch instead of serving stale
+  // sources. Both likerId and plusAffiliateFrom feed the resolved set.
+  const loadedFor = useState<string | null>('plus-affiliate-loaded-for', () => null)
   const isLoading = useState<boolean>('plus-affiliate-loading', () => false)
 
+  function identityKey() {
+    // Plus status is part of the key so an upgrade/downgrade invalidates the cache:
+    // sources are Plus-gated, so the resolved set differs across that boundary.
+    return `${user.value?.likerId ?? ''}|${user.value?.plusAffiliateFrom ?? ''}|${user.value?.isLikerPlus ? '1' : '0'}`
+  }
+
+  function clearSources() {
+    sources.value = []
+    loadedFor.value = null
+  }
+
   async function fetchConfig() {
-    const from = affiliateFrom.value
-    if (!from) {
-      loadedConfig.value = null
-      loadedFrom.value = null
+    if (!loggedIn.value) {
+      clearSources()
       return
     }
-    if (loadedFrom.value === from || isLoading.value) return
+    const identity = identityKey()
+    if (loadedFor.value === identity || isLoading.value) return
+    // Affiliate voices are Plus-only and the endpoint enforces it, so skip the
+    // fetch for non-Plus sessions while recording the identity so we don't retry.
+    // An upgrade changes identityKey, which invalidates this and triggers a fetch.
+    if (!user.value?.isLikerPlus) {
+      sources.value = []
+      loadedFor.value = identity
+      return
+    }
     isLoading.value = true
     try {
-      const data = await apiFetch<AffiliatePublicConfig>(`/affiliate/${encodeURIComponent(from)}`)
-      loadedConfig.value = data?.active ? data : null
-      loadedFrom.value = from
+      const data = await apiFetch<PlusAffiliateSourcesResponse>('/plus/affiliate')
+      // The session may have changed while the request was in flight. On logout,
+      // clear so a prior user's voices don't linger; on an identity swap, skip the
+      // stale write and let the next fetch repopulate for the new identity.
+      if (!loggedIn.value) {
+        clearSources()
+        return
+      }
+      if (identityKey() !== identity) return
+      sources.value = data?.sources ?? []
+      loadedFor.value = identity
     }
     catch (error) {
       console.error('[PlusAffiliate] Failed to fetch:', error)
@@ -53,12 +107,11 @@ export function usePlusAffiliate() {
     nftClassId: MaybeRefOrGetter<string | undefined>,
     ownerWallet?: MaybeRefOrGetter<string | undefined>,
   ): AffiliateVoiceData[] {
-    return getAffiliateVoicesForBook(loadedConfig.value, toValue(nftClassId), toValue(ownerWallet))
+    return getAffiliateVoicesFromSources(sources.value, toValue(nftClassId), toValue(ownerWallet))
   }
 
   return {
-    config: loadedConfig,
-    affiliateFrom,
+    sources,
     fetchConfig,
     voicesForBook,
   }

--- a/server/api/affiliate/[likerId].get.ts
+++ b/server/api/affiliate/[likerId].get.ts
@@ -1,5 +1,5 @@
 import type { AffiliatePublicConfig } from '~~/shared/types/affiliate'
-import { getAffiliateConfig, getAffiliatePlusDiscountAllowed } from '~~/server/utils/affiliate'
+import { getAffiliateConfig, getAffiliatePlusDiscountAllowed, toPublicAffiliateVoices } from '~~/server/utils/affiliate'
 import { fetchCachedNFTClassAggregatedMetadata } from '~~/server/utils/likecoin-nft'
 
 export default defineEventHandler(async (event): Promise<AffiliatePublicConfig> => {
@@ -45,11 +45,6 @@ export default defineEventHandler(async (event): Promise<AffiliatePublicConfig> 
     isPlusDiscountAllowed,
     affiliateClassIds: config.affiliateClassIds,
     affiliatePublisherWallets: config.affiliatePublisherWallets,
-    customVoices: config.customVoices.map(v => ({
-      id: v.id,
-      name: v.name,
-      language: v.language,
-      avatarUrl: v.avatarUrl,
-    })),
+    customVoices: toPublicAffiliateVoices(config.customVoices),
   }
 })

--- a/server/api/plus/affiliate.get.ts
+++ b/server/api/plus/affiliate.get.ts
@@ -1,0 +1,23 @@
+import type { PlusAffiliateSourcesResponse } from '~~/shared/types/affiliate'
+import { getUserAffiliateSources, toPublicAffiliateVoices } from '~~/server/utils/affiliate'
+
+export default defineEventHandler(async (event): Promise<PlusAffiliateSourcesResponse> => {
+  const session = await requireUserSession(event)
+  // Affiliate voices are Plus-only, so gate at the boundary (matching the check
+  // in reader/tts.get.ts) to avoid resolving sources for sessions that can't use them.
+  if (!session.user.isLikerPlus) {
+    throw createError({ status: 402, message: 'REQUIRE_LIKER_PLUS' })
+  }
+  // Self + referrer voice sources. providerVoiceId is stripped at this browser
+  // boundary; synthesis re-resolves it server-side in reader/tts.get.ts.
+  const sources = await getUserAffiliateSources(session.user)
+  return {
+    sources: sources.map(source => ({
+      likerId: source.likerId,
+      isSelf: source.isSelf,
+      affiliateClassIds: source.config.affiliateClassIds,
+      affiliatePublisherWallets: source.config.affiliatePublisherWallets,
+      customVoices: toPublicAffiliateVoices(source.config.customVoices),
+    })),
+  }
+})

--- a/server/api/reader/tts.get.ts
+++ b/server/api/reader/tts.get.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'node:crypto'
 import type { Writable } from 'node:stream'
 import type { H3Event } from 'h3'
+import type { AffiliateCustomVoice } from '~~/server/types/affiliate'
 import { TTSQuerySchema } from '~~/server/schemas/tts'
 import { computeLegacyTTSTextSig, computeTTSTextSig, decodeAffiliateVoiceId, isAffiliateVoiceId, TTS_PREVIEW_NFT_CLASS_ID } from '~~/shared/utils/tts-sig'
 import { buildTTSServerTiming, TTS_SERVER_SOURCE, type TTSServerSource } from '~~/shared/utils/tts-server-timing'
@@ -165,28 +166,43 @@ export default defineEventHandler(async (event) => {
     if (!isLikerPlus) {
       throw createError({ status: 402, message: 'REQUIRE_LIKER_PLUS' })
     }
-    const plusAffiliateFrom = session.user.plusAffiliateFrom
-    if (!plusAffiliateFrom) {
-      throw createError({ status: 403, message: 'NO_PLUS_AFFILIATE' })
-    }
     if (!affiliateVoiceSlot) {
       throw createError({ status: 400, message: 'INVALID_AFFILIATE_VOICE' })
     }
-    const affiliateConfig = await getAffiliateConfig(plusAffiliateFrom)
-    if (!affiliateConfig?.active) {
-      throw createError({ status: 403, message: 'AFFILIATE_INACTIVE' })
+    // Resolve across every source the user may use — their own publisher voices
+    // and the affiliate they were referred by. Ownership is gated at the
+    // reader-page level; the scope check is a sanity boundary to stop an
+    // arbitrary book from riding an affiliate voice URL.
+    const sources = await getUserAffiliateSources(session.user)
+    // Resolve the requested slot in each source, then keep only those whose config
+    // scopes this book. Voice ids are globally unique across affiliates, so at most
+    // one source should own a slot for a given book.
+    const slotMatches = sources.flatMap((source) => {
+      const voice = source.config.customVoices.find(v => v.id === affiliateVoiceSlot)
+      return voice?.providerVoiceId ? [{ source, voice }] : []
+    })
+    const inScopeVoices: AffiliateCustomVoice[] = []
+    for (const { source, voice } of slotMatches) {
+      if (await isBookInAffiliateVoiceScope(source.config, nftClassId)) {
+        inScopeVoices.push(voice)
+      }
     }
-    // Ownership is gated at the reader-page level; this check is a sanity
-    // boundary to stop an arbitrary book from riding an affiliate voice URL.
-    if (!(await isBookInAffiliateVoiceScope(affiliateConfig, nftClassId))) {
-      throw createError({ status: 403, message: 'BOOK_NOT_IN_AFFILIATE' })
+    // Fail loud only when the in-scope sources disagree on the provider voice — an
+    // out-of-scope duplicate slot must not block a voice that legitimately scopes
+    // this book. Uniqueness should hold upstream, so this guards a broken invariant.
+    if (new Set(inScopeVoices.map(voice => voice.providerVoiceId)).size > 1) {
+      throw createError({ status: 409, message: 'AFFILIATE_VOICE_AMBIGUOUS' })
     }
-    const affiliateVoice = affiliateConfig.customVoices.find(v => v.id === affiliateVoiceSlot)
-    if (!affiliateVoice?.providerVoiceId) {
-      throw createError({ status: 404, message: 'AFFILIATE_VOICE_NOT_FOUND' })
+    const matchedVoice = inScopeVoices[0]
+    if (!matchedVoice) {
+      // A slot match that survived nowhere means the book is out of scope; no slot
+      // match at all means the voice id is unknown to this user's sources.
+      throw createError(slotMatches.length
+        ? { status: 403, message: 'BOOK_NOT_IN_AFFILIATE' }
+        : { status: 404, message: 'AFFILIATE_VOICE_NOT_FOUND' })
     }
-    customMiniMaxVoiceId = affiliateVoice.providerVoiceId
-    voiceDisplayName = affiliateVoice.name
+    customMiniMaxVoiceId = matchedVoice.providerVoiceId
+    voiceDisplayName = matchedVoice.name
     provider = new MinimaxTTSProvider()
   }
   else if (isCustomVoice) {

--- a/server/utils/affiliate.ts
+++ b/server/utils/affiliate.ts
@@ -1,4 +1,5 @@
 import type { AffiliateConfig, AffiliateCustomVoice } from '~~/server/types/affiliate'
+import type { AffiliateVoiceData } from '~~/shared/types/custom-voice'
 import { fetchCachedNFTClassAggregatedMetadata } from '~~/server/utils/likecoin-nft'
 import { checkIsEVMAddress, checksumEVMAddress, normalizeNFTClassId } from '~~/shared/utils'
 import { getLikeCoinAPIFetch } from '~~/shared/utils/api'
@@ -86,6 +87,42 @@ async function getAffiliateEntry(likerId: string): Promise<AffiliateEntry | null
 
 export async function getAffiliateConfig(likerId: string): Promise<AffiliateConfig | null> {
   return (await getAffiliateEntry(likerId))?.config ?? null
+}
+
+export interface AffiliateVoiceSourceInternal {
+  likerId: string
+  isSelf: boolean
+  config: AffiliateConfig
+}
+
+// Drop providerVoiceId so only browser-safe voice metadata crosses the API.
+export function toPublicAffiliateVoices(voices: AffiliateCustomVoice[]): AffiliateVoiceData[] {
+  return voices.map(voice => ({
+    id: voice.id,
+    name: voice.name,
+    language: voice.language,
+    avatarUrl: voice.avatarUrl,
+  }))
+}
+
+// The affiliate configs a Plus user may draw voices from: their own publisher
+// config plus the affiliate they were referred by. Both resolve through the
+// existing per-likerId cache, so this adds no new upstream surface.
+export async function getUserAffiliateSources(
+  user: { likerId?: string, plusAffiliateFrom?: string },
+): Promise<AffiliateVoiceSourceInternal[]> {
+  const selfLikerId = user.likerId ? normalizeLikerId(user.likerId) : undefined
+  const referrerLikerId = user.plusAffiliateFrom ? normalizeLikerId(user.plusAffiliateFrom) : undefined
+  const likerIds = [selfLikerId, referrerLikerId]
+    .filter((id, i, arr) => !!id && arr.indexOf(id) === i) as string[]
+  const configs = await Promise.all(likerIds.map(id => getAffiliateConfig(id)))
+  const sources: AffiliateVoiceSourceInternal[] = []
+  likerIds.forEach((likerId, i) => {
+    const config = configs[i]
+    if (!config?.active) return
+    sources.push({ likerId, isSelf: likerId === selfLikerId, config })
+  })
+  return sources
 }
 
 export async function getAffiliatePlusDiscountAllowed(likerId: string): Promise<boolean> {

--- a/shared/types/affiliate.d.ts
+++ b/shared/types/affiliate.d.ts
@@ -21,3 +21,18 @@ export type AffiliatePublicConfig =
     affiliatePublisherWallets: string[]
     customVoices: AffiliateVoiceData[]
   }
+
+// One affiliate config a Plus user may draw TTS voices from — either their own
+// publisher config (isSelf) or the affiliate they were referred by. Carries the
+// scope fields needed for client-side book matching; providerVoiceId is stripped.
+export interface AffiliateVoiceSource {
+  likerId: string
+  isSelf: boolean
+  affiliateClassIds: string[]
+  affiliatePublisherWallets: string[]
+  customVoices: AffiliateVoiceData[]
+}
+
+export interface PlusAffiliateSourcesResponse {
+  sources: AffiliateVoiceSource[]
+}

--- a/test/unit/affiliate-voices.test.ts
+++ b/test/unit/affiliate-voices.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import { getAffiliateVoicesForBook } from '~/composables/use-plus-affiliate'
-import type { AffiliatePublicConfig } from '~~/shared/types/affiliate'
+import { getAffiliateVoicesForBook, getAffiliateVoicesFromSources } from '~/composables/use-plus-affiliate'
+import type { AffiliatePublicConfig, AffiliateVoiceSource } from '~~/shared/types/affiliate'
 
 const VOICES = [{ id: 'chiming', name: 'Chiming' }]
 
@@ -37,5 +37,53 @@ describe('getAffiliateVoicesForBook', () => {
   it('denies when neither the classId nor the owner wallet match', () => {
     expect(getAffiliateVoicesForBook(activeConfig, '0xother', STRANGER_WALLET)).toEqual([])
     expect(getAffiliateVoicesForBook(activeConfig, '0xother')).toEqual([])
+  })
+})
+
+const SELF_VOICE = { id: 'self-voice', name: 'Self' }
+const REFERRER_VOICE = { id: 'referrer-voice', name: 'Referrer' }
+const SHARED_VOICE = { id: 'shared-voice', name: 'Shared' }
+
+const selfSource: AffiliateVoiceSource = {
+  likerId: 'self',
+  isSelf: true,
+  affiliateClassIds: ['0xaaa'],
+  affiliatePublisherWallets: [PUBLISHER_WALLET],
+  customVoices: [SELF_VOICE, SHARED_VOICE],
+}
+
+const referrerSource: AffiliateVoiceSource = {
+  likerId: 'referrer',
+  isSelf: false,
+  affiliateClassIds: ['0xbbb'],
+  affiliatePublisherWallets: [STRANGER_WALLET],
+  customVoices: [REFERRER_VOICE, SHARED_VOICE],
+}
+
+describe('getAffiliateVoicesFromSources', () => {
+  it('returns no voices when nftClassId is missing', () => {
+    expect(getAffiliateVoicesFromSources([selfSource], undefined)).toEqual([])
+  })
+
+  it('merges voices across sources that both scope the book', () => {
+    // 0xaaa is in self scope; STRANGER_WALLET owner puts it in referrer scope too.
+    const voices = getAffiliateVoicesFromSources([selfSource, referrerSource], '0xaaa', STRANGER_WALLET)
+    expect(voices).toEqual([SELF_VOICE, SHARED_VOICE, REFERRER_VOICE])
+  })
+
+  it('dedupes a voice id surfaced by multiple in-scope sources', () => {
+    // Both sources scope 0xaaa and carry the same SHARED_VOICE; it must appear once.
+    const a = { ...selfSource, customVoices: [SHARED_VOICE] }
+    const b = { ...referrerSource, affiliateClassIds: ['0xaaa'], customVoices: [SHARED_VOICE] }
+    expect(getAffiliateVoicesFromSources([a, b], '0xaaa')).toEqual([SHARED_VOICE])
+  })
+
+  it('only includes voices from sources whose scope matches the book', () => {
+    // 0xbbb matches only the referrer source; the self source is out of scope.
+    expect(getAffiliateVoicesFromSources([selfSource, referrerSource], '0xbbb')).toEqual([REFERRER_VOICE, SHARED_VOICE])
+  })
+
+  it('returns no voices when no source scopes the book', () => {
+    expect(getAffiliateVoicesFromSources([selfSource, referrerSource], '0xnope')).toEqual([])
   })
 })


### PR DESCRIPTION
Resolve TTS affiliate voices across every source a Plus user may use — their own publisher config plus the affiliate they were referred by — instead of only the referrer. Adds a shared getUserAffiliateSources resolver over the existing per-likerId endpoint (no new upstream API), an authed /plus/affiliate listing route, and multi-source matching in synthesis. Drops the hard referrer requirement so a referrer-less self-publisher can still use their own voices.