### PR TITLE
🐛 Drop desynced CMS tag ids to fix store crash

### DIFF
--- a/app/stores/bookstore.ts
+++ b/app/stores/bookstore.ts
@@ -120,7 +120,12 @@ export const useBookstoreStore = defineStore('bookstore', () => {
 
   const bookstoreCMSTagsMapById = ref<Record<string, BookstoreCMSTag>>({})
   const bookstoreCMSTagIds = ref<string[]>([])
-  const bookstoreCMSTags = computed(() => bookstoreCMSTagIds.value.map(tagId => bookstoreCMSTagsMapById.value[tagId]!))
+  // Drop ids missing from the map: persisted ids and the persisted map can desync
+  // (older build, partial write, edited storage), and an undefined entry here
+  // crashes consumers that read tag.isPublic / tag.isForLibrary.
+  const bookstoreCMSTags = computed(() => bookstoreCMSTagIds.value
+    .map(tagId => bookstoreCMSTagsMapById.value[tagId])
+    .filter((tag): tag is BookstoreCMSTag => !!tag))
   const isFetchingBookstoreCMSTags = ref(false)
   const hasFetchedBookstoreCMSTags = ref(false)
 


### PR DESCRIPTION
Persisted bookstoreCMSTagIds and bookstoreCMSTagsMapById can desync (older build, partial write, edited storage), leaving an undefined entry in the bookstoreCMSTags getter that crashed the store tag list on tag.isPublic. Filter out ids missing from the map.