### PR TITLE
🔥 Remove generic yearly gift book benefit from pricing

### DIFF
--- a/app/components/PricingPlanBenefits.vue
+++ b/app/components/PricingPlanBenefits.vue
@@ -72,24 +72,12 @@
           </i18n-t>
         </li>
       </template>
-      <li v-if="selectedPlan === undefined || isYearlyPlan">
-        <UIcon name="i-material-symbols-check" />
-        <span
-          v-if="isYearlyPlan"
-          v-text="$t('pricing_page_feature_6_yearly')"
-        />
-        <span
-          v-else
-          v-text="$t('pricing_page_feature_6')"
-        />
-      </li>
     </ul>
   </div>
 </template>
 
 <script lang="ts" setup>
-const props = withDefaults(defineProps<{
-  selectedPlan?: SubscriptionPlan
+withDefaults(defineProps<{
   title?: string
   isTitleCenter?: boolean
   isTitleHidden?: boolean
@@ -104,10 +92,6 @@ const props = withDefaults(defineProps<{
   isCompact: false,
   isAudioHidden: false,
   prependedFeatures: () => [],
-})
-
-const isYearlyPlan = computed(() => {
-  return props.selectedPlan === 'yearly'
 })
 
 const { t: $t } = useI18n()

--- a/app/components/UpsellPlusModal.vue
+++ b/app/components/UpsellPlusModal.vue
@@ -23,7 +23,6 @@
     <template #body>
       <PricingPlanBenefits
         class="self-center"
-        :selected-plan="selectedPlan"
         :title="$t('upsell_plus_benefits_title')"
         :is-title-center="true"
         :is-compact="false"

--- a/app/pages/gift/plus/claim.vue
+++ b/app/pages/gift/plus/claim.vue
@@ -67,7 +67,6 @@
           v-if="!isExistingPlusMember"
           class="mt-6"
           :title="$t('gift_plus_claim_info_title')"
-          :selected-plan="period"
           :is-title-center="true"
           :is-dark-background="true"
           :is-compact="true"

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -667,8 +667,6 @@
   "pricing_page_feature_3": "Dark mode and other exclusive features",
   "pricing_page_feature_4": "{customerService} to resolve any issues",
   "pricing_page_feature_4_customer_service": "Live support",
-  "pricing_page_feature_6": "Yearly-exclusive gift: any ebook of your choice, every year",
-  "pricing_page_feature_6_yearly": "Receive one free ebook of your choice",
   "pricing_page_feature_library": "All-you-can-read access to the Library",
   "pricing_page_intercom_prefill": "Hi, I'd like to learn more about 3ook.com Plus",
   "pricing_page_learn_more": "Learn more about 3ook.com",

--- a/i18n/locales/zh-Hant.json
+++ b/i18n/locales/zh-Hant.json
@@ -667,8 +667,6 @@
   "pricing_page_feature_3": "專享深色模式等專屬功能",
   "pricing_page_feature_4": "{customerService}，替你排解各種疑難",
   "pricing_page_feature_4_customer_service": "真人客服",
-  "pricing_page_feature_6": "年費會員限定禮：每年全站任選電子書乙本",
-  "pricing_page_feature_6_yearly": "每年獲贈自選電子書",
   "pricing_page_feature_library": "暢讀暢聽所有圖書館藏書",
   "pricing_page_intercom_prefill": "你好，我想了解更多關於 3ook.com Plus 的資訊",
   "pricing_page_learn_more": "了解更多關於 3ook.com",


### PR DESCRIPTION
Drop the yearly-exclusive gift book line from the shared plan benefits list. The affiliate gift picker and the store upsell gift book are separate flows and stay intact. Clean up the now-dead selectedPlan prop and its bindings.