### PR TITLE
🚸 Hint to check spam during Magic email OTP login

### DIFF
--- a/app/stores/account.ts
+++ b/app/stores/account.ts
@@ -418,6 +418,7 @@ export const useAccountStore = defineStore('account', () => {
       if (!connector) return
 
       let magicEmailInput: HTMLInputElement | undefined
+      let removeMagicOTPHint: (() => void) | undefined
       if (connectorId === 'magic' && magicEmail) {
         document.getElementById(MAGIC_EMAIL_INPUT_ELEMENT_ID)?.remove()
         magicEmailInput = document.createElement('input')
@@ -426,6 +427,9 @@ export const useAccountStore = defineStore('account', () => {
         magicEmailInput.value = magicEmail
         magicEmailInput.style.display = 'none'
         document.body.appendChild(magicEmailInput)
+        // Magic owns the OTP entry UI; surface a hint above it asking the user
+        // to confirm the address and check spam if the code never arrives.
+        removeMagicOTPHint = showMagicOTPHint($t('login_magic_otp_hint', { email: magicEmail }))
       }
 
       isLoggingIn.value = true
@@ -439,8 +443,9 @@ export const useAccountStore = defineStore('account', () => {
       }
       finally {
         if (connectorId === 'magic') {
-          // Clean up the Magic email input if exists
+          // Clean up the Magic email input and OTP hint if they exist
           magicEmailInput?.remove()
+          removeMagicOTPHint?.()
         }
       }
 

--- a/app/utils/magic-otp-hint.ts
+++ b/app/utils/magic-otp-hint.ts
@@ -4,13 +4,19 @@ const MAGIC_OTP_HINT_ELEMENT_ID = 'MagicOTPHint'
 // and DOM order (not z-index) decides which wins — see keepOnTop below.
 const MAGIC_OVERLAY_MAX_Z_INDEX = '2147483647'
 
-// Magic SDK renders its email-OTP entry screen inside a full-viewport iframe
-// (`.magic-iframe`, z-index 2147483647) that we can't reach into. This pins a
-// non-interactive hint just above that iframe, so it reads as a note below the
-// OTP card. Returns a cleanup function that removes the hint.
+// Only one hint exists at a time; track its observer so a re-show can tear the
+// previous one down instead of leaking it.
+let activeObserver: MutationObserver | undefined
+
+// Magic renders its email-OTP screen in a full-viewport iframe we can't reach
+// into, so this pins a non-interactive hint above it that reads as a note below
+// the OTP card. Returns a cleanup function.
 export function showMagicOTPHint(message: string): () => void {
   if (!import.meta.client) return () => {}
 
+  // Disconnect a still-running observer first; otherwise its keepOnTop would
+  // re-append the node we're about to remove.
+  activeObserver?.disconnect()
   document.getElementById(MAGIC_OTP_HINT_ELEMENT_ID)?.remove()
 
   const hint = document.createElement('div')
@@ -43,10 +49,12 @@ export function showMagicOTPHint(message: string): () => void {
     }
   }
   const observer = new MutationObserver(keepOnTop)
+  activeObserver = observer
   observer.observe(document.body, { childList: true })
 
   return () => {
     observer.disconnect()
+    if (activeObserver === observer) activeObserver = undefined
     hint.remove()
   }
 }

--- a/app/utils/magic-otp-hint.ts
+++ b/app/utils/magic-otp-hint.ts
@@ -1,0 +1,52 @@
+const MAGIC_OTP_HINT_ELEMENT_ID = 'MagicOTPHint'
+
+// Matches the z-index Magic gives its iframe, so the hint shares the top layer
+// and DOM order (not z-index) decides which wins — see keepOnTop below.
+const MAGIC_OVERLAY_MAX_Z_INDEX = '2147483647'
+
+// Magic SDK renders its email-OTP entry screen inside a full-viewport iframe
+// (`.magic-iframe`, z-index 2147483647) that we can't reach into. This pins a
+// non-interactive hint just above that iframe, so it reads as a note below the
+// OTP card. Returns a cleanup function that removes the hint.
+export function showMagicOTPHint(message: string): () => void {
+  if (!import.meta.client) return () => {}
+
+  document.getElementById(MAGIC_OTP_HINT_ELEMENT_ID)?.remove()
+
+  const hint = document.createElement('div')
+  hint.id = MAGIC_OTP_HINT_ELEMENT_ID
+  hint.textContent = message
+  Object.assign(hint.style, {
+    position: 'fixed',
+    left: '50%',
+    bottom: 'calc(env(safe-area-inset-bottom, 0px) + 24px)',
+    transform: 'translateX(-50%)',
+    zIndex: MAGIC_OVERLAY_MAX_Z_INDEX,
+    maxWidth: 'min(420px, calc(100vw - 32px))',
+    padding: '12px 16px',
+    borderRadius: '12px',
+    background: 'rgba(0, 0, 0, 0.72)',
+    color: '#ffffff',
+    font: '500 13px/1.5 system-ui, -apple-system, sans-serif',
+    textAlign: 'center',
+    pointerEvents: 'none',
+    boxShadow: '0 4px 16px rgba(0, 0, 0, 0.24)',
+  })
+  document.body.appendChild(hint)
+
+  // The Magic iframe shares our max z-index, so DOM order decides stacking.
+  // Keep the hint as body's last child so it stays above the iframe, even when
+  // Magic lazily appends the iframe after us on the first login of a session.
+  const keepOnTop = () => {
+    if (document.body.lastElementChild !== hint) {
+      document.body.appendChild(hint)
+    }
+  }
+  const observer = new MutationObserver(keepOnTop)
+  observer.observe(document.body, { childList: true })
+
+  return () => {
+    observer.disconnect()
+    hint.remove()
+  }
+}

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -619,7 +619,7 @@
   "local_histories_units_title": "Local history units",
   "login_button": "Sign in / Sign up",
   "login_button_app": "Sign in",
-  "login_magic_otp_hint": "Code sent to {email}. Check the address is correct, and look in your spam folder if it doesn't arrive.",
+  "login_magic_otp_hint": "Code sent to {email}. Check that the address is correct, and look in your spam folder if it doesn't arrive.",
   "login_panel_continue_with_email": "Continue with email",
   "login_panel_email_placeholder": "Email address",
   "login_panel_or_separator": "OR",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -619,6 +619,7 @@
   "local_histories_units_title": "Local history units",
   "login_button": "Sign in / Sign up",
   "login_button_app": "Sign in",
+  "login_magic_otp_hint": "Code sent to {email}. Check the address is correct, and look in your spam folder if it doesn't arrive.",
   "login_panel_continue_with_email": "Continue with email",
   "login_panel_email_placeholder": "Email address",
   "login_panel_or_separator": "OR",

--- a/i18n/locales/zh-Hant.json
+++ b/i18n/locales/zh-Hant.json
@@ -619,7 +619,7 @@
   "local_histories_units_title": "地方誌單位",
   "login_button": "登入 / 註冊",
   "login_button_app": "登入",
-  "login_magic_otp_hint": "驗證碼已寄至 {email}。請確認電郵地址無誤，若未收到請查看垃圾郵件匣。",
+  "login_magic_otp_hint": "驗證碼已寄至 {email}。請確認電子信箱地址無誤，若未收到請查看垃圾郵件匣。",
   "login_panel_continue_with_email": "以電子信箱登入",
   "login_panel_email_placeholder": "電子信箱地址",
   "login_panel_or_separator": "或",

--- a/i18n/locales/zh-Hant.json
+++ b/i18n/locales/zh-Hant.json
@@ -619,6 +619,7 @@
   "local_histories_units_title": "地方誌單位",
   "login_button": "登入 / 註冊",
   "login_button_app": "登入",
+  "login_magic_otp_hint": "驗證碼已寄至 {email}。請確認電郵地址無誤，若未收到請查看垃圾郵件匣。",
   "login_panel_continue_with_email": "以電子信箱登入",
   "login_panel_email_placeholder": "電子信箱地址",
   "login_panel_or_separator": "或",


### PR DESCRIPTION

<img width="1078" height="1454" alt="image" src="https://github.com/user-attachments/assets/242e72af-090d-4042-817a-8d915bf995b2" />

Magic owns the OTP entry iframe, so users who mistype their address or miss the code in spam have no guidance. Pin a non-interactive hint above the iframe showing the entered email and prompting a spam check.