### PR TITLE
🐛 Fix TTS showing English voices after a book's language is corrected

### DIFF
--- a/app/composables/use-text-to-speech.ts
+++ b/app/composables/use-text-to-speech.ts
@@ -152,12 +152,7 @@ export function useTextToSpeech(options: TTSOptions) {
   }
 
   // Playback rate options and storage
-  const ttsConfigCacheKey = computed(() =>
-    [
-      config.public.cacheKeyPrefix,
-      TTS_CONFIG_KEY,
-    ].join('-'),
-  )
+  const ttsConfigCacheKey = computed(() => getTTSConfigCacheKey(config.public.cacheKeyPrefix))
 
   const DEFAULT_PLAYBACK_RATE = 1.0
 

--- a/app/composables/use-tts-voice.ts
+++ b/app/composables/use-tts-voice.ts
@@ -21,12 +21,7 @@ export function useTTSVoice(options: TTSVoiceOptions = {}) {
   const { detectedCountry } = useDetectedGeolocation()
   const { getResizedImageURL } = useImageResize()
 
-  const ttsConfigCacheKey = computed(() =>
-    [
-      config.public.cacheKeyPrefix,
-      TTS_CONFIG_KEY,
-    ].join('-'),
-  )
+  const ttsConfigCacheKey = computed(() => getTTSConfigCacheKey(config.public.cacheKeyPrefix))
 
   // hardcoded voice options for now
   const ttsLanguageVoiceOptions = [
@@ -105,6 +100,17 @@ export function useTTSVoice(options: TTSVoiceOptions = {}) {
       ttsLanguageVoice.value = languageVoice
     }
   }
+
+  // The persisted voice is global, not per-book: a book opened while mislabeled
+  // (e.g. English) pins an incompatible voice that then sticks across all books.
+  // Reset to the locale default when invalid here; skip async-gated affiliate/custom.
+  watch(availableTTSLanguageVoiceOptions, (voiceOptions) => {
+    const current = ttsLanguageVoice.value
+    if (!current || isAffiliateVoiceId(current) || current === 'custom') return
+    if (!voiceOptions.some(option => option.value === current)) {
+      ttsLanguageVoice.value = getDefaultTTSVoiceByLocale()
+    }
+  }, { immediate: true })
 
   const activeTTSLanguageVoiceAvatar = computed(() => {
     return getVoiceAvatar(ttsLanguageVoice.value)

--- a/app/stores/account.ts
+++ b/app/stores/account.ts
@@ -589,8 +589,11 @@ export const useAccountStore = defineStore('account', () => {
 
       window.localStorage.removeItem(getBookFileCacheIndexKey(config.public.cacheKeyPrefix))
 
+      // Must use the same cacheKeyPrefix-scoped key the values are written under
+      // (getTTSConfigCacheKey); the unprefixed key would clear nothing.
+      const ttsConfigCacheKey = getTTSConfigCacheKey(config.public.cacheKeyPrefix)
       getTTSConfigKeySuffixes().forEach((suffix) => {
-        window.localStorage.removeItem(getTTSConfigKeyWithSuffix(TTS_CONFIG_KEY, suffix))
+        window.localStorage.removeItem(getTTSConfigKeyWithSuffix(ttsConfigCacheKey, suffix))
       })
     }
     finally {

--- a/app/stores/nft.ts
+++ b/app/stores/nft.ts
@@ -86,10 +86,9 @@ export const useNFTStore = defineStore('nft', () => {
     next()
   }
 
-  // Refetches the displayed aspects (class + bookstore) in the background,
-  // coalescing concurrent callers and bounding fan-out. Goes through the CDN
-  // cache (no nocache) — enough to heal a days-old persisted entry — and keeps
-  // serving the cached value if it fails.
+  // Background revalidation: coalesced, bounded fan-out. nocache is required —
+  // the LikeCoin CDN serves a 24h stale-while-revalidate body, so a plain refetch
+  // loops on the stale value and never heals a corrected field. Keeps cache on failure.
   function revalidateNFTClassAggregatedMetadataById(nftClassId: string) {
     const key = normalizeNFTClassId(nftClassId)
     const existing = inflightRevalidations.get(key)
@@ -97,7 +96,7 @@ export const useNFTStore = defineStore('nft', () => {
     revalidatingCount.value += 1
     const promise = new Promise<void>((resolve) => {
       queuedRevalidations.push(() => {
-        fetchNFTClassAggregatedMetadataById(nftClassId, { include: ['class_chain', 'bookstore'] })
+        fetchNFTClassAggregatedMetadataById(nftClassId, { include: ['class_chain', 'bookstore'], nocache: true })
           .catch(() => { /* keep the cached value; retry on a later session */ })
           .finally(() => {
             activeRevalidationCount -= 1

--- a/app/utils/tts.ts
+++ b/app/utils/tts.ts
@@ -204,6 +204,10 @@ export function getTTSConfigKeySuffixes() {
   return TTS_CONFIG_KEY_SUFFIX_LIST
 }
 
+export function getTTSConfigCacheKey(cacheKeyPrefix: string) {
+  return [cacheKeyPrefix, TTS_CONFIG_KEY].join('-')
+}
+
 export function getTTSConfigKeyWithSuffix(key: string, suffix: TTSConfigKeySuffix) {
   return `${key}-${suffix}`
 }


### PR DESCRIPTION
A book mislabeled English left users with no Chinese TTS voices even after the metadata was fixed, due to two client-side caches that never healed:

- NFT metadata background revalidation went through the LikeCoin CDN, whose 24h stale-while-revalidate window kept serving the stale language. Pass nocache so the refetch busts it and converges to the corrected value.
- The persisted TTS voice is global, not per-book, so a mislabeled book could pin an incompatible (English) voice that then stuck across every book. Reset to the locale default when the active voice isn't valid for the current book.
- Clear-cache used the unprefixed TTS config key, so it never cleared the voice/playback-rate values. Route writer and clearer through a shared getTTSConfigCacheKey helper so they can't drift again.