### PR TITLE
🐛 Fix Plus embedded checkout broken by Stripe.js dahlia

### DIFF
--- a/app/pages/plus/checkout.vue
+++ b/app/pages/plus/checkout.vue
@@ -90,7 +90,7 @@ interface StripeEmbeddedCheckout {
 }
 
 interface StripeInstance {
-  initEmbeddedCheckout: (options: {
+  createEmbeddedCheckoutPage: (options: {
     fetchClientSecret: () => Promise<string>
     onComplete?: () => void
   }) => Promise<StripeEmbeddedCheckout>
@@ -125,7 +125,7 @@ async function mountCheckout() {
   try {
     const { Stripe } = await stripeScript.load() as { Stripe: (publishableKey: string) => StripeInstance }
     const stripe = Stripe(publishableKey)
-    embeddedCheckout = await stripe.initEmbeddedCheckout({
+    embeddedCheckout = await stripe.createEmbeddedCheckoutPage({
       fetchClientSecret: async () => clientSecret,
       onComplete: handleComplete,
     })


### PR DESCRIPTION
The dahlia release removes stripe.initEmbeddedCheckout(); call its replacement createEmbeddedCheckoutPage() so the embedded checkout page mounts instead of failing to load.