### PR TITLE
[TAS-6122] ✨ Forward UTM attribution into app download links

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -13,6 +13,7 @@
 import { useDocumentVisibility } from '@vueuse/core'
 
 import { SESSION_REFRESH_TIMESTAMP_KEY } from '~/stores/account'
+import { APP_STORE_URL, GOOGLE_PLAY_URL } from '~/utils/app-store'
 
 const { t: $t, locales } = useI18n()
 const config = useRuntimeConfig()
@@ -287,7 +288,7 @@ useHead({
           'price': 0,
           'priceCurrency': 'USD',
         },
-        'installUrl': 'https://apps.apple.com/app/id6757783481',
+        'installUrl': APP_STORE_URL,
       },
       {
         '@context': 'https://schema.org',
@@ -300,7 +301,7 @@ useHead({
           'price': 0,
           'priceCurrency': 'USD',
         },
-        'installUrl': 'https://play.google.com/store/apps/details?id=land.liker.book3app',
+        'installUrl': GOOGLE_PLAY_URL,
       },
       ]),
     },

--- a/app/components/AppDownloadButtons.vue
+++ b/app/components/AppDownloadButtons.vue
@@ -3,7 +3,7 @@
     <UButton
       :label="$t('app_download_buttons_app_store')"
       icon="i-simple-icons-apple"
-      to="https://apps.apple.com/app/id6757783481"
+      :to="appStoreUrl"
       target="_blank"
       rel="noopener noreferrer"
       color="neutral"
@@ -15,7 +15,7 @@
     <UButton
       :label="$t('app_download_buttons_google_play')"
       icon="i-simple-icons-googleplay"
-      to="https://play.google.com/store/apps/details?id=land.liker.book3app"
+      :to="googlePlayUrl"
       target="_blank"
       rel="noopener noreferrer"
       color="neutral"
@@ -28,10 +28,23 @@
 </template>
 
 <script setup lang="ts">
+import type { AppDownloadPlacement } from '~/composables/use-app-download-urls'
+
+const props = withDefaults(
+  defineProps<{
+    // Static fallback campaign tag identifying where this CTA lives, used when
+    // the session carries no UTM. See useAppDownloadUrls.
+    placement?: AppDownloadPlacement
+  }>(),
+  { placement: 'app_download' },
+)
+
 const emit = defineEmits<{
   clickAppStore: []
   clickGooglePlay: []
 }>()
+
+const { appStoreUrl, googlePlayUrl } = useAppDownloadUrls(props.placement)
 
 function onClickAppStore() {
   emit('clickAppStore')

--- a/app/components/AppFooter.vue
+++ b/app/components/AppFooter.vue
@@ -138,6 +138,7 @@
     <AppDownloadButtons
       v-if="!isApp"
       class="mx-auto"
+      placement="footer"
       @click-app-store="onClickAppStoreButton"
       @click-google-play="onClickGooglePlayButton"
     />

--- a/app/composables/use-app-download-urls.ts
+++ b/app/composables/use-app-download-urls.ts
@@ -1,0 +1,52 @@
+import { APP_STORE_URL, GOOGLE_PLAY_URL } from '~/utils/app-store'
+
+// Builds App Store / Google Play download links that carry install attribution.
+// Live UTM (from usePostHogAttribution) wins; a static per-CTA `placement` tag
+// is the fallback so organic clicks are still attributed to where they came
+// from. Google Play reads the encoded `referrer` via the Install Referrer API;
+// Apple campaign tokens (pt/ct) surface in App Store Connect App Analytics only.
+
+export const APP_DOWNLOAD_PLACEMENTS = [
+  'footer',
+  'about',
+  'app_page_hero',
+  'app_page_cta',
+  'app_download',
+] as const
+export type AppDownloadPlacement = (typeof APP_DOWNLOAD_PLACEMENTS)[number]
+
+const STATIC_SOURCE = '3ookcom'
+const STATIC_MEDIUM = 'app_download'
+
+// Apple App Store Connect provider token (pt); fill in when available,
+// otherwise the campaign link omits it and relies on ct alone.
+const APP_STORE_PROVIDER_TOKEN = ''
+
+export function useAppDownloadUrls(placement: AppDownloadPlacement) {
+  const attribution = usePostHogAttribution()
+
+  const params: Record<string, string> = {
+    utm_source: attribution.utm_source || STATIC_SOURCE,
+    utm_medium: attribution.utm_medium || STATIC_MEDIUM,
+    utm_campaign: attribution.utm_campaign || placement,
+  }
+  // Carry through finer-grained attribution when the session has it.
+  for (const key of ['utm_content', 'utm_term', 'gclid', 'gad_source', 'fbclid'] as const) {
+    if (attribution[key]) params[key] = attribution[key]
+  }
+
+  // Play wants the whole UTM string as one URL-encoded `referrer` value.
+  const referrer = encodeURIComponent(new URLSearchParams(params).toString())
+  const googlePlayUrl = `${GOOGLE_PLAY_URL}&referrer=${referrer}`
+
+  // Apple `ct` is free campaign text, <=40 chars; `pt` is the provider token,
+  // `mt=8` marks it an app link.
+  const ct = `${params.utm_source}_${params.utm_campaign}`
+    .replace(/[^a-zA-Z0-9_]/g, '_')
+    .slice(0, 40)
+  const appStoreParams = new URLSearchParams({ ct, mt: '8' })
+  if (APP_STORE_PROVIDER_TOKEN) appStoreParams.set('pt', APP_STORE_PROVIDER_TOKEN)
+  const appStoreUrl = `${APP_STORE_URL}?${appStoreParams.toString()}`
+
+  return { appStoreUrl, googlePlayUrl }
+}

--- a/app/pages/about.vue
+++ b/app/pages/about.vue
@@ -760,6 +760,7 @@
 
           <AppDownloadButtons
             class="*:text-theme-white *:ring-theme-white *:hover:bg-theme-white/20"
+            placement="about"
             @click-app-store="onClickAppStoreButton"
             @click-google-play="onClickGooglePlayButton"
           />

--- a/app/pages/app.vue
+++ b/app/pages/app.vue
@@ -35,6 +35,7 @@
 
           <AppDownloadButtons
             class="*:text-theme-white *:ring-theme-white *:hover:bg-theme-white/20"
+            placement="app_page_hero"
             @click-app-store="onClickAppStore"
             @click-google-play="onClickGooglePlay"
           />
@@ -194,6 +195,7 @@
         />
         <AppDownloadButtons
           class="w-full max-w-md"
+          placement="app_page_cta"
           @click-app-store="onClickCtaAppStore"
           @click-google-play="onClickCtaGooglePlay"
         />
@@ -203,6 +205,8 @@
 </template>
 
 <script setup lang="ts">
+import { APP_STORE_URL, GOOGLE_PLAY_URL } from '~/utils/app-store'
+
 definePageMeta({
   layout: false,
   colorMode: 'light',
@@ -211,9 +215,6 @@ definePageMeta({
 const { t: $t } = useI18n()
 const config = useRuntimeConfig()
 const baseURL = config.public.baseURL
-
-const APP_STORE_URL = 'https://apps.apple.com/app/id6757783481'
-const GOOGLE_PLAY_URL = 'https://play.google.com/store/apps/details?id=land.liker.book3app'
 
 function onClickAppStore() {
   useLogEvent('app_page_hero_app_store_click')

--- a/app/utils/app-store.ts
+++ b/app/utils/app-store.ts
@@ -1,0 +1,6 @@
+// Canonical 3ook Reader store identifiers and listing URLs, shared by the
+// download CTAs (useAppDownloadUrls) and the structured-data / SEO meta.
+export const APP_STORE_APP_ID = '6757783481'
+export const ANDROID_PACKAGE_NAME = 'land.liker.book3app'
+export const APP_STORE_URL = `https://apps.apple.com/app/id${APP_STORE_APP_ID}`
+export const GOOGLE_PLAY_URL = `https://play.google.com/store/apps/details?id=${ANDROID_PACKAGE_NAME}`


### PR DESCRIPTION
Build App Store / Google Play CTA links from live session UTM (via usePostHogAttribution) with a static per-CTA placement fallback, so installs can be attributed to their source. Google Play gets an encoded referrer; Apple gets ct/pt campaign tokens. Centralize the store URLs in utils/app-store.ts.