### PR TITLE
📈 Fire unified PlusAcquisition conversion event

### DIFF
--- a/app/composables/use-logger.ts
+++ b/app/composables/use-logger.ts
@@ -90,13 +90,14 @@ const INTERCOM_EVENT_ALLOWLIST = new Set<string>([
 // (timestamp, distinct_id, event, uuid) then collapses the pair into one row. The
 // matching server helper lives in likecoin-api-public/src/util/posthog.ts — the URL
 // format below is the contract; keep both sides identical or dedup breaks silently.
-// The 4 entries below are the subset of likecoin-api-public's SERVER_EVENT_MAP that the
+// The 5 entries below are the subset of likecoin-api-public's SERVER_EVENT_MAP that the
 // browser also fires (from success pages after a user action).
 const POSTHOG_SERVER_MIRRORED_EVENTS = new Set<string>([
   'begin_checkout',
   'purchase',
   'start_trial',
   'subscribe',
+  'plus_acquisition',
 ])
 
 // The host must be a fixed literal: substituting useRuntimeConfig().public.siteUrl or
@@ -147,6 +148,31 @@ export function useLogEvent(eventName: string, eventParams: EventParams = {}) {
           : undefined,
         content_ids: Array.isArray(items) ? items.map(i => i.id) : undefined,
         predicted_ltv: predictedLTV,
+      }, { eventID: eventId })
+    }
+
+    // Custom (non-standard) Meta events. PlusAcquisition is the unified Plus
+    // conversion signal fired alongside start_trial/subscribe; optimize ad sets on it.
+    const customEventNameMapping: { [key: string]: string } = {
+      plus_acquisition: 'PlusAcquisition',
+    }
+    if (customEventNameMapping[eventName]) {
+      const {
+        transaction_id: paymentId,
+        value,
+        currency,
+        predicted_ltv: predictedLTV,
+        is_trial: isTrial,
+      } = eventParams
+      const metaEventName = customEventNameMapping[eventName]
+      const eventId = paymentId ? `${metaEventName}_${paymentId}` : undefined
+      const { proxy } = useScriptMetaPixel()
+      proxy.fbq('trackCustom', metaEventName, {
+        currency,
+        value,
+        order_id: paymentId,
+        predicted_ltv: predictedLTV,
+        is_trial: isTrial,
       }, { eventID: eventId })
     }
   }

--- a/app/pages/plus/success.vue
+++ b/app/pages/plus/success.vue
@@ -151,29 +151,24 @@ onMounted(async () => {
       const PREDICTED_LTV_USD = 100
       const TRIAL_TO_PAID_CONVERSION = 0.5
 
-      if (isTrial) {
-        const trialExpectedValue = convertPrice(PREDICTED_LTV_USD * TRIAL_TO_PAID_CONVERSION)
-        useLogEvent('start_trial', {
-          transaction_id: paymentId.value,
-          currency: currency.value,
-          value: trialExpectedValue,
-          predicted_ltv: trialExpectedValue,
-          promotion_id: coupon.value,
-          promotion_name: coupon.value,
-        })
+      const conversionValue = isTrial
+        ? convertPrice(PREDICTED_LTV_USD * TRIAL_TO_PAID_CONVERSION)
+        : (isYearly.value ? yearlyPrice.value : monthlyPrice.value)
+      const conversionPredictedLTV = convertPrice(
+        isTrial ? PREDICTED_LTV_USD * TRIAL_TO_PAID_CONVERSION : PREDICTED_LTV_USD,
+      )
+      const conversionParams = {
+        transaction_id: paymentId.value,
+        currency: currency.value,
+        value: conversionValue,
+        predicted_ltv: conversionPredictedLTV,
+        promotion_id: coupon.value,
+        promotion_name: coupon.value,
       }
-      else {
-        const subscriptionPrice = isYearly.value ? yearlyPrice.value : monthlyPrice.value
-        const predictedLTV = convertPrice(PREDICTED_LTV_USD)
-        useLogEvent('subscribe', {
-          transaction_id: paymentId.value,
-          currency: currency.value,
-          value: subscriptionPrice,
-          predicted_ltv: predictedLTV,
-          promotion_id: coupon.value,
-          promotion_name: coupon.value,
-        })
-      }
+      useLogEvent(isTrial ? 'start_trial' : 'subscribe', conversionParams)
+      // Unified acquisition signal across web trial / web direct / app IAP
+      // (mirrored server-side from Stripe + RevenueCat). Optimize Meta on this.
+      useLogEvent('plus_acquisition', { ...conversionParams, is_trial: isTrial })
 
       await navigateTo(localeRoute({
         name: getRouteBaseName(route),


### PR DESCRIPTION
Single cross-platform Plus conversion signal fired alongside start_trial/subscribe so Meta can optimize one event regardless of web-trial, web-direct, or app-IAP entry. Mirrored server-side and deduped against the server copy via the shared paymentId (PostHog uuid
+ Meta eventID).