### PR TITLE
[TAS-6122] ✨ Fall back to native install attribution in analytics params

### DIFF
--- a/app/composables/use-analytics.ts
+++ b/app/composables/use-analytics.ts
@@ -1,3 +1,9 @@
+import { getInstallAttribution } from '~/utils/native-bridge'
+
+// Meta's click-attribution window; install click ids older than this are dropped
+// so stale clicks aren't sent to CAPI. UTM has no window (tagged instead).
+const INSTALL_CLICK_FRESHNESS_MS = 7 * 24 * 60 * 60 * 1000
+
 export function useAnalytics() {
   const getRouteQuery = useRouteQuery()
   const { proxy } = useScriptGoogleAnalytics()
@@ -43,21 +49,54 @@ export function useAnalytics() {
       }
     }
 
+    // Fall back to the install referrer only when the live session has no value,
+    // so last-touch always wins. Click ids (`gated`) are additionally limited to
+    // the freshness window. Any fill is flagged via `attributionSource` so it is
+    // never confused with live last-touch attribution downstream.
+    const install = getInstallAttribution()
+    const now = Date.now()
+    // Reject future timestamps (clock skew / malformed payload) — a negative
+    // difference would otherwise satisfy the window check and look "fresh".
+    const installFresh = !!install
+      && install.installedAt <= now
+      && now - install.installedAt < INSTALL_CLICK_FRESHNESS_MS
+    let usedInstall = false
+    const withInstall = (live: string | undefined, key: string, gated = false): string | undefined => {
+      if (live) return live
+      if (!install || (gated && !installFresh)) return live
+      const value = install.attribution[key]
+      if (!value) return live
+      usedInstall = true
+      return value
+    }
+
+    // Resolve every field before the return so `usedInstall` is fully
+    // accumulated, keeping `attributionSource` independent of property order.
+    const utmCampaign = withInstall(getRouteQuery('utm_campaign'), 'utm_campaign')
+    const utmMediumResolved = withInstall(resolvedUtmMedium || getRouteQuery('ll_medium') || utmMedium, 'utm_medium')
+    const utmSourceResolved = withInstall(resolvedUtmSource || getRouteQuery('ll_source') || utmSource, 'utm_source')
+    const utmContent = withInstall(getRouteQuery('utm_content'), 'utm_content')
+    const utmTerm = withInstall(getRouteQuery('utm_term'), 'utm_term')
+    const gadClickId = withInstall(getRouteQuery('gclid'), 'gclid', true)
+    const gadSource = withInstall(getRouteQuery('gad_source'), 'gad_source', true)
+    const fbClickId = withInstall(getRouteQuery('fbclid'), 'fbclid', true)
+
     return {
       gaClientId: gaClientId.value,
       gaSessionId: gaSessionId.value,
       referrer: referrer.value,
-      utmCampaign: getRouteQuery('utm_campaign'),
-      utmMedium: resolvedUtmMedium || getRouteQuery('ll_medium') || utmMedium,
-      utmSource: resolvedUtmSource || getRouteQuery('ll_source') || utmSource,
-      utmContent: getRouteQuery('utm_content'),
-      utmTerm: getRouteQuery('utm_term'),
-      gadClickId: getRouteQuery('gclid'),
-      gadSource: getRouteQuery('gad_source'),
-      fbClickId: getRouteQuery('fbclid'),
+      utmCampaign,
+      utmMedium: utmMediumResolved,
+      utmSource: utmSourceResolved,
+      utmContent,
+      utmTerm,
+      gadClickId,
+      gadSource,
+      fbClickId,
       fbp: fbp.value || undefined,
       fbc: fbc.value || undefined,
       posthogDistinctId: posthogDistinctId.value,
+      attributionSource: usedInstall ? 'install_referrer' : undefined,
     }
   }
 

--- a/app/composables/use-posthog-attribution.ts
+++ b/app/composables/use-posthog-attribution.ts
@@ -1,7 +1,10 @@
-// Mirrors the fallback logic in `useAnalytics.getAnalyticsParameters()` so
+// Mirrors the normalization in `useAnalytics.getAnalyticsParameters()` so
 // PostHog ends up with the same normalized values the backend (Airtable) gets:
 // `ll_source`/`ll_medium` collapse into `utm_source`/`utm_medium`, and
 // `srsltid` becomes `utm_source=google` + `utm_medium=organic`.
+// getAnalyticsParameters ALSO applies a native install-referrer fallback that
+// this helper intentionally omits — install attribution reaches PostHog via the
+// native SDK super properties and the backend conversion events instead.
 
 export const POSTHOG_ATTRIBUTION_KEYS = [
   'utm_source',

--- a/app/composables/use-subscription-checkout.ts
+++ b/app/composables/use-subscription-checkout.ts
@@ -176,6 +176,11 @@ export function useSubscriptionCheckout() {
         setAttribute('utmTerm', analyticsParams.utmTerm)
         setAttribute('referrer', analyticsParams.referrer)
         setAttribute('posthogDistinctId', analyticsParams.posthogDistinctId)
+        // Reflects THIS purchase's attribution origin. Unlike the sticky values
+        // above it must be cleared on live-attributed purchases, else a prior
+        // install flag persists (RC attributes are sticky). '' is the tombstone,
+        // as with plusGiftClassId. See useAnalytics.
+        attributes.attributionSource = analyticsParams.attributionSource || ''
 
         const result = await purchaseViaIAP(plan, user.value.likerId, attributes)
         if (result.status === 'cancelled') return

--- a/app/utils/native-bridge.ts
+++ b/app/utils/native-bridge.ts
@@ -13,6 +13,31 @@ export function isNativeFeatureSupported(feature: string): boolean {
   return Array.isArray(features) && features.includes(feature)
 }
 
+// Android install-referrer attribution the native shell exposes; null on web/iOS.
+// Reads off `window`, so the value is untrusted: validate and sanitize into a
+// fresh object (finite installedAt, string-only values) inside try/catch, so a
+// malformed injection can't throw into — or leak non-strings through — checkout's
+// getAnalyticsParameters. Returns null unless there's at least one fillable value.
+export function getInstallAttribution(): InstallAttribution | null {
+  if (typeof window === 'undefined') return null
+  try {
+    const raw: unknown = window.__nativeBridge?.installAttribution
+    if (!raw || typeof raw !== 'object') return null
+    const { installedAt, attribution } = raw as { installedAt?: unknown, attribution?: unknown }
+    if (typeof installedAt !== 'number' || !Number.isFinite(installedAt)) return null
+    if (!attribution || typeof attribution !== 'object') return null
+    const clean: Record<string, string> = {}
+    for (const [key, value] of Object.entries(attribution)) {
+      if (typeof value === 'string' && value.length > 0) clean[key] = value
+    }
+    return Object.keys(clean).length ? { attribution: clean, installedAt } : null
+  }
+  catch {
+    // Hostile/exotic shape (e.g. throwing getters) — treat as absent.
+    return null
+  }
+}
+
 export function isNativeIntercomAvailable(): boolean {
   return isNativeWebView() && isNativeFeatureSupported('intercom')
 }

--- a/shared/types/native-bridge.d.ts
+++ b/shared/types/native-bridge.d.ts
@@ -1,8 +1,18 @@
+interface InstallAttribution {
+  // utm_* / click ids parsed from the native Play install referrer.
+  attribution: Record<string, string>
+  // Epoch ms of first capture, for freshness gating (e.g. fbclid).
+  installedAt: number
+}
+
 interface Window {
   ReactNativeWebView?: {
     postMessage(message: string): void
   }
-  __nativeBridge?: { features?: readonly string[] }
+  __nativeBridge?: {
+    features?: readonly string[]
+    installAttribution?: InstallAttribution
+  }
 }
 
 interface WindowEventMap {


### PR DESCRIPTION
getAnalyticsParameters() fills utm_*/click-ids from the native shell's window.__nativeBridge.installAttribution only when the live session lacks them (last-touch wins). Click ids are gated to a 7-day freshness window so stale clicks aren't sent to CAPI, and any install-sourced fill is flagged via attributionSource so it's distinguishable from live attribution.