### PR TITLE
✨ Pack affiliate 'from' into app download referrer

### DIFF
--- a/app/composables/use-app-download-urls.ts
+++ b/app/composables/use-app-download-urls.ts
@@ -24,6 +24,7 @@ const APP_STORE_PROVIDER_TOKEN = ''
 
 export function useAppDownloadUrls(placement: AppDownloadPlacement) {
   const attribution = usePostHogAttribution()
+  const getRouteQuery = useRouteQuery()
 
   const params: Record<string, string> = {
     utm_source: attribution.utm_source || STATIC_SOURCE,
@@ -34,6 +35,10 @@ export function useAppDownloadUrls(placement: AppDownloadPlacement) {
   for (const key of ['utm_content', 'utm_term', 'gclid', 'gad_source', 'fbclid'] as const) {
     if (attribution[key]) params[key] = attribution[key]
   }
+  // Affiliate/channel id rides the referrer as its own `from` key (never folded
+  // into utm) so the native shell can credit an affiliate-driven install.
+  const affiliateFrom = getRouteQuery('from')
+  if (affiliateFrom) params.from = affiliateFrom
 
   // Play wants the whole UTM string as one URL-encoded `referrer` value.
   const referrer = encodeURIComponent(new URLSearchParams(params).toString())

--- a/shared/types/native-bridge.d.ts
+++ b/shared/types/native-bridge.d.ts
@@ -3,6 +3,9 @@ interface InstallAttribution {
   attribution: Record<string, string>
   // Epoch ms of first capture, for freshness gating (e.g. fbclid).
   installedAt: number
+  // Affiliate/channel id (`from`) — money-routing, kept separate from the
+  // analytics `attribution` map so it never feeds the last-touch UTM fallback.
+  affiliateFrom?: string
 }
 
 interface Window {


### PR DESCRIPTION
Include the live 'from' affiliate/channel id as its own key in the Google Play referrer (never folded into utm) so the native shell can credit an affiliate-driven install. Freeze the bridge contract by adding affiliateFrom to the InstallAttribution type.