### PR TITLE
🔍 Prefer author as book brand and fix e-book category casing

### DIFF
--- a/app/composables/use-book-info.ts
+++ b/app/composables/use-book-info.ts
@@ -69,10 +69,11 @@ export default function (
     return ''
   })
 
-  // A product's brand is its real brand, not the storefront; for books that's
-  // the publisher/imprint, falling back to author (self-published) then
-  // 3ook.com. Mirrors the API catalog feed (likecoin-api-public metaCatalog.ts).
-  const brandName = computed(() => publisherName.value || authorName.value || '3ook.com')
+  // A product's brand is its real brand, not the storefront; on an
+  // independent-author storefront the author is the strongest brand signal, so
+  // prefer author, fall back to publisher/imprint then 3ook.com. Mirrors the API
+  // catalog feed brand (likecoin-api-public catalogSource.ts resolveCatalogBrand).
+  const brandName = computed(() => authorName.value || publisherName.value || '3ook.com')
 
   const formattedPublishedDate = computed(() => {
     return bookInfo.publishedDate.value?.toISOString().split('T')[0] || ''

--- a/app/composables/use-structured-data.ts
+++ b/app/composables/use-structured-data.ts
@@ -315,7 +315,7 @@ export function useStructuredData(
     },
     {
       property: 'product:category',
-      content: 'Media > Books > E-Books',
+      content: 'Media > Books > E-books',
     },
     {
       property: 'product:condition',


### PR DESCRIPTION
On independent-author storefronts the author is the strongest brand signal, so resolve brand as author > publisher > 3ook.com, matching the API catalog feed (resolveCatalogBrand). Also correct the Google product category to the canonical "Media > Books > E-books" casing.