### PR TITLE
📈 Expand Meta Pixel standard event coverage

### DIFF
--- a/app/composables/use-logger.ts
+++ b/app/composables/use-logger.ts
@@ -116,12 +116,18 @@ export function useLogEvent(eventName: string, eventParams: EventParams = {}) {
   }
 
   try {
+    // Maps our GA4-style event names to Meta Pixel standard events. Prefer GA4
+    // recommended names as keys; app-specific names (e.g. store/library search
+    // submit) map to the closest Meta standard event.
     const eventNameMapping: { [key: string]: string } = {
       view_item: 'ViewContent',
       begin_checkout: 'InitiateCheckout',
       add_to_cart: 'AddToCart',
+      add_to_wishlist: 'AddToWishlist',
       purchase: 'Purchase',
-      search: 'Search',
+      store_search_submit: 'Search',
+      library_search_submit: 'Search',
+      sign_up: 'CompleteRegistration',
       start_trial: 'StartTrial',
       subscribe: 'Subscribe',
     }
@@ -132,10 +138,12 @@ export function useLogEvent(eventName: string, eventParams: EventParams = {}) {
         currency,
         items,
         predicted_ltv: predictedLTV,
+        search_term: searchString,
       } = eventParams
-      const eventId = paymentId ? `${eventNameMapping[eventName]}_${paymentId}` : undefined
+      const metaEventName = eventNameMapping[eventName]
+      const eventId = paymentId ? `${metaEventName}_${paymentId}` : undefined
       const { proxy } = useScriptMetaPixel()
-      proxy.fbq('track', eventNameMapping[eventName], {
+      proxy.fbq('track', metaEventName, {
         currency,
         value,
         order_id: paymentId,
@@ -148,6 +156,7 @@ export function useLogEvent(eventName: string, eventParams: EventParams = {}) {
           : undefined,
         content_ids: Array.isArray(items) ? items.map(i => i.id) : undefined,
         predicted_ltv: predictedLTV,
+        search_string: searchString,
       }, { eventID: eventId })
     }
 

--- a/app/pages/store/[nftClassId]/index.vue
+++ b/app/pages/store/[nftClassId]/index.vue
@@ -1740,8 +1740,8 @@ async function handleBookListButtonClick() {
     }
   }
   else {
-    // Add to book list
-    useLogEvent('add_to_cart', formattedLogPayload.value)
+    // Add to book list (a save-for-later wishlist, not the checkout cart)
+    useLogEvent('add_to_wishlist', formattedLogPayload.value)
     try {
       await bookListStore.addItem(
         nftClassId.value,

--- a/app/pages/store/index.vue
+++ b/app/pages/store/index.vue
@@ -1624,7 +1624,9 @@ async function handleSearchSubmit() {
   if (checkIsEVMAddress(searchInputValue.value)) {
     query = 'owner_wallet'
   }
-  useLogEvent(isLibraryTab.value ? 'library_search_submit' : 'store_search_submit')
+  // Omit search_term for wallet-address searches so we don't forward a persistent
+  // on-chain identifier to GA4/Meta; still fire the event to keep the search count.
+  useLogEvent(isLibraryTab.value ? 'library_search_submit' : 'store_search_submit', query === 'owner_wallet' ? {} : { search_term: searchInputValue.value })
   await navigateTo({ query: { [query]: searchInputValue.value } })
 }
 </script>

--- a/app/stores/account.ts
+++ b/app/stores/account.ts
@@ -496,6 +496,9 @@ export const useAccountStore = defineStore('account', () => {
         }
         useLogEvent('sign_up', {
           method: connector.id,
+          // Dedup key shared with the server CompleteRegistration CAPI event so
+          // Meta collapses the browser + server pair into one conversion.
+          transaction_id: walletAddress?.toLowerCase(),
         })
       }
 


### PR DESCRIPTION
Fire Search on store/library search submit (the previous mapping keyed a `search` event nobody emitted), reclassify "Add to 3ookList" as AddToWishlist instead of AddToCart, and map sign_up to CompleteRegistration. sign_up carries the lowercased wallet as its dedup key so Meta collapses the browser event with the server-side CompleteRegistration CAPI event.