### PR TITLE
📈 Capture UTM attribution on user registration

### DIFF
--- a/app/stores/account.ts
+++ b/app/stores/account.ts
@@ -58,6 +58,7 @@ export const useAccountStore = defineStore('account', () => {
   const { t: $t, locale } = useI18n()
   const { getLikeCoinV3BookMigrationSiteURL } = useLikeCoinV3MigrationSite()
   const likeCoinSessionAPI = useLikeCoinSessionAPI()
+  const { getAnalyticsParameters } = useAnalytics()
 
   const { ensureMagicSession } = useMagicSession()
   const loginModal = overlay.create(LazyLoginModal)
@@ -326,6 +327,7 @@ export const useAccountStore = defineStore('account', () => {
             magicUserId,
             magicDIDToken,
             locale: locale.value,
+            ...getAnalyticsParameters(),
           },
         })
 

--- a/server/api/register.post.ts
+++ b/server/api/register.post.ts
@@ -19,6 +19,10 @@ export default defineEventHandler(async (event) => {
         magicUserId: body.magicUserId,
         magicDIDToken: body.magicDIDToken,
         locale: body.locale?.startsWith('zh') ? 'zh' : 'en',
+        utmSource: body.utmSource || undefined,
+        utmMedium: body.utmMedium || undefined,
+        utmCampaign: body.utmCampaign || undefined,
+        sourceURL: body.referrer || undefined,
       },
     })
   }
@@ -88,6 +92,17 @@ export default defineEventHandler(async (event) => {
     likerId: userInfoRes.user,
     loginMethod: body.loginMethod,
     locale: body.locale,
+    utmSource: body.utmSource,
+    utmMedium: body.utmMedium,
+    utmCampaign: body.utmCampaign,
+    utmContent: body.utmContent,
+    utmTerm: body.utmTerm,
+    gadClickId: body.gadClickId,
+    gadSource: body.gadSource,
+    fbClickId: body.fbClickId,
+    gaClientId: body.gaClientId,
+    gaSessionId: body.gaSessionId,
+    referrer: body.referrer,
   })
 
   return userInfo

--- a/server/schemas/auth.ts
+++ b/server/schemas/auth.ts
@@ -38,6 +38,17 @@ export const RegisterBodySchema = v.object({
   magicUserId: v.optional(v.string()),
   magicDIDToken: v.optional(v.string()),
   locale: v.optional(v.string()),
+  utmSource: v.optional(v.string()),
+  utmMedium: v.optional(v.string()),
+  utmCampaign: v.optional(v.string()),
+  utmContent: v.optional(v.string()),
+  utmTerm: v.optional(v.string()),
+  gadClickId: v.optional(v.string()),
+  gadSource: v.optional(v.string()),
+  fbClickId: v.optional(v.string()),
+  gaClientId: v.optional(v.string()),
+  gaSessionId: v.optional(v.union([v.string(), v.number()])),
+  referrer: v.optional(v.string()),
 })
 
 export const AccountDeleteBodySchema = v.object({


### PR DESCRIPTION
Thread analytics params (UTM, click IDs, GA client/session, referrer) from the client register call through /api/register into the UserRegister pubsub event, and forward utmSource/medium/campaign + sourceURL to the LikeCoin /users/new API so registrations can be attributed to source.