### PR TITLE
[TAS-6133] 🐛 Keep Plus paywall open until checkout navigates

### DIFF
--- a/app/components/PaywallModal.vue
+++ b/app/components/PaywallModal.vue
@@ -3,7 +3,7 @@
     :title="$t('pricing_page_subscription')"
     :description="$t('pricing_page_subscription_description')"
     :fullscreen="isFullscreenModal"
-    :dismissible="props.isBackdropDismissible"
+    :dismissible="canDismissBackdrop"
     :transition="props.hasTransition"
     :modal="isModalityOn"
     :ui="{ content: modalContentClass }"
@@ -29,13 +29,16 @@
       >
         <template #header-action>
           <UButton
-            v-if="!props.isCloseButtonHidden"
+            v-if="isCloseButtonVisible"
             icon="i-material-symbols-close"
             :class="[
               'absolute',
               'z-10',
-              'top-0 phone:top-4',
-              'right-0 phone:right-4',
+              // Offset below the status bar / notch on fullscreen mobile so the
+              // close button stays reachable (the phone: variants only kick in
+              // on larger screens where the modal is windowed).
+              'top-[max(8px,env(safe-area-inset-top))] phone:top-4',
+              'right-1 phone:right-4',
               'max-phone:scale-75',
               'max-laptop:text-white',
               'cursor-pointer',
@@ -84,8 +87,15 @@ const props = withDefaults(
 
 const { t: $t } = useI18n()
 const isScreenSmall = useMediaQuery('(max-width: 1023px)')
+const { isIAPSupported } = useNativeIAP()
 
 const isFullscreenModal = computed(() => props.isFullscreen || isScreenSmall.value)
+
+// Never let a backdrop tap dismiss the paywall while the native purchase sheet is
+// loading in IAP mode — the user must resolve the purchase or use the X instead,
+// so keep the close button reachable there regardless of isCloseButtonHidden.
+const canDismissBackdrop = computed(() => props.isBackdropDismissible && !isIAPSupported.value)
+const isCloseButtonVisible = computed(() => !props.isCloseButtonHidden || isIAPSupported.value)
 
 const modalContentClass = computed(() => {
   const classes = [

--- a/app/components/PaywallModal.vue
+++ b/app/components/PaywallModal.vue
@@ -91,9 +91,9 @@ const { isIAPSupported } = useNativeIAP()
 
 const isFullscreenModal = computed(() => props.isFullscreen || isScreenSmall.value)
 
-// Never let a backdrop tap dismiss the paywall while the native purchase sheet is
-// loading in IAP mode — the user must resolve the purchase or use the X instead,
-// so keep the close button reachable there regardless of isCloseButtonHidden.
+// In the native app (IAP-supported), don't allow backdrop tap-to-dismiss: keep the
+// paywall visible until the user explicitly closes it or completes purchase.
+// Ensure the close button stays reachable in this mode regardless of isCloseButtonHidden.
 const canDismissBackdrop = computed(() => props.isBackdropDismissible && !isIAPSupported.value)
 const isCloseButtonVisible = computed(() => !props.isCloseButtonHidden || isIAPSupported.value)
 

--- a/app/composables/use-subscription-modal.ts
+++ b/app/composables/use-subscription-modal.ts
@@ -76,11 +76,20 @@ export function useSubscriptionModal() {
     props: getUpsellPlusModalProps(),
   })
 
-  const route = useRoute()
-  watch(() => route.path, () => {
+  // Close on committed navigation via router.afterEach rather than
+  // watch(() => route.path): callers such as the reader page unmount when
+  // checkout navigates (embedded plus-checkout, IAP plus-success). A route-path
+  // watcher's async-flushed callback can be torn down with the page before it
+  // runs, leaking the app-root overlay onto the next page; afterEach fires
+  // synchronously during navigation, before unmount. Guard on path so in-place
+  // query updates (e.g. UTM persistence) don't dismiss the modal.
+  const router = useRouter()
+  const stopCloseOnNavigate = router.afterEach((to, from) => {
+    if (to.path === from.path) return
     paywallModal.close()
     upsellPlusModal.close()
   })
+  onScopeDispose(stopCloseOnNavigate)
 
   async function openPaywallModal(options: OpenPaywallModalOptions = {}) {
     if (paywallModal.isOpen) {
@@ -93,7 +102,11 @@ export function useSubscriptionModal() {
       ...baseProps,
       ...modalProps,
       onSubscribe: (payload) => {
-        paywallModal.close()
+        // Keep the paywall open while checkout starts so the user is never dropped
+        // back to the book: the native IAP sheet takes a moment to appear, and the
+        // Stripe flow either navigates away (closing the tab's page) or, on error,
+        // leaves the paywall in place to retry. A successful in-app/embedded flow
+        // changes the route, which closes the modal via router.afterEach below.
         startSubscription({ ...payload, redirectRoute })
       },
     }


### PR DESCRIPTION
Pressing 繼續 closed the paywall before the native IAP sheet had time to appear (and before the Stripe redirect), dropping the user back onto the book with no dialog and no obvious way forward or back. Keep the modal open while checkout starts; a committed navigation now closes it.

- Replace the flaky watch(() => route.path) close with router.afterEach: the composable lives in the reader page, which unmounts on checkout navigation, so the async-flushed watcher could be torn down before it fired and leak the app-root overlay onto the next page.
- Lock backdrop dismissal in IAP mode and always show a close button, offset below the status bar / notch so there is a reachable escape.