### PR TITLE
🐛 Fix bookshelf stuck loading forever on a wedged request

### DIFF
--- a/app/stores/bookshelf.ts
+++ b/app/stores/bookshelf.ts
@@ -254,12 +254,15 @@ export const useBookshelfStore = defineStore('bookshelf', () => {
     isRefresh?: boolean
   }) {
     await fetchItems({ walletAddress, isRefresh })
+    // Track visited cursors so a misbehaving indexer cursor that cycles
+    // (A→B→A) can't loop forever — the exact-repeat check alone misses cycles.
+    const visitedKeys = new Set<number>()
     while (nextKey.value) {
-      const previousNextKey = nextKey.value
-      await fetchItems({ walletAddress })
-      if (nextKey.value === previousNextKey) {
+      if (visitedKeys.has(nextKey.value)) {
         break
       }
+      visitedKeys.add(nextKey.value)
+      await fetchItems({ walletAddress })
     }
   }
 

--- a/app/utils/api.ts
+++ b/app/utils/api.ts
@@ -7,7 +7,9 @@ import type { CollectiveBookNFT, CollectiveBookNFTsQueryOptions, CollectivePagin
  * GET/HEAD retry twice on a `<no response>`; payload methods opt in
  * via an explicit `retry`).
  */
-export const apiFetch = createRetryingFetch({ baseURL: '/api' })
+// Bound wedged requests (see createRetryingFetch) so awaits that gate loading
+// state — e.g. the bookshelf spinner — can't hang forever.
+export const apiFetch = createRetryingFetch({ baseURL: '/api', timeout: API_FETCH_TIMEOUT_MS })
 
 /**
  * Fetches the staking book listing through our same-origin `/api/store/staking-books`

--- a/shared/utils/fetch-retry.ts
+++ b/shared/utils/fetch-retry.ts
@@ -8,6 +8,27 @@ import type { FetchOptions } from 'ofetch'
 export const API_MAX_RETRIES = 2
 
 /**
+ * Per-attempt fetch timeout (ms). Paired with `API_MAX_RETRIES` as the
+ * shared retry/timeout policy; re-armed on each retry — see `createRetryingFetch`.
+ */
+export const API_FETCH_TIMEOUT_MS = 30_000
+
+/**
+ * `AbortSignal.timeout` polyfill — the iOS 15 WKWebView this bounds lacks it
+ * (landed in Safari 16.0). Aborts with a `TimeoutError` to match the native
+ * semantics; on iOS 15.1 the reason is dropped and falls back to `AbortError`.
+ */
+function createTimeoutSignal(timeout: number) {
+  const controller = new AbortController()
+  const timer = setTimeout(
+    () => controller.abort(new DOMException('Request timed out', 'TimeoutError')),
+    timeout,
+  )
+  controller.signal.addEventListener('abort', () => clearTimeout(timer), { once: true })
+  return controller.signal
+}
+
+/**
  * Wraps `$fetch.create` with a method-aware retry policy.
  *
  * A transient network drop surfaces in ofetch as a `<no response>`
@@ -16,11 +37,19 @@ export const API_MAX_RETRIES = 2
  * methods never), so an idempotent request on a flaky connection fails
  * hard instead of recovering.
  *
+ * Pass `timeout` (ms) to bound every attempt: a wedged connection (iOS
+ * WKWebView can poison one so it never responds) otherwise hangs the
+ * `await` forever, stranding loading state that only clears in a
+ * request's `finally`. We re-arm a fresh timeout signal per attempt in
+ * `onRequest` — ofetch's own `timeout` only arms when no signal is set
+ * and reuses the aborted signal across retries, so it would leave
+ * retries unbounded.
+ *
  * Do NOT use for clients that perform financial / on-chain mutations
  * (e.g. the LikeCoin session API) — a replayed purchase after a
  * `<no response>` double-charges.
  */
-export function createRetryingFetch(options: FetchOptions = {}) {
+export function createRetryingFetch({ timeout, ...options }: FetchOptions = {}) {
   return $fetch.create({
     ...options,
     retryDelay({ options }) {
@@ -34,6 +63,11 @@ export function createRetryingFetch(options: FetchOptions = {}) {
       if (options.retry === undefined) {
         const method = (options.method ?? 'GET').toUpperCase()
         options.retry = method === 'GET' || method === 'HEAD' ? API_MAX_RETRIES : 0
+      }
+      // Runs per attempt (including retries), so this re-arms the timeout
+      // on each retry and replaces any aborted signal from the last one.
+      if (timeout) {
+        options.signal = createTimeoutSignal(timeout)
       }
     },
   })

--- a/shared/utils/indexer.ts
+++ b/shared/utils/indexer.ts
@@ -42,7 +42,9 @@ export interface FetchAccountByBookNFTResponseData {
 
 export function getIndexerAPIFetch() {
   const config = useRuntimeConfig()
-  return createRetryingFetch({ baseURL: config.public.likeCoinEVMChainAPIEndpoint })
+  // Bound wedged requests (see createRetryingFetch) so the bookshelf pagination
+  // await can't hang, stranding the shelf on its loading spinner.
+  return createRetryingFetch({ baseURL: config.public.likeCoinEVMChainAPIEndpoint, timeout: API_FETCH_TIMEOUT_MS })
 }
 
 export interface IndexerQueryOptions {


### PR DESCRIPTION
The shelf spinner is bound to the store's isFetching, which only clears in a request's finally. createRetryingFetch set no timeout, so a wedged connection (e.g. a poisoned iOS WKWebView socket that never responds) hung the await forever and stranded the spinner.

Add an opt-in per-attempt timeout to createRetryingFetch — re-armed via a fresh AbortSignal.timeout in onRequest so retries stay bounded too (ofetch's own timeout only arms the first attempt) — and enable 30s on the indexer and first-party API clients on the shelf's load path.

Also harden fetchAllItems with a visited-cursor set so a misbehaving indexer cursor that cycles (A→B→A) can't loop forever.