### PR TITLE
🚀 Mark hero LCP images with fetchpriority=high

### DIFF
--- a/app/pages/about.vue
+++ b/app/pages/about.vue
@@ -44,6 +44,7 @@
           class="w-full max-w-xl -mt-10 mb-10"
           src="~/assets/images/mockup.png"
           alt="3ook.com"
+          fetchpriority="high"
         >
 
         <div

--- a/app/pages/app.vue
+++ b/app/pages/app.vue
@@ -55,6 +55,7 @@
               class="-my-40 max-md:scale-200 origin-center object-contain"
               src="~/assets/images/about/app-mockup.png"
               alt="3ook Reader App"
+              fetchpriority="high"
             >
           </aside>
         </div>


### PR DESCRIPTION
Prioritize the above-the-fold hero images on the app and about pages so the browser fetches the LCP element sooner.