### PR TITLE
🐛 Skip error modal on navigation-aborted store fetches

### DIFF
--- a/app/pages/store/index.vue
+++ b/app/pages/store/index.vue
@@ -1421,7 +1421,8 @@ async function fetchItems({ lazy = false, isRefresh = false } = {}): Promise<boo
       return true
     }
     catch (error) {
-      if (!isOnline.value) return false
+      // A navigation-aborted fetch isn't a failure worth a modal.
+      if (!isOnline.value || getIsAbortError(error)) return false
       await handleError(error, {
         title: isRefresh ? $t('store_fetch_items_error') : $t('store_fetch_more_items_error'),
       })
@@ -1434,7 +1435,7 @@ async function fetchItems({ lazy = false, isRefresh = false } = {}): Promise<boo
     return true
   }
   catch (error) {
-    if (!isOnline.value) return false
+    if (!isOnline.value || getIsAbortError(error)) return false
     await handleError(error, {
       title: isRefresh ? $t('store_fetch_items_error') : $t('store_fetch_more_items_error'),
       customHandlerMap: {

--- a/app/utils/error.ts
+++ b/app/utils/error.ts
@@ -39,6 +39,25 @@ export function parseErrorData<T>(error: unknown, key: string): T | undefined {
   return undefined
 }
 
+// A navigation/timeout-cancelled fetch surfaces as an `AbortError`/`TimeoutError`
+// DOMException, which ofetch rewraps in a `<no response>` FetchError under
+// `cause`. Benign (superseded, not failed), so callers can skip the error modal.
+export function getIsAbortError(error: unknown): boolean {
+  const isAbortName = (name?: string) => name === 'AbortError' || name === 'TimeoutError'
+  // DOMException is not an Error subclass, and may be absent in some SSR/test
+  // runtimes, so guard the global before the instanceof check.
+  const isAbortLike = (e: unknown): boolean => {
+    if (typeof DOMException !== 'undefined' && e instanceof DOMException) return isAbortName(e.name)
+    return e instanceof Error && isAbortName(e.name)
+  }
+  if (isAbortLike(error)) return true
+  if (error instanceof Error) {
+    if (isAbortLike((error as { cause?: unknown }).cause)) return true
+    if (/\baborted\b/i.test(error.message)) return true
+  }
+  return false
+}
+
 export function getErrorURL(error: unknown) {
   if (error instanceof FetchError) {
     return error.response?.url


### PR DESCRIPTION
A staking-books fetch cancelled by navigating away surfaced as a `<no response> Fetch is aborted` and raised the "無法載入書本" modal over the next page. Add getIsAbortError to detect the ofetch-wrapped AbortError/TimeoutError and bail out of fetchItems without a modal, alongside the existing offline guard.