### PR TITLE
[TAS-6117] ✨ Add live search suggestions to store search input

### DIFF
--- a/app/composables/use-store-search-suggestions.ts
+++ b/app/composables/use-store-search-suggestions.ts
@@ -1,0 +1,116 @@
+export interface StoreSearchSuggestion {
+  classId: string
+  title: string
+  thumbnailUrl?: string
+}
+
+export const SUGGESTION_MIN_TERM_LENGTH = 2
+const SUGGESTION_DEBOUNCE_MS = 300
+const SUGGESTION_LIMIT = 6
+const SUGGESTION_CACHE_MAX = 50
+
+/**
+ * Live search suggestions for the store/library search input. Debounces the
+ * term, hits the existing `/api/store/search` endpoint (sharing its 60s cache
+ * via `ts`), and returns the top matching books. Reads the raw endpoint
+ * response rather than the bookstore store getter so fresh matches aren't
+ * dropped by the hidden-book filter before their bookstore info has loaded.
+ */
+export function useStoreSearchSuggestions(
+  searchTerm: MaybeRefOrGetter<string>,
+  options: {
+    isLibrary?: MaybeRefOrGetter<boolean>
+    isComposing?: MaybeRefOrGetter<boolean>
+  } = {},
+) {
+  const suggestions = ref<StoreSearchSuggestion[]>([])
+  const isLoading = ref(false)
+  const { getResizedNormalizedImageURL } = useImageResize()
+
+  const debouncedTerm = refDebounced(
+    computed(() => toValue(searchTerm).trim()),
+    SUGGESTION_DEBOUNCE_MS,
+  )
+
+  // Cache resolved suggestions per scope+term so re-typing a cleared term is instant.
+  const cache = new Map<string, StoreSearchSuggestion[]>()
+
+  // Monotonic id, bumped on every run, so any short-circuit (cleared/cached
+  // term) or newer request invalidates an older in-flight fetch's late response.
+  let latestRequestId = 0
+
+  function clearSuggestions() {
+    if (suggestions.value.length) suggestions.value = []
+  }
+
+  watch(
+    [
+      debouncedTerm,
+      () => !!toValue(options.isLibrary),
+      () => !!toValue(options.isComposing),
+    ],
+    async ([term, isLibrary, isComposing]) => {
+      // Bump before the isComposing guard so entering composition also invalidates
+      // any in-flight fetch's late response.
+      const requestId = ++latestRequestId
+
+      // Reset here; only the fetch path below re-enables it, so cached/too-short/
+      // composing runs never spin and a superseded run stops the spinner cleanly.
+      isLoading.value = false
+
+      // Hold results steady mid-IME-composition; the compositionend flip re-runs this.
+      if (isComposing) return
+
+      if (term.length < SUGGESTION_MIN_TERM_LENGTH) {
+        clearSuggestions()
+        return
+      }
+
+      const cacheKey = `${isLibrary ? '1' : '0'}:${term}`
+      const cached = cache.get(cacheKey)
+      if (cached) {
+        suggestions.value = cached
+        return
+      }
+
+      isLoading.value = true
+      try {
+        const result = await fetchBookstoreCMSPublicationsBySearchTerm(term, {
+          limit: SUGGESTION_LIMIT,
+          ts: getTimestampRoundedToMinute(),
+          isLibrary,
+        })
+        if (requestId !== latestRequestId) return
+
+        const items = result.records
+          .filter(record => record.classId && record.title)
+          .slice(0, SUGGESTION_LIMIT)
+          .map(record => ({
+            classId: normalizeNFTClassId(record.classId),
+            title: record.title!,
+            // Route the raw (possibly ipfs://) thumbnailUrl through the resize proxy
+            // once here so the CSP-safe URL isn't rebuilt on every keystroke re-render.
+            thumbnailUrl: record.imageUrl ? getResizedNormalizedImageURL(record.imageUrl, { size: 100 }) : undefined,
+          }))
+        cache.set(cacheKey, items)
+        // Cap the per-instance cache so a long session of distinct searches can't grow it unbounded.
+        if (cache.size > SUGGESTION_CACHE_MAX) {
+          const oldestKey = cache.keys().next().value
+          if (oldestKey) cache.delete(oldestKey)
+        }
+        suggestions.value = items
+      }
+      catch {
+        if (requestId === latestRequestId) clearSuggestions()
+      }
+      finally {
+        if (requestId === latestRequestId) isLoading.value = false
+      }
+    },
+  )
+
+  return {
+    suggestions: readonly(suggestions),
+    isLoading: readonly(isLoading),
+  }
+}

--- a/app/pages/store/index.vue
+++ b/app/pages/store/index.vue
@@ -192,7 +192,7 @@
             <ul
               v-if="shouldShowSearchSuggestions"
               data-search-suggestions
-              class="border-t border-default max-h-80 overflow-y-auto py-2"
+              class="border-t border-default max-h-[min(20rem,50svh)] overflow-y-auto py-2"
               :aria-label="$t('store_search_suggestions_label')"
             >
               <li

--- a/app/pages/store/index.vue
+++ b/app/pages/store/index.vue
@@ -130,7 +130,9 @@
           v-model:open="isSearchInputOpen"
           :close="false"
           :ui="{
-            content: 'max-phone:top-30 top-1/4',
+            // translate-y-0 cancels the modal theme's default -translate-y-1/2 so the
+            // box anchors by its top edge and grows downward as suggestions appear.
+            content: 'max-phone:top-30 top-1/4 translate-y-0',
             body: 'p-0 sm:p-0',
             footer: [
               'flex',
@@ -159,6 +161,7 @@
                 v-model="searchInputValue"
                 class="w-full"
                 icon="i-material-symbols-search-rounded"
+                :loading="isSearchSuggestionsLoading"
                 size="xl"
                 variant="none"
                 :placeholder="$t('store_search_input_placeholder')"
@@ -167,7 +170,9 @@
                   base: 'py-5 [&::-webkit-search-cancel-button]:appearance-none',
                   trailing: 'pe-2',
                 }"
-                @blur="isSearchInputOpen = false"
+                @compositionstart="isSearchInputComposing = true"
+                @compositionend="isSearchInputComposing = false"
+                @blur="handleSearchInputBlur"
               >
                 <template
                   v-if="searchInputValue.length"
@@ -183,6 +188,39 @@
                 </template>
               </UInput>
             </form>
+
+            <ul
+              v-if="shouldShowSearchSuggestions"
+              data-search-suggestions
+              class="border-t border-default max-h-80 overflow-y-auto py-2"
+              :aria-label="$t('store_search_suggestions_label')"
+            >
+              <li
+                v-for="suggestion in searchSuggestions"
+                :key="suggestion.classId"
+              >
+                <!-- mousedown.prevent keeps focus on the input so its blur
+                     handler doesn't close the modal before the click lands. -->
+                <button
+                  type="button"
+                  class="flex w-full items-center gap-3 px-4 py-2 text-left hover:bg-elevated focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary"
+                  @mousedown.prevent
+                  @click="handleSearchSuggestionSelect(suggestion)"
+                >
+                  <img
+                    v-if="suggestion.thumbnailUrl"
+                    :src="suggestion.thumbnailUrl"
+                    alt=""
+                    class="h-12 w-9 shrink-0 rounded object-cover"
+                    loading="lazy"
+                  >
+                  <span
+                    class="line-clamp-2 text-sm"
+                    v-text="suggestion.title"
+                  />
+                </button>
+              </li>
+            </ul>
           </template>
         </UModal>
 
@@ -1607,10 +1645,47 @@ async function handleLibraryLogoClick() {
 
 const isSearchInputOpen = ref(false)
 const searchInputValue = ref('')
+// Track IME composition so live suggestions don't fire on half-typed CJK input.
+const isSearchInputComposing = ref(false)
+
+const { suggestions: searchSuggestions, isLoading: isSearchSuggestionsLoading } = useStoreSearchSuggestions(
+  searchInputValue,
+  {
+    isLibrary: isLibraryTab,
+    isComposing: isSearchInputComposing,
+  },
+)
+
+const shouldShowSearchSuggestions = computed(() =>
+  isSearchInputOpen.value
+  && searchInputValue.value.trim().length >= SUGGESTION_MIN_TERM_LENGTH
+  && searchSuggestions.value.length > 0,
+)
+
+// Keep the modal open when focus moves into the suggestions list so keyboard users
+// can Tab from the input to a suggestion; close on any other blur.
+function handleSearchInputBlur(event: FocusEvent) {
+  const nextFocused = event.relatedTarget as HTMLElement | null
+  if (nextFocused?.closest('[data-search-suggestions]')) return
+  isSearchInputOpen.value = false
+}
 
 function handleSearchTagClick() {
   useLogEvent(isLibraryTab.value ? 'library_tag_search_click' : 'store_tag_search_click')
   searchInputValue.value = ''
+}
+
+async function handleSearchSuggestionSelect(suggestion: StoreSearchSuggestion) {
+  useLogEvent(isLibraryTab.value ? 'library_search_suggestion_click' : 'store_search_suggestion_click', {
+    search_term: searchInputValue.value,
+    nft_class_id: suggestion.classId,
+    item_name: suggestion.title,
+  })
+  isSearchInputOpen.value = false
+  await navigateTo(localeRoute({
+    name: isLibraryTab.value ? 'library-nftClassId' : 'store-nftClassId',
+    params: { nftClassId: suggestion.classId },
+  }))
 }
 
 function handleClearSearchInputButton() {

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -935,6 +935,7 @@
   "store_search_input_placeholder": "Search...",
   "store_search_label": "Search",
   "store_search_prefix": "Search: ",
+  "store_search_suggestions_label": "Search suggestions",
   "store_showing_recommendations": "Here are some recommended books for you",
   "store_tag_more_categories": "More",
   "store_tag_more_categories_label": "More categories",

--- a/i18n/locales/zh-Hant.json
+++ b/i18n/locales/zh-Hant.json
@@ -935,6 +935,7 @@
   "store_search_input_placeholder": "搜尋⋯⋯",
   "store_search_label": "搜尋",
   "store_search_prefix": "搜尋：",
+  "store_search_suggestions_label": "搜尋建議",
   "store_showing_recommendations": "以下是為你推薦的書籍",
   "store_tag_more_categories": "更多類別",
   "store_tag_more_categories_label": "更多類別",

--- a/test/unit/use-store-search-suggestions.test.ts
+++ b/test/unit/use-store-search-suggestions.test.ts
@@ -1,0 +1,147 @@
+import { nextTick, ref } from 'vue'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+import { useStoreSearchSuggestions } from '~/composables/use-store-search-suggestions'
+
+// Mirrors SUGGESTION_DEBOUNCE_MS in the composable (not exported).
+const DEBOUNCE_MS = 300
+
+const { mockFetch } = vi.hoisted(() => ({ mockFetch: vi.fn() }))
+
+mockNuxtImport('fetchBookstoreCMSPublicationsBySearchTerm', () => mockFetch)
+mockNuxtImport('useImageResize', () => () => ({
+  getResizedNormalizedImageURL: (url: string, opts?: { size?: number }) => `resized:${url}:${opts?.size}`,
+  getResizedImageURL: (url: string) => url,
+}))
+mockNuxtImport('normalizeNFTClassId', () => (id?: string) => id ?? '')
+mockNuxtImport('getTimestampRoundedToMinute', () => () => 0)
+
+// Let awaited fetch continuations and the Vue watcher scheduler settle.
+async function flush() {
+  for (let i = 0; i < 3; i++) await Promise.resolve()
+  await nextTick()
+}
+
+describe('useStoreSearchSuggestions', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    mockFetch.mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('debounces the term, then populates suggestions with resized thumbnails', async () => {
+    mockFetch.mockResolvedValue({
+      records: [
+        { classId: 'a', title: 'Book A', imageUrl: 'ipfs://a' },
+        { classId: 'b', title: 'Book B', imageUrl: '' },
+      ],
+    })
+    const term = ref('')
+    const { suggestions } = useStoreSearchSuggestions(term)
+
+    term.value = 'harry'
+    expect(mockFetch).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(DEBOUNCE_MS)
+
+    expect(mockFetch).toHaveBeenCalledOnce()
+    expect(suggestions.value).toEqual([
+      { classId: 'a', title: 'Book A', thumbnailUrl: 'resized:ipfs://a:100' },
+      { classId: 'b', title: 'Book B', thumbnailUrl: undefined },
+    ])
+  })
+
+  it('does not fetch for terms shorter than the minimum length', async () => {
+    const term = ref('')
+    const { suggestions } = useStoreSearchSuggestions(term)
+
+    term.value = 'a'
+    await vi.advanceTimersByTimeAsync(DEBOUNCE_MS)
+
+    expect(mockFetch).not.toHaveBeenCalled()
+    expect(suggestions.value).toEqual([])
+  })
+
+  it('holds off fetching while IME composition is active, then fetches once it ends', async () => {
+    mockFetch.mockResolvedValue({ records: [{ classId: 'a', title: 'A', imageUrl: 'ipfs://a' }] })
+    const term = ref('')
+    const isComposing = ref(true)
+    const { suggestions } = useStoreSearchSuggestions(term, { isComposing })
+
+    term.value = 'harry'
+    await vi.advanceTimersByTimeAsync(DEBOUNCE_MS)
+    expect(mockFetch).not.toHaveBeenCalled()
+
+    isComposing.value = false
+    await flush()
+
+    expect(mockFetch).toHaveBeenCalledOnce()
+    expect(suggestions.value).toEqual([{ classId: 'a', title: 'A', thumbnailUrl: 'resized:ipfs://a:100' }])
+  })
+
+  it('ignores a stale response so it cannot overwrite a newer term', async () => {
+    const resolvers: Array<(value: unknown) => void> = []
+    mockFetch.mockImplementation(() => new Promise((resolve) => {
+      resolvers.push(resolve)
+    }))
+    const term = ref('')
+    const { suggestions } = useStoreSearchSuggestions(term)
+
+    term.value = 'aa'
+    await vi.advanceTimersByTimeAsync(DEBOUNCE_MS)
+    term.value = 'bb'
+    await vi.advanceTimersByTimeAsync(DEBOUNCE_MS)
+
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+    expect(resolvers).toHaveLength(2)
+
+    // Resolve the newer request first, then let the stale earlier one land late.
+    resolvers[1]!({ records: [{ classId: 'new', title: 'New', imageUrl: 'ipfs://new' }] })
+    await flush()
+    resolvers[0]!({ records: [{ classId: 'old', title: 'Old', imageUrl: 'ipfs://old' }] })
+    await flush()
+
+    expect(suggestions.value).toEqual([{ classId: 'new', title: 'New', thumbnailUrl: 'resized:ipfs://new:100' }])
+  })
+
+  it('serves a repeated term from cache without refetching', async () => {
+    mockFetch.mockResolvedValue({ records: [{ classId: 'a', title: 'A', imageUrl: 'ipfs://a' }] })
+    const term = ref('')
+    const { suggestions } = useStoreSearchSuggestions(term)
+
+    term.value = 'harry'
+    await vi.advanceTimersByTimeAsync(DEBOUNCE_MS)
+    expect(mockFetch).toHaveBeenCalledOnce()
+
+    // Clear to a too-short term, then retype the same term: it should hit the cache.
+    term.value = 'h'
+    await vi.advanceTimersByTimeAsync(DEBOUNCE_MS)
+    term.value = 'harry'
+    await vi.advanceTimersByTimeAsync(DEBOUNCE_MS)
+
+    expect(mockFetch).toHaveBeenCalledOnce()
+    expect(suggestions.value).toEqual([{ classId: 'a', title: 'A', thumbnailUrl: 'resized:ipfs://a:100' }])
+  })
+
+  it('flags isLoading only while a fetch is in flight', async () => {
+    const resolvers: Array<(value: unknown) => void> = []
+    mockFetch.mockImplementation(() => new Promise((resolve) => {
+      resolvers.push(resolve)
+    }))
+    const term = ref('')
+    const { isLoading } = useStoreSearchSuggestions(term)
+
+    expect(isLoading.value).toBe(false)
+
+    term.value = 'harry'
+    await vi.advanceTimersByTimeAsync(DEBOUNCE_MS)
+    expect(isLoading.value).toBe(true)
+
+    resolvers[0]!({ records: [] })
+    await flush()
+    expect(isLoading.value).toBe(false)
+  })
+})


### PR DESCRIPTION
Show a debounced dropdown of matching books as the user types in the store/library search, selecting one opens that book directly. Reuses the existing /api/store/search endpoint; skips fetching mid-IME-composition for CJK input and guards against stale responses overwriting newer terms.