### PR TITLE
🐛 Prevent Magic login from hanging on missing email or session

### DIFF
--- a/app/composables/use-magic-session.ts
+++ b/app/composables/use-magic-session.ts
@@ -10,17 +10,7 @@ export function useMagicSession() {
       : undefined
     if (!connector || connector.id !== 'magic') return
 
-    let needsReauth = false
-    try {
-      const magic = await resolveMagicFromConnector(connector)
-      if (!magic) return
-      needsReauth = !(await magic.user.isLoggedIn())
-    }
-    catch {
-      needsReauth = true
-    }
-
-    if (!needsReauth) return
+    if (await isMagicSessionAlive(connector)) return
 
     const accountStore = useAccountStore()
     const { user } = useUserSession()

--- a/app/stores/account.ts
+++ b/app/stores/account.ts
@@ -382,6 +382,13 @@ export const useAccountStore = defineStore('account', () => {
       connector = $wagmiConfig.connectors.find(c => c.id === lastUsedConnectorId)
     }
     if (connector) {
+      // Magic can only reconnect silently while its client session is alive; if
+      // it has expired, connectAsync falls into the connector's OTP form with no
+      // email and hangs, so fall back to the explicit login flow instead.
+      if (connector.id === 'magic' && !(await isMagicSessionAlive(connector))) {
+        await login()
+        return
+      }
       await connectAsync({
         connector,
         chainId: chainId.value,
@@ -402,14 +409,18 @@ export const useAccountStore = defineStore('account', () => {
         await disconnectAsync().catch(() => {})
       }
       let magicEmail: string | undefined = preferredEmail
-      if (!connectorId || !connectors.some((c: { id: string }) => c.id === connectorId)) {
+      // Magic needs an email to seed its OTP input; entering connectAsync without
+      // one hangs the connector, so treat a magic login lacking an email as
+      // unresolved and fall back to the panel to collect it.
+      const isMagicWithoutEmail = () => connectorId === 'magic' && !magicEmail
+      if (!connectorId || !connectors.some((c: { id: string }) => c.id === connectorId) || isMagicWithoutEmail()) {
         useLogEvent('login_panel_open')
         // Cast because the Lazy* async-component wrapper hides LoginModal's close-payload from useOverlay's inference
         const result = await loginModal.open().result as { id: string, email?: string } | undefined
         connectorId = result?.id
         magicEmail = result?.email
       }
-      if (!connectorId) {
+      if (!connectorId || isMagicWithoutEmail()) {
         useLogEvent('login_panel_dismiss')
         return
       }

--- a/app/utils/magic.ts
+++ b/app/utils/magic.ts
@@ -8,3 +8,15 @@ export async function resolveMagicFromConnector(connector: unknown): Promise<Mag
   }
   return (connector as { getMagic: () => Promise<Magic> }).getMagic()
 }
+
+// Whether the connector's Magic client session is still valid. A missing SDK or
+// any probe error counts as expired so callers re-authenticate rather than hang.
+export async function isMagicSessionAlive(connector: unknown): Promise<boolean> {
+  try {
+    const magic = await resolveMagicFromConnector(connector)
+    return !!magic && await magic.user.isLoggedIn()
+  }
+  catch {
+    return false
+  }
+}


### PR DESCRIPTION
The custom-UI Magic connector never settles when it reads no valid email input, freezing the login spinner with no error. Guard the two entry points that could reach it without one: skip silent reconnect in restoreConnection when the client session is dead, and route a magic login lacking an email back to the panel. Extract isMagicSessionAlive to share the liveness probe with use-magic-session.