### PR TITLE
🐛 Show affiliate alert for any valid Liker ID referrer

### DIFF
--- a/app/pages/member.vue
+++ b/app/pages/member.vue
@@ -32,7 +32,7 @@
     </template>
 
     <template
-      v-if="activeAffiliate"
+      v-if="affiliateLikerId"
       #affiliate-alert
     >
       <AffiliateAlert class="mb-6" />


### PR DESCRIPTION
The alert slot was gated on an active affiliate config, so a `from=@id` referral from a user without monetization enabled showed nothing. AffiliateAlert already resolves and validates the Liker profile itself, and stays hidden when it cannot, so gate on the referrer ID instead.