### PR TITLE
✨ Preview a referrer's built-in voice as TTS sample on /member

### DIFF
--- a/app/components/PricingPageContent.vue
+++ b/app/components/PricingPageContent.vue
@@ -274,6 +274,7 @@
 <script setup lang="ts">
 import type { PricingPageContentProps } from './PricingPageContent.props'
 import { resolveIsPaidTrial } from '~~/shared/utils/pricing'
+import { getSystemVoiceByOwnerLikerId } from '~~/shared/utils/tts-sample'
 
 const localeRoute = useLocaleRoute()
 const isDesktopScreen = useDesktopScreen()
@@ -310,8 +311,13 @@ const hasAffiliateVoices = computed(() => (props.affiliateVoices?.length ?? 0) >
 
 const isAffiliateBooksModalOpen = ref(false)
 
+// A referrer owning a built-in voice has no affiliate voices, but their sample
+// is still the reason they shared the link — show the samples card for them.
+const hasReferrerSystemVoice = computed(() => !!getSystemVoiceByOwnerLikerId(props.affiliateLikerId))
+
 const shouldShowTTSSamples = computed(() => {
-  return getRouteQuery('samples') === '1' || isCustomVoiceCampaign.value || hasAffiliateVoices.value
+  return getRouteQuery('samples') === '1' || isCustomVoiceCampaign.value
+    || hasAffiliateVoices.value || hasReferrerSystemVoice.value
 })
 
 const abTest = shouldShowTTSSamples.value

--- a/app/composables/use-tts-samples-player.ts
+++ b/app/composables/use-tts-samples-player.ts
@@ -1,6 +1,7 @@
 import type { AffiliateVoiceData } from '~~/shared/types/custom-voice'
+import type { TTSSampleLanguage } from '~~/shared/utils/tts-sample'
 import { encodeAffiliateVoiceId } from '~~/shared/utils/tts-sig'
-import { getAffiliateSampleScript, getTTSSampleText } from '~~/shared/utils/tts-sample'
+import { getAffiliateSampleScript, getSystemVoiceByOwnerLikerId, getTTSSampleText } from '~~/shared/utils/tts-sample'
 
 interface TTSSamplesPlayerOptions {
   onError?: (error: unknown) => void
@@ -16,6 +17,12 @@ export function useTTSSamplesPlayer(options: TTSSamplesPlayerOptions = {}) {
   const affiliateVoicesComputed = computed(() => toValue(affiliateVoices) ?? [])
   const { getVoiceAvatar } = useTTSVoice({ affiliateVoices: affiliateVoicesComputed })
 
+  function getSampleDescription(language: TTSSampleLanguage) {
+    return language === 'zh-TW'
+      ? $t('tts_sample_mandarin')
+      : $t('tts_sample_cantonese')
+  }
+
   const affiliateSamples = computed<TTSSample[]>(() => {
     const voices = affiliateVoicesComputed.value
     const likerId = toValue(affiliateLikerId)
@@ -27,9 +34,7 @@ export function useTTSSamplesPlayer(options: TTSSamplesPlayerOptions = {}) {
       const language = script?.language
         ?? (voice.language?.toLowerCase().startsWith('zh-tw') ? 'zh-TW' : 'zh-HK')
       const sampleId = `affiliate-${voice.id}`
-      const description = language === 'zh-TW'
-        ? $t('tts_sample_mandarin')
-        : $t('tts_sample_cantonese')
+      const description = getSampleDescription(language)
       const segmentTexts = script?.segments ?? [getTTSSampleText(language)]
       const baseQuery = new URLSearchParams({
         voice_id: encodedVoiceId,
@@ -114,8 +119,37 @@ export function useTTSSamplesPlayer(options: TTSSamplesPlayerOptions = {}) {
     })
   })
 
+  // A referrer who owns a built-in voice gets it surfaced alongside the
+  // defaults, even without an affiliate config.
+  const referrerSystemVoiceSamples = computed<TTSSample[]>(() => {
+    const voice = getSystemVoiceByOwnerLikerId(toValue(affiliateLikerId))
+    if (!voice) return []
+    const languageVoice = `${voice.language}_${voice.voiceId}`
+    const sampleId = `system-${voice.voiceId}`
+    const query = new URLSearchParams({
+      voice_id: voice.voiceId,
+      language: voice.language,
+    }).toString()
+    return [{
+      id: sampleId,
+      title: voice.name,
+      description: getSampleDescription(voice.language),
+      segments: [{
+        id: `${sampleId}-segment-0`,
+        text: getTTSSampleText(voice.language),
+        sectionIndex: 0,
+        cfi: undefined,
+        audioSrc: `/api/tts/sample?${query}`,
+      }],
+      language: voice.language,
+      languageVoice,
+      avatarSrc: getVoiceAvatar(languageVoice),
+    }]
+  })
+
   const samples = computed<TTSSample[]>(() => [
     ...defaultSamples.value,
+    ...referrerSystemVoiceSamples.value,
     ...affiliateSamples.value,
   ])
 

--- a/shared/utils/tts-sample.ts
+++ b/shared/utils/tts-sample.ts
@@ -60,3 +60,25 @@ export function getAffiliateSampleScript(
   if (!likerId || !voiceSlot) return undefined
   return AFFILIATE_SAMPLE_SCRIPTS[normalizeLikerId(likerId)]?.[voiceSlot]
 }
+
+// Built-in TTS voices lent by their owner. A referral from the owner surfaces
+// their voice sample even when they have no affiliate config or custom voice.
+export interface SystemVoice {
+  voiceId: string
+  name: string
+  language: TTSSampleLanguage
+}
+
+// Keyed by owner Liker ID. Unlike AFFILIATE_SAMPLE_SCRIPTS these have no
+// testnet counterpart to duplicate — the owners hold no sepolia account.
+const SYSTEM_VOICES_BY_OWNER: Record<string, SystemVoice> = {
+  withthepoons: { voiceId: 'phoebe', name: 'Phoebe', language: 'zh-HK' },
+  astrohsu99: { voiceId: 'astro', name: '許明恩', language: 'zh-TW' },
+}
+
+export function getSystemVoiceByOwnerLikerId(
+  likerId: string | undefined,
+): SystemVoice | undefined {
+  if (!likerId) return undefined
+  return SYSTEM_VOICES_BY_OWNER[normalizeLikerId(likerId)]
+}


### PR DESCRIPTION
Owners of a built-in voice have no affiliate config, so their referral showed no voice sample at all — the very thing they shared the link for. Map owner Liker ID to voice, surface that sample alongside the defaults, and open the samples card for it. Audio comes from the existing non-affiliate branch of /api/tts/sample, so no server change is needed.