### PR TITLE
🐛 Serve uploaded book files chunked to lift Cloud Run's 32 MiB cap

### DIFF
--- a/app/composables/use-book-file-loader.ts
+++ b/app/composables/use-book-file-loader.ts
@@ -1,3 +1,5 @@
+import { ORIGINAL_CONTENT_LENGTH_HEADER } from '~~/shared/utils/book-file'
+
 // Abort a book-file load when no progress is made within this window. iOS
 // WebKit wedges in-flight cross-origin fetches after the app is backgrounded,
 // which would otherwise strand the reader on the loading bar forever.
@@ -182,7 +184,7 @@ export default function () {
       if (!streamReader) return
 
       const contentLength = Number(
-        res?.headers?.get('X-Original-Content-Length')
+        res?.headers?.get(ORIGINAL_CONTENT_LENGTH_HEADER)
         || res?.headers?.get('Content-Length'),
       )
       if (contentLength) {

--- a/server/api/uploaded-books/[bookId]/file.get.ts
+++ b/server/api/uploaded-books/[bookId]/file.get.ts
@@ -1,9 +1,15 @@
+import { ORIGINAL_CONTENT_LENGTH_HEADER } from '~~/shared/utils/book-file'
 import { UploadedBookIdParamsSchema } from '~~/server/schemas/uploaded-book'
 
 const CONTENT_TYPE_MAP: Record<string, string> = {
   epub: 'application/epub+zip',
   pdf: 'application/pdf',
 }
+
+// Cloud Run caps a fixed-length HTTP/1 response body at 32 MiB. Ranges carry a
+// content-length, so cap each 206 well below it; a client asking for more gets
+// a short 206 and requests the rest.
+const MAX_RANGE_CHUNK_SIZE = 24 * 1024 * 1024
 
 export default defineEventHandler(async (event) => {
   const { wallet, isLikerPlus } = await requireUserWalletWithStatus(event)
@@ -48,7 +54,8 @@ export default defineEventHandler(async (event) => {
   if (rangeHeader && totalSize) {
     const range = parseRangeHeader(rangeHeader, totalSize)
     if (range) {
-      const { start, end } = range
+      const { start, end: requestedEnd } = range
+      const end = Math.min(requestedEnd, start + MAX_RANGE_CHUNK_SIZE - 1)
       setResponseStatus(event, 206)
       setHeader(event, 'content-range', `bytes ${start}-${end}/${totalSize}`)
       setHeader(event, 'content-length', end - start + 1)
@@ -56,8 +63,11 @@ export default defineEventHandler(async (event) => {
     }
   }
 
+  // Deliberately no `content-length`: that would frame the body as fixed-length,
+  // which Cloud Run caps at 32 MiB. Omitting it lets Node fall back to
+  // `Transfer-Encoding: chunked`, which is uncapped.
   if (totalSize) {
-    setHeader(event, 'content-length', totalSize)
+    setHeader(event, ORIGINAL_CONTENT_LENGTH_HEADER, totalSize)
   }
   return sendStream(event, file.createReadStream())
 })

--- a/shared/utils/book-file.ts
+++ b/shared/utils/book-file.ts
@@ -1,0 +1,6 @@
+// Wire contract for a book file's byte size. Large files can't carry a real
+// `content-length` — a fixed-length body would hit Cloud Run's 32 MiB response
+// cap — so the size travels in this header instead. Both sides MUST go through
+// this symbol: a mismatch degrades silently to chunk accumulation (~2x peak
+// memory) with no error. Also emitted by the LikeCoin API's /ebook-cors/.
+export const ORIGINAL_CONTENT_LENGTH_HEADER = 'x-original-content-length'


### PR DESCRIPTION
Uploaded EPUBs over 32 MB failed to load. Firebase App Hosting runs on Cloud Run, which caps a fixed-length HTTP/1 response body at 32 MiB; setting `content-length` was what framed the body as fixed-length. Omitting it lets Node fall back to `Transfer-Encoding: chunked`, which is uncapped. The size now travels as `x-original-content-length`, which the client already prefers, so the progress bar and its pre-allocated buffer keep working.

Range responses carry a real `content-length` by definition, so clamp each 206 to 24 MiB — a `bytes=0-` on a large book would otherwise hit the same cap.

Promote the header name to a shared constant, mirroring `tts-server-timing.ts`: a mismatch across the client/server contract degrades silently to chunk accumulation with no error.