### PR TITLE
📈 Forward Meta match keys to registration CAPI event

### DIFF
--- a/server/api/register.post.ts
+++ b/server/api/register.post.ts
@@ -23,6 +23,10 @@ export default defineEventHandler(async (event) => {
         utmMedium: body.utmMedium || undefined,
         utmCampaign: body.utmCampaign || undefined,
         sourceURL: body.referrer || undefined,
+        // Meta match keys for the server-side CompleteRegistration CAPI event
+        fbClickId: body.fbClickId || undefined,
+        fbp: body.fbp || undefined,
+        fbc: body.fbc || undefined,
       },
     })
   }

--- a/server/schemas/auth.ts
+++ b/server/schemas/auth.ts
@@ -46,6 +46,8 @@ export const RegisterBodySchema = v.object({
   gadClickId: v.optional(v.string()),
   gadSource: v.optional(v.string()),
   fbClickId: v.optional(v.string()),
+  fbp: v.optional(v.string()),
+  fbc: v.optional(v.string()),
   gaClientId: v.optional(v.string()),
   gaSessionId: v.optional(v.union([v.string(), v.number()])),
   referrer: v.optional(v.string()),


### PR DESCRIPTION
fbp/fbc were stripped by RegisterBodySchema and fbClickId was never proxied to /users/new, so the server-side CompleteRegistration event fired with no browser identifiers (0% fbc/fbp match coverage).