### PR TITLE
[TAS-6137] ✨ Rank library 熱門 by reading time instead of stake

### DIFF
--- a/app/composables/use-store-tags.ts
+++ b/app/composables/use-store-tags.ts
@@ -28,11 +28,11 @@ export function useStoreTags({ routeName, isLibraryTab }: StoreTagsOptions) {
     value: `${STAKING_SORT_TAG_PREFIX}${option.value}`,
   }))
   const STAKING_TAG_DEFAULT = STAKING_SORT_OPTIONS[0]!.value
-  // The library always lands on the staking-ranked (熱門) tab regardless of login
-  // status. On the store, signed-in readers land on the freshest titles while
-  // signed-out visitors get the staking-ranked landing as the default tab.
+  // The library always lands on the usage-ranked (熱門) tab regardless of login status.
+  // On the store, signed-in readers land on the freshest titles while signed-out
+  // visitors get the staking-ranked landing as the default tab.
   const defaultTagId = computed(() => {
-    if (isLibraryTab.value) return STAKING_TAG_DEFAULT
+    if (isLibraryTab.value) return BOOKSTORE_POPULAR_LIST_TYPE
     return hasLoggedIn.value ? BOOKSTORE_DEFAULT_LIST_TYPE : STAKING_TAG_DEFAULT
   })
 
@@ -68,6 +68,7 @@ export function useStoreTags({ routeName, isLibraryTab }: StoreTagsOptions) {
   })
   const isDefaultTagId = computed(() => getIsDefaultTagId(tagId.value))
   const isStakingTagId = computed(() => getIsStakingTagId(tagId.value))
+  const isPopularTagId = computed(() => tagId.value === BOOKSTORE_POPULAR_LIST_TYPE)
 
   const normalizedLocale = computed(() => locale.value === 'zh-Hant' ? 'zh' : 'en')
 
@@ -102,12 +103,15 @@ export function useStoreTags({ routeName, isLibraryTab }: StoreTagsOptions) {
   }
 
   const allTagItems = computed(() => {
-    const stakingTags = STAKING_SORT_OPTIONS
-      .map(option => ({
-        ...option,
-        label: getStakingTagLabel(option.value),
-      }))
-      .filter(option => tagId.value === option.value || option.isPublic)
+    // Stake ranking is a storefront signal; the library ranks by reading instead.
+    const stakingTags = isLibraryTab.value
+      ? []
+      : STAKING_SORT_OPTIONS
+          .map(option => ({
+            ...option,
+            label: getStakingTagLabel(option.value),
+          }))
+          .filter(option => tagId.value === option.value || option.isPublic)
 
     // Built-in list types (latest/free/drm-free) are mirrored as CMS tags so editors
     // control their ordering here, hence they surface through cmsTags like any other tag.
@@ -179,6 +183,7 @@ export function useStoreTags({ routeName, isLibraryTab }: StoreTagsOptions) {
     tagId,
     isDefaultTagId,
     isStakingTagId,
+    isPopularTagId,
     getIsLocalHistoriesTagId,
     normalizedLocale,
     activeCMSTag,

--- a/app/pages/store/index.vue
+++ b/app/pages/store/index.vue
@@ -446,6 +446,7 @@ const {
   tagId,
   isDefaultTagId,
   isStakingTagId,
+  isPopularTagId,
   getIsLocalHistoriesTagId,
   normalizedLocale,
   activeCMSTag,
@@ -639,7 +640,9 @@ const cmsProducts = computed<BookstoreItemList>(() => {
       ...item,
       totalStaked: stakingInfo?.totalStaked ?? 0n,
       stakerCount: stakingInfo?.stakerCount ?? 0,
-      likeRank: stakingInfo?.likeRank ?? 0,
+      // `likeRank` is a stake rank linking to the staking page, so it's meaningless on
+      // the reading-ranked popular list — suppress the badge rather than mislabel it.
+      likeRank: isPopularTagId.value ? 0 : (stakingInfo?.likeRank ?? 0),
     }
   })
 
@@ -878,9 +881,11 @@ useHead(() => {
           crossorigin: 'anonymous' as const,
           key: 'preload-staking-books',
         }]
+      // The library scopes its listing with `library=1`; preloading without it primes a
+      // different response than the one the page goes on to fetch.
       : [{
           rel: 'preload',
-          href: `/api/store/products?tag=${encodedTagId}&limit=${MAX_BOOKSTORE_PAGE_SIZE}&ts=${getTimestampRoundedToMinute()}`,
+          href: `/api/store/products?tag=${encodedTagId}&limit=${MAX_BOOKSTORE_PAGE_SIZE}&ts=${getTimestampRoundedToMinute()}${isLibraryTab.value ? '&library=1' : ''}`,
           as: 'fetch' as const,
           crossorigin: 'anonymous' as const,
           key: 'preload-store-products',
@@ -986,6 +991,9 @@ async function fetchTags() {
 
 async function fetchTagItems({ isRefresh = false } = {}) {
   const currentTagId = tagId.value
+  // Captured with currentTagId: both guards below run after awaits, and reading the
+  // reactive computed there would follow a mid-fetch tab switch instead of this batch.
+  const isPopularTag = isPopularTagId.value
   const apiSortValue = mapTagIdToAPIStakingSortValue(isStakingTagId.value ? currentTagId : STAKING_TAG_DEFAULT)
 
   if (isStakingTagId.value) {
@@ -1001,10 +1009,13 @@ async function fetchTagItems({ isRefresh = false } = {}) {
     return
   }
 
-  // Fetch staking books first so CMS tag items can be sorted by staking
-  await bookstoreStore.fetchStakingBooks(apiSortValue, { isRefresh, limit: 100 }).catch((error) => {
-    console.warn('[store] Failed to fetch staking data for CMS tag sorting:', error)
-  })
+  // Fetch staking books first so CMS tag items can be sorted by staking. The popular
+  // list arrives ranked by reading time, so it needs neither the fetch nor the sort.
+  if (!isPopularTag) {
+    await bookstoreStore.fetchStakingBooks(apiSortValue, { isRefresh, limit: 100 }).catch((error) => {
+      console.warn('[store] Failed to fetch staking data for CMS tag sorting:', error)
+    })
+  }
 
   // Capture the items array reference before fetch so we can detect
   // if the store replaced it (e.g. on refresh or expired-offset retry)
@@ -1013,8 +1024,9 @@ async function fetchTagItems({ isRefresh = false } = {}) {
   const countBefore = isRefresh ? 0 : (itemsBefore?.length ?? 0)
   await bookstoreStore.fetchCMSProductsByTagId(currentTagId, { isRefresh, isLibrary: isLibraryTab.value })
 
-  // Sort only the new batch by staking amount (skip 'latest' which preserves Airtable order)
-  if (currentTagId !== 'latest') {
+  // Sort only the new batch by staking amount (skip 'latest' which preserves Airtable
+  // order, and 'popular' which arrives ranked by reading time)
+  if (currentTagId !== 'latest' && !isPopularTag) {
     const items = bookstoreStore.bookstoreCMSProductsByTagKeyMap[currentTagKey]?.items
     if (items === itemsBefore && items?.length === countBefore) return
     // If the array was replaced (refresh or offset-refresh), sort from 0

--- a/server/api/store/products.get.ts
+++ b/server/api/store/products.get.ts
@@ -2,14 +2,23 @@ import {
   BUILT_IN_LIST_PATHS,
   fetchBookstoreBookListing,
   fetchBookstoreCMSProductsByTagId,
+  fetchBookstorePopularListing,
   respondWithBookstoreAPI,
 } from '~~/server/utils/bookstore'
 import { StoreProductsQuerySchema } from '~~/server/schemas/store'
-import { BOOKSTORE_DEFAULT_LIST_TYPE, isBookstoreBuiltInListType } from '~~/shared/utils/bookstore'
+import { BOOKSTORE_DEFAULT_LIST_TYPE, BOOKSTORE_POPULAR_LIST_TYPE, isBookstoreBuiltInListType } from '~~/shared/utils/bookstore'
 
 export default defineEventHandler(async (event) => {
   const query = await getValidatedQuery(event, createValidator(StoreProductsQuerySchema))
   const tag = query.tag || BOOKSTORE_DEFAULT_LIST_TYPE
+  // Checked first: `popular` is a built-in list type, but needs the class-id cursor fetcher.
+  if (tag === BOOKSTORE_POPULAR_LIST_TYPE) {
+    return respondWithBookstoreAPI(
+      event,
+      opts => fetchBookstorePopularListing(BUILT_IN_LIST_PATHS[BOOKSTORE_POPULAR_LIST_TYPE], opts),
+      { hasOpaqueCursor: true, notFoundStatusCode: 501, notFoundStatusMessage: 'LIST_NOT_IMPLEMENTED' },
+    )
+  }
   if (isBookstoreBuiltInListType(tag)) {
     return respondWithBookstoreAPI(
       event,

--- a/server/api/store/products.get.ts
+++ b/server/api/store/products.get.ts
@@ -6,6 +6,7 @@ import {
   respondWithBookstoreAPI,
 } from '~~/server/utils/bookstore'
 import { StoreProductsQuerySchema } from '~~/server/schemas/store'
+import { checkIsEVMAddress } from '~~/shared/utils'
 import { BOOKSTORE_DEFAULT_LIST_TYPE, BOOKSTORE_POPULAR_LIST_TYPE, isBookstoreBuiltInListType } from '~~/shared/utils/bookstore'
 
 export default defineEventHandler(async (event) => {
@@ -16,7 +17,7 @@ export default defineEventHandler(async (event) => {
     return respondWithBookstoreAPI(
       event,
       opts => fetchBookstorePopularListing(BUILT_IN_LIST_PATHS[BOOKSTORE_POPULAR_LIST_TYPE], opts),
-      { hasOpaqueCursor: true, notFoundStatusCode: 501, notFoundStatusMessage: 'LIST_NOT_IMPLEMENTED' },
+      { validateCursor: checkIsEVMAddress, notFoundStatusCode: 501, notFoundStatusMessage: 'LIST_NOT_IMPLEMENTED' },
     )
   }
   if (isBookstoreBuiltInListType(tag)) {

--- a/server/utils/bookstore.ts
+++ b/server/utils/bookstore.ts
@@ -9,6 +9,7 @@ export const BUILT_IN_LIST_PATHS: Record<BookstoreBuiltInListType, string> = {
   'latest': `${BOOKSTORE_API_BASE_PATH}/list`,
   'free': `${BOOKSTORE_API_BASE_PATH}/list/free`,
   'drm-free': `${BOOKSTORE_API_BASE_PATH}/list/drm-free`,
+  'popular': `${BOOKSTORE_API_BASE_PATH}/list/popular`,
 }
 
 interface NFTBookPrice {
@@ -44,9 +45,17 @@ interface NFTBookListResponse {
   nextKey?: number | null
 }
 
+interface NFTBookPopularListResponse {
+  list: NFTBookListingInfo[]
+  // /list/popular resumes from the previous page's last class id: ranking ties
+  // (most of the catalogue sits at zero reading time) can't be resumed from a value.
+  nextKey?: string | null
+}
+
 interface BookstoreListingFetchOptions {
   pageSize?: number
-  // Pagination cursor: numeric offset for /cms/list, timestamp key for /list*.
+  // Pagination cursor: numeric offset for /cms/list, timestamp key for /list*,
+  // class id for /list/popular.
   nextKey?: string
   // When true, restricts results to Plus-reading titles via the upstream `library` flag.
   isLibrary?: boolean
@@ -162,6 +171,32 @@ export async function fetchBookstoreBookListing(
   }
 }
 
+// Kept separate from fetchBookstoreBookListing rather than merged behind a flag: that
+// one coerces the cursor with `Number(key)`, which silently parses a class id as hex
+// (`Number('0x1a') === 26`). The dialects must not share a code path.
+export async function fetchBookstorePopularListing(
+  path: string,
+  {
+    pageSize = MAX_BOOKSTORE_PAGE_SIZE,
+    nextKey: key,
+    isLibrary = false,
+  }: BookstoreListingFetchOptions = {},
+): Promise<FetchBookstoreCMSProductsResponseData> {
+  const fetch = getLikeCoinAPIFetch()
+  const { list, nextKey } = await fetch<NFTBookPopularListResponse>(path, {
+    query: {
+      limit: pageSize,
+      key,
+      library: isLibrary ? '1' : undefined,
+    },
+  })
+  return {
+    records: (list || []).map(normalizeBookListingToProduct),
+    offset: nextKey || undefined,
+    hasMore: !!nextKey,
+  }
+}
+
 // Parse a raw `limit` query value into a valid page size. An invalid/missing/empty
 // limit falls back to the max, while `limit=0` clamps to 1 (not the max — `0 || max`
 // would have swallowed it). `limit=` alone is treated as missing so it doesn't slip
@@ -180,9 +215,12 @@ export async function respondWithBookstoreAPI(
   {
     notFoundStatusCode = 404,
     notFoundStatusMessage = 'NOT_FOUND',
+    hasOpaqueCursor = false,
   }: {
     notFoundStatusCode?: number
     notFoundStatusMessage?: string
+    // Pass the offset through unvalidated for fetchers whose cursor isn't a number.
+    hasOpaqueCursor?: boolean
   } = {},
 ) {
   const query = getQuery(event)
@@ -192,11 +230,16 @@ export async function respondWithBookstoreAPI(
   // Validate offset as a non-negative integer; treat 0 the same as omitted so page-1 stays cacheable.
   let nextKey: string | undefined
   if (offsetRaw !== undefined && offsetRaw !== '') {
-    const offsetNum = Number(offsetRaw)
-    if (!Number.isInteger(offsetNum) || offsetNum < 0) {
-      throw createError({ statusCode: 400, statusMessage: 'INVALID_OFFSET' })
+    if (hasOpaqueCursor) {
+      nextKey = offsetRaw
     }
-    nextKey = offsetNum === 0 ? undefined : String(offsetNum)
+    else {
+      const offsetNum = Number(offsetRaw)
+      if (!Number.isInteger(offsetNum) || offsetNum < 0) {
+        throw createError({ statusCode: 400, statusMessage: 'INVALID_OFFSET' })
+      }
+      nextKey = offsetNum === 0 ? undefined : String(offsetNum)
+    }
   }
   try {
     const result = await fetcher({ pageSize, nextKey, isLibrary })

--- a/server/utils/bookstore.ts
+++ b/server/utils/bookstore.ts
@@ -215,22 +215,26 @@ export async function respondWithBookstoreAPI(
   {
     notFoundStatusCode = 404,
     notFoundStatusMessage = 'NOT_FOUND',
-    hasOpaqueCursor = false,
+    validateCursor,
   }: {
     notFoundStatusCode?: number
     notFoundStatusMessage?: string
-    // Pass the offset through unvalidated for fetchers whose cursor isn't a number.
-    hasOpaqueCursor?: boolean
+    // Fetchers whose cursor isn't a number supply their own format check, so junk is
+    // rejected before it reaches the upstream API or the cached response below.
+    validateCursor?: (cursor: string) => boolean
   } = {},
 ) {
   const query = getQuery(event)
   const offsetRaw = Array.isArray(query.offset) ? query.offset[0] : query.offset
   const pageSize = parseBookstorePageSize(query.limit as string | string[] | undefined)
   const isLibrary = (Array.isArray(query.library) ? query.library[0] : query.library) === '1'
-  // Validate offset as a non-negative integer; treat 0 the same as omitted so page-1 stays cacheable.
+  // Default to a non-negative integer offset; treat 0 the same as omitted so page-1 stays cacheable.
   let nextKey: string | undefined
   if (offsetRaw !== undefined && offsetRaw !== '') {
-    if (hasOpaqueCursor) {
+    if (validateCursor) {
+      if (!validateCursor(offsetRaw)) {
+        throw createError({ statusCode: 400, statusMessage: 'INVALID_OFFSET' })
+      }
       nextKey = offsetRaw
     }
     else {

--- a/shared/utils/bookstore.ts
+++ b/shared/utils/bookstore.ts
@@ -1,10 +1,13 @@
 export const MAX_BOOKSTORE_PAGE_SIZE = 100
 
 // Built-in list types — backed by upstream `/list*`, not editor-managed CMS tags.
-export const BOOKSTORE_BUILT_IN_LIST_TYPES = ['latest', 'free', 'drm-free'] as const
+export const BOOKSTORE_BUILT_IN_LIST_TYPES = ['latest', 'free', 'drm-free', 'popular'] as const
 export type BookstoreBuiltInListType = typeof BOOKSTORE_BUILT_IN_LIST_TYPES[number]
 
 export const BOOKSTORE_DEFAULT_LIST_TYPE: BookstoreBuiltInListType = 'latest'
+
+// Ranked upstream by lifetime reading + TTS time. Backs the library's default tab.
+export const BOOKSTORE_POPULAR_LIST_TYPE: BookstoreBuiltInListType = 'popular'
 
 export function isBookstoreBuiltInListType(value: string): value is BookstoreBuiltInListType {
   return (BOOKSTORE_BUILT_IN_LIST_TYPES as readonly string[]).includes(value)


### PR DESCRIPTION
The library's default tab ranked books by staked LIKE, so a single whale outranked what readers actually read, and only the 43 library titles inside the global top-100 staked list could surface at all. It now reads the upstream /list/popular listing, ranked by lifetime reading + TTS time and covering the whole library.

Adds a `popular` built-in list type. Its cursor is an opaque class id, so it needs its own fetcher and a hasOpaqueCursor escape from the responder's integer validation -- fetchBookstoreBookListing coerces the cursor with Number(), which parses a class id as hex.

The stake sort tabs leave the library, and the #N badge is suppressed there: it is a stake rank linking to the staking page, so it would mislabel a reading-ranked list. fetchTagItems skips both the staking fetch and the client-side stake re-sort, which would otherwise silently re-rank the list the server just ordered.

Also scopes the SSR preload with library=1. It primed a different URL than the page went on to fetch, wasting the preload on every library tab, not just the new default.

Needs the upstream endpoint deployed and an Airtable CMS tag `popular` (isPublic, isForLibrary) before the tab renders.