### PR TITLE
📈 Log error code and message on login_error

### DIFF
--- a/app/stores/account.ts
+++ b/app/stores/account.ts
@@ -575,7 +575,11 @@ export const useAccountStore = defineStore('account', () => {
         useLogEvent('login_email_already_used', { method: connectorId })
         return
       }
-      useLogEvent('login_error', { method: connectorId })
+      useLogEvent('login_error', {
+        method: connectorId,
+        error_code: getErrorCode(error),
+        error_message: getErrorEventMessage(error),
+      })
       await handleError(error)
       return login()
     }

--- a/app/utils/error.ts
+++ b/app/utils/error.ts
@@ -29,6 +29,39 @@ export function getErrorStatusCode(error: unknown) {
   return undefined
 }
 
+// A low-cardinality grouping key for analytics, unlike the free-form message.
+// viem/wagmi and Magic SDK errors carry `code`; HTTP failures carry a statusCode.
+// Falls back to the error class name so every error still groups into something.
+export function getErrorCode(error: unknown) {
+  if (
+    error instanceof Error && 'code' in error
+    && (typeof error.code === 'number' || typeof error.code === 'string')
+  ) {
+    return error.code
+  }
+  const statusCode = getErrorStatusCode(error)
+  if (statusCode !== undefined) {
+    return statusCode
+  }
+  if (error instanceof Error) {
+    return error.name
+  }
+  return undefined
+}
+
+// GA4 silently truncates event parameter values beyond 100 characters.
+const MAX_ERROR_EVENT_MESSAGE_LENGTH = 100
+
+// Never log a raw `message` to analytics: viem appends its metaMessages to it, and
+// those embed the full RPC request body — on the login path that carries the user's
+// wallet and signed email. `shortMessage` is the first line, before any of that.
+export function getErrorEventMessage(error: unknown) {
+  const message = error instanceof Error && 'shortMessage' in error && typeof error.shortMessage === 'string'
+    ? error.shortMessage
+    : getErrorMessage(error)
+  return message.slice(0, MAX_ERROR_EVENT_MESSAGE_LENGTH)
+}
+
 export function parseErrorData<T>(error: unknown, key: string): T | undefined {
   if (error instanceof Error && 'data' in error && error.data && typeof error.data === 'object') {
     const data = error.data as Record<string, unknown>

--- a/test/unit/error-code.test.ts
+++ b/test/unit/error-code.test.ts
@@ -1,0 +1,84 @@
+import { RpcRequestError } from 'viem'
+import { FetchError } from 'ofetch'
+import { describe, expect, it } from 'vitest'
+import { getErrorCode, getErrorEventMessage } from '~/utils/error'
+
+function createFetchError(statusCode: number, data?: unknown) {
+  const error = new FetchError('fetch failed')
+  Object.assign(error, { statusCode, data })
+  return error
+}
+
+describe('getErrorCode', () => {
+  it('prefers a numeric `code`, as carried by Magic SDK RPC errors', () => {
+    const error = Object.assign(new Error('Internal error'), { code: -32603 })
+    expect(getErrorCode(error)).toBe(-32603)
+  })
+
+  it('prefers a string `code`, as carried by network-level errors', () => {
+    const error = Object.assign(new Error('connect ECONNREFUSED'), { code: 'ECONNREFUSED' })
+    expect(getErrorCode(error)).toBe('ECONNREFUSED')
+  })
+
+  it('falls back to the status code of a FetchError', () => {
+    expect(getErrorCode(createFetchError(401, { message: 'UNAUTHORIZED' }))).toBe(401)
+  })
+
+  it('prefers `code` over a status code when both are present', () => {
+    const error = Object.assign(new Error('RPC failed'), { code: 4001, statusCode: 500 })
+    expect(getErrorCode(error)).toBe(4001)
+  })
+
+  it('falls back to the status code of a createError()-style error', () => {
+    const error = Object.assign(new Error('Connect wallet failed'), { statusCode: 400 })
+    expect(getErrorCode(error)).toBe(400)
+  })
+
+  it('falls back to the error name, as carried by viem/wagmi errors', () => {
+    const error = new Error('Connector not connected')
+    error.name = 'ConnectorNotConnectedError'
+    expect(getErrorCode(error)).toBe('ConnectorNotConnectedError')
+  })
+
+  it('ignores a non-primitive `code`', () => {
+    const error = Object.assign(new Error('weird'), { code: { nested: true } })
+    expect(getErrorCode(error)).toBe('Error')
+  })
+
+  it('returns undefined for non-Error values', () => {
+    expect(getErrorCode('some string')).toBeUndefined()
+    expect(getErrorCode(undefined)).toBeUndefined()
+  })
+})
+
+describe('getErrorEventMessage', () => {
+  // The shape wagmi's signMessageAsync throws when the RPC transport fails: viem
+  // folds the signed payload into `message`, so only `shortMessage` is safe to log.
+  const rpcError = new RpcRequestError({
+    body: { method: 'personal_sign', params: ['0xdeadbeef', '0xX_WALLET'] },
+    error: { code: -32603, message: 'Internal JSON-RPC error' },
+    url: 'https://mainnet.base.org',
+  })
+
+  it('keeps the wallet and signed payload out of a viem error message', () => {
+    expect(rpcError.message).toContain('0xX_WALLET')
+    expect(getErrorEventMessage(rpcError)).toBe('RPC Request failed.')
+  })
+
+  it('leaves the RPC code recoverable via getErrorCode', () => {
+    expect(getErrorCode(rpcError)).toBe(-32603)
+  })
+
+  it('falls back to the plain message for non-viem errors', () => {
+    expect(getErrorEventMessage(createFetchError(401, { message: 'UNAUTHORIZED' }))).toBe('UNAUTHORIZED')
+    expect(getErrorEventMessage(new Error('Connect wallet failed'))).toBe('Connect wallet failed')
+  })
+
+  it('truncates to GA4\'s 100-character parameter limit', () => {
+    expect(getErrorEventMessage(new Error('a'.repeat(250)))).toHaveLength(100)
+  })
+
+  it('returns an empty string for non-Error values', () => {
+    expect(getErrorEventMessage(undefined)).toBe('')
+  })
+})

--- a/test/unit/error-code.test.ts
+++ b/test/unit/error-code.test.ts
@@ -62,7 +62,9 @@ describe('getErrorEventMessage', () => {
 
   it('keeps the wallet and signed payload out of a viem error message', () => {
     expect(rpcError.message).toContain('0xX_WALLET')
-    expect(getErrorEventMessage(rpcError)).toBe('RPC Request failed.')
+    const eventMessage = getErrorEventMessage(rpcError)
+    expect(eventMessage).toBe(rpcError.shortMessage)
+    expect(eventMessage).not.toContain('0xX_WALLET')
   })
 
   it('leaves the RPC code recoverable via getErrorCode', () => {


### PR DESCRIPTION
login_error only carried `method`, so Magic failures were countable but not diagnosable. Add `error_code` as a low-cardinality grouping key (viem/Magic `code`, else HTTP statusCode, else the error class name) alongside the `error_message` convention the other *_error events already follow.

Log viem's `shortMessage` rather than `message`: viem folds its metaMessages into `message`, and those embed the full RPC request body — on the login path that carries the user's wallet and signed email, which must not reach GA4, PostHog or Intercom. Cap at GA4's 100-char event parameter limit.