### PR TITLE
[TAS-6162] ✨ Ask for a store rating once Plus is backend-confirmed

### DIFF
--- a/app/composables/use-subscription-checkout.ts
+++ b/app/composables/use-subscription-checkout.ts
@@ -194,7 +194,11 @@ export function useSubscriptionCheckout() {
           })
         }
         blockingModal.open({ title: $t('common_processing') })
-        await pollSessionUntilPlus()
+        const isPlusConfirmed = await pollSessionUntilPlus()
+        // Only once the backend has actually granted Plus: asking on the store's
+        // purchase result would catch the user while the app still shows them as a
+        // non-subscriber, since the webhook can lag. A slow webhook means no prompt.
+        if (isPlusConfirmed) requestNativeStoreReview('purchase_confirmed')
         // Flag a pending gift so the success page waits for the webhook to attach the
         // book (the cart is created async on grant) before routing to the claim page.
         const hasGift = isYearly && Boolean(nftClassId)

--- a/app/utils/native-bridge.ts
+++ b/app/utils/native-bridge.ts
@@ -38,6 +38,14 @@ export function getInstallAttribution(): InstallAttribution | null {
   }
 }
 
+// A hint, not a command: the shell applies its own engagement gate and both
+// stores silently quota the prompt, so it usually will not appear. Store policy
+// forbids tying it to a button press or preceding it with a question.
+export function requestNativeStoreReview(reason: string): void {
+  if (!isNativeWebView() || !isNativeFeatureSupported('storeReview')) return
+  postToNative({ type: 'requestStoreReview', reason })
+}
+
 export function isNativeIntercomAvailable(): boolean {
   return isNativeWebView() && isNativeFeatureSupported('intercom')
 }


### PR DESCRIPTION
Sends `requestStoreReview` to the native shell after pollSessionUntilPlus() confirms the backend granted Plus, not when the store's purchase call returns. Entitlement is flipped asynchronously by the RevenueCat→backend webhook, so prompting on the purchase result would catch the user while the app still shows them as a non-subscriber — the surest way to earn a one-star review.

pollSessionUntilPlus() already returned this boolean and it was being discarded; navigation is unaffected, a slow webhook just means no prompt. The native shell applies its own engagement gate and both stores quota the prompt, so this is only ever a hint.