### PR TITLE
🐛 Show the 熱門 pill on the library's default tab

### DIFF
--- a/app/composables/use-store-tags.ts
+++ b/app/composables/use-store-tags.ts
@@ -143,8 +143,16 @@ export function useStoreTags({ routeName, isLibraryTab }: StoreTagsOptions) {
       ? cmsTags.filter(tag => !getIsLocalHistoriesTagId(tag.value))
       : cmsTags
 
+    // 熱門 is the only built-in list type with no CMS tag mirroring it, so the library's
+    // default tab would render no pill; yield if editors ever add one, so their label wins.
+    const popularTags = isLibraryTab.value
+      && !visibleCMSTags.some(tag => tag.value === BOOKSTORE_POPULAR_LIST_TYPE)
+      ? [{ label: $t('store_tag_popular'), value: BOOKSTORE_POPULAR_LIST_TYPE }]
+      : []
+
+    const ordered = [...popularTags, ...stakingTags, ...visibleCMSTags]
+
     // On mobile, pin the local-histories CMS tag last.
-    const ordered = [...stakingTags, ...visibleCMSTags]
     if (isMobile.value) {
       const localHistoriesIndex = ordered.findIndex(tag => getIsLocalHistoriesTagId(tag.value))
       if (localHistoriesIndex !== -1) {

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -939,6 +939,7 @@
   "store_showing_recommendations": "Here are some recommended books for you",
   "store_tag_more_categories": "More",
   "store_tag_more_categories_label": "More categories",
+  "store_tag_popular": "Popular",
   "subscribe_plus_alert_limited_offer": "Limited Offer",
   "subscription_success_continue_button": "Continue to 3ookshelf",
   "subscription_success_description": "Your subscription has been successfully activated. You can now enjoy all the benefits of Plus.",

--- a/i18n/locales/zh-Hant.json
+++ b/i18n/locales/zh-Hant.json
@@ -939,6 +939,7 @@
   "store_showing_recommendations": "以下是為你推薦的書籍",
   "store_tag_more_categories": "更多類別",
   "store_tag_more_categories_label": "更多類別",
+  "store_tag_popular": "熱門",
   "subscribe_plus_alert_limited_offer": "限時優惠",
   "subscription_success_continue_button": "前往書架",
   "subscription_success_description": "你的訂閱已成功啟動。現在你可以享受 Plus 的所有優惠。",


### PR DESCRIPTION
The library lands on the built-in `popular` listing, but unlike the other built-in list types it has no Airtable CMS tag mirroring it, and the pill row is built from CMS tags alone. So the active tab rendered no pill: the row silently started at 最新, and once a reader left 熱門 there was no way back to it.

Add the pill client-side, like the staking sort tabs, rather than relying on an editor creating the CMS record. It yields to a mirrored CMS tag if one is ever added, so editors keep control of the label and ordering.